### PR TITLE
Update analysis options

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,4 @@
+analyzer:
+  errors:
+    unused_element: ignore
+    unused_field: ignore

--- a/packages/symgen/analysis_options.yaml
+++ b/packages/symgen/analysis_options.yaml
@@ -1,16 +1,1 @@
-# Defines a default set of lint rules enforced for projects at Google. For
-# details and rationale, see
-# https://github.com/dart-lang/pedantic#enabled-lints.
-
-include: package:pedantic/analysis_options.yaml
-
-# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
-
-# Uncomment to specify additional rules.
-# linter:
-#   rules:
-#     - camel_case_types
-
-# analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
+include: package:lints/recommended.yaml

--- a/packages/symgen/lib/src/config.dart
+++ b/packages/symgen/lib/src/config.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:io' show Platform;
+
 import 'package:args/args.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
@@ -10,22 +11,21 @@ import 'package:yaml/yaml.dart';
 
 class Config {
   String get name => _name;
-  late String _name;
+  late final String _name;
 
   String get output => _output;
-  late String _output;
+  late final String _output;
 
-  List<String> get allowlist => _allowlist;
-  late final List<String> _allowlist = <String>[];
+  final List<String> allowlist = <String>[];
 
   String get libraryPath => _libraryPath;
-  late String _libraryPath;
+  late final String _libraryPath;
 
   List<String> get targetLibraries => _targetLibraries;
-  late List<String> _targetLibraries;
+  late final List<String> _targetLibraries;
 
   String get preamble => _preamble;
-  late String _preamble;
+  late final String _preamble;
 
   Config._();
 
@@ -47,15 +47,9 @@ class Config {
     config._libraryPath = argResults?['library-path'] ??
         _mapEnvironmentVariables(map.getValue('library-path'));
 
-    config._allowlist.addAll(
-      _readAllowlistFile(
-        argResults?['allowlist'] ??
-            map.getValue(
-              'allowlist',
-              mandatory: false,
-            ),
-      ),
-    );
+    config.allowlist.addAll(_readAllowlistFile(
+      argResults?['allowlist'] ?? map.getValue('allowlist', mandatory: false),
+    ));
 
     config._targetLibraries =
         List.unmodifiable(map.getValue('target-libraries'));
@@ -67,11 +61,11 @@ class Config {
   }
 
   static String? _mapEnvironmentVariables(String? value) {
-    if (value == null || !value.contains('\$\{')) {
+    if (value == null || !value.contains('\${')) {
       return value;
     }
     for (var key in Platform.environment.keys) {
-      value = value!.replaceAll('\$\{$key\}', Platform.environment[key]!);
+      value = value!.replaceAll('\${$key}', Platform.environment[key]!);
     }
     return value;
   }
@@ -97,7 +91,6 @@ extension _YamlMapExtensions on YamlMap {
       }
       value = defaultValue;
     }
-
     return value;
   }
 }

--- a/packages/symgen/lib/src/executable.dart
+++ b/packages/symgen/lib/src/executable.dart
@@ -5,6 +5,7 @@
 // Executable script to generate symbol mapping for shared libraries.
 
 import 'dart:io';
+
 import 'package:args/args.dart';
 
 import 'config.dart';

--- a/packages/symgen/lib/src/generator.dart
+++ b/packages/symgen/lib/src/generator.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 import 'dart:io';
+
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 

--- a/packages/symgen/pubspec.yaml
+++ b/packages/symgen/pubspec.yaml
@@ -1,9 +1,9 @@
 name: symgen
 description: Symbol mapping generator for shared libraries.
-version: 1.0.0
+publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies: 
   args: ^2.1.1
@@ -11,4 +11,4 @@ dependencies:
   yaml: ^3.1.0
 
 dev_dependencies:
-  pedantic: ^1.10.0
+  lints: ^2.0.0


### PR DESCRIPTION
- Ignore `unused_element` and `unused_field` lint warnings in generated files. (Now `dart analyze` reports 0 issues.)
- Migrate `symgen`'s analysis_options from `package:pedantic` to `package:lints`.
