### PR TITLE
Add binding code related to libshortcut.so

### DIFF
--- a/configs/10.0/entrypoints.h
+++ b/configs/10.0/entrypoints.h
@@ -66,8 +66,8 @@
 #include <rpc-port-parcel.h>
 #include <rpc-port.h>
 #include <service_app.h>
-#include <shortcut/shortcut_manager.h>
 #include <shortcut_error.h>
+#include <shortcut_manager.h>
 #include <tizen_core.h>
 
 // Base

--- a/configs/6.0/entrypoints.h
+++ b/configs/6.0/entrypoints.h
@@ -57,6 +57,7 @@
 #include <rpc-port-parcel.h>
 #include <rpc-port.h>
 #include <service_app.h>
+#include <shortcut_error.h>
 #include <shortcut_manager.h>
 
 // Base

--- a/configs/6.0/ffigen_shortcut.yaml
+++ b/configs/6.0/ffigen_shortcut.yaml
@@ -15,7 +15,7 @@ headers:
   entry-points:
     - 'entrypoints.h'
   include-directives:
-    - '**/shortcut_manager.h'
+    - '**/shortcut/*.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.5/entrypoints.h
+++ b/configs/6.5/entrypoints.h
@@ -68,6 +68,7 @@
 #include <rpc-port-parcel.h>
 #include <rpc-port.h>
 #include <service_app.h>
+#include <shortcut_error.h>
 #include <shortcut_manager.h>
 
 // Base

--- a/configs/6.5/ffigen_capi_appfw_app_control_uri.yaml
+++ b/configs/6.5/ffigen_capi_appfw_app_control_uri.yaml
@@ -64,7 +64,6 @@ compiler-opts:
   - '-I./rootstraps/6.5/usr/include/web/'
   - '-I./rootstraps/6.5/usr/include/wifi-direct/'
   - '-I./rootstraps/6.5/usr/include/yaca/'
-
   # include EFL directories
   - '-I./rootstraps/6.5/usr/include/ecore-imf-1/'
   - '-I./rootstraps/6.5/usr/include/efl-1/'

--- a/configs/6.5/ffigen_capi_media_webrtc.yaml
+++ b/configs/6.5/ffigen_capi_media_webrtc.yaml
@@ -88,7 +88,6 @@ compiler-opts:
   - '-I./rootstraps/6.5/usr/include/web/'
   - '-I./rootstraps/6.5/usr/include/wifi-direct/'
   - '-I./rootstraps/6.5/usr/include/yaca/'
-
   # include EFL directories
   - '-I./rootstraps/6.5/usr/include/ecore-imf-1/'
   - '-I./rootstraps/6.5/usr/include/efl-1/'

--- a/configs/6.5/ffigen_capi_nnstreamer.yaml
+++ b/configs/6.5/ffigen_capi_nnstreamer.yaml
@@ -64,7 +64,6 @@ compiler-opts:
   - '-I./rootstraps/6.5/usr/include/web/'
   - '-I./rootstraps/6.5/usr/include/wifi-direct/'
   - '-I./rootstraps/6.5/usr/include/yaca/'
-
   # include EFL directories
   - '-I./rootstraps/6.5/usr/include/ecore-imf-1/'
   - '-I./rootstraps/6.5/usr/include/efl-1/'

--- a/configs/6.5/ffigen_capi_nntrainer.yaml
+++ b/configs/6.5/ffigen_capi_nntrainer.yaml
@@ -74,7 +74,6 @@ compiler-opts:
   - '-I./rootstraps/6.5/usr/include/web/'
   - '-I./rootstraps/6.5/usr/include/wifi-direct/'
   - '-I./rootstraps/6.5/usr/include/yaca/'
-
   # include EFL directories
   - '-I./rootstraps/6.5/usr/include/ecore-imf-1/'
   - '-I./rootstraps/6.5/usr/include/efl-1/'

--- a/configs/6.5/ffigen_cion.yaml
+++ b/configs/6.5/ffigen_cion.yaml
@@ -64,7 +64,6 @@ compiler-opts:
   - '-I./rootstraps/6.5/usr/include/web/'
   - '-I./rootstraps/6.5/usr/include/wifi-direct/'
   - '-I./rootstraps/6.5/usr/include/yaca/'
-
   # include EFL directories
   - '-I./rootstraps/6.5/usr/include/ecore-imf-1/'
   - '-I./rootstraps/6.5/usr/include/efl-1/'

--- a/configs/6.5/ffigen_shortcut.yaml
+++ b/configs/6.5/ffigen_shortcut.yaml
@@ -15,7 +15,7 @@ headers:
   entry-points:
     - 'entrypoints.h'
   include-directives:
-    - '**/shortcut_manager.h'
+    - '**/shortcut/*.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.5/ffigen_time.yaml
+++ b/configs/6.5/ffigen_time.yaml
@@ -84,7 +84,6 @@ compiler-opts:
   - '-I./rootstraps/6.5/usr/include/web/'
   - '-I./rootstraps/6.5/usr/include/wifi-direct/'
   - '-I./rootstraps/6.5/usr/include/yaca/'
-
   # include EFL directories
   - '-I./rootstraps/6.5/usr/include/ecore-imf-1/'
   - '-I./rootstraps/6.5/usr/include/efl-1/'

--- a/configs/7.0/ffigen_capi_media_editor.yaml
+++ b/configs/7.0/ffigen_capi_media_editor.yaml
@@ -63,7 +63,6 @@ compiler-opts:
   - '-I./rootstraps/7.0/usr/include/web/'
   - '-I./rootstraps/7.0/usr/include/wifi-direct/'
   - '-I./rootstraps/7.0/usr/include/yaca/'
-
   # include EFL directories
   - '-I./rootstraps/7.0/usr/include/ecore-imf-1/'
   - '-I./rootstraps/7.0/usr/include/efl-1/'

--- a/configs/7.0/ffigen_capi_ml_common.yaml
+++ b/configs/7.0/ffigen_capi_ml_common.yaml
@@ -65,7 +65,6 @@ compiler-opts:
   - '-I./rootstraps/7.0/usr/include/web/'
   - '-I./rootstraps/7.0/usr/include/wifi-direct/'
   - '-I./rootstraps/7.0/usr/include/yaca/'
-
   # include EFL directories
   - '-I./rootstraps/7.0/usr/include/ecore-imf-1/'
   - '-I./rootstraps/7.0/usr/include/efl-1/'

--- a/configs/7.0/ffigen_capi_ml_inference_single.yaml
+++ b/configs/7.0/ffigen_capi_ml_inference_single.yaml
@@ -147,7 +147,6 @@ compiler-opts:
   - '-I./rootstraps/7.0/usr/include/web/'
   - '-I./rootstraps/7.0/usr/include/wifi-direct/'
   - '-I./rootstraps/7.0/usr/include/yaca/'
-
   # include EFL directories
   - '-I./rootstraps/7.0/usr/include/ecore-imf-1/'
   - '-I./rootstraps/7.0/usr/include/efl-1/'

--- a/configs/7.0/ffigen_capi_ml_service.yaml
+++ b/configs/7.0/ffigen_capi_ml_service.yaml
@@ -77,7 +77,6 @@ compiler-opts:
   - '-I./rootstraps/7.0/usr/include/web/'
   - '-I./rootstraps/7.0/usr/include/wifi-direct/'
   - '-I./rootstraps/7.0/usr/include/yaca/'
-
   # include EFL directories
   - '-I./rootstraps/7.0/usr/include/ecore-imf-1/'
   - '-I./rootstraps/7.0/usr/include/efl-1/'

--- a/configs/7.0/ffigen_capi_system_resource_monitor.yaml
+++ b/configs/7.0/ffigen_capi_system_resource_monitor.yaml
@@ -63,7 +63,6 @@ compiler-opts:
   - '-I./rootstraps/7.0/usr/include/web/'
   - '-I./rootstraps/7.0/usr/include/wifi-direct/'
   - '-I./rootstraps/7.0/usr/include/yaca/'
-
   # include EFL directories
   - '-I./rootstraps/7.0/usr/include/ecore-imf-1/'
   - '-I./rootstraps/7.0/usr/include/efl-1/'

--- a/configs/7.0/ffigen_mv_3d.yaml
+++ b/configs/7.0/ffigen_mv_3d.yaml
@@ -78,7 +78,6 @@ compiler-opts:
   - '-I./rootstraps/7.0/usr/include/web/'
   - '-I./rootstraps/7.0/usr/include/wifi-direct/'
   - '-I./rootstraps/7.0/usr/include/yaca/'
-
   # include EFL directories
   - '-I./rootstraps/7.0/usr/include/ecore-imf-1/'
   - '-I./rootstraps/7.0/usr/include/efl-1/'

--- a/configs/7.0/ffigen_mv_face_recognition.yaml
+++ b/configs/7.0/ffigen_mv_face_recognition.yaml
@@ -74,7 +74,6 @@ compiler-opts:
   - '-I./rootstraps/7.0/usr/include/web/'
   - '-I./rootstraps/7.0/usr/include/wifi-direct/'
   - '-I./rootstraps/7.0/usr/include/yaca/'
-
   # include EFL directories
   - '-I./rootstraps/7.0/usr/include/ecore-imf-1/'
   - '-I./rootstraps/7.0/usr/include/efl-1/'

--- a/configs/7.0/ffigen_mv_roi_tracker.yaml
+++ b/configs/7.0/ffigen_mv_roi_tracker.yaml
@@ -82,7 +82,6 @@ compiler-opts:
   - '-I./rootstraps/7.0/usr/include/web/'
   - '-I./rootstraps/7.0/usr/include/wifi-direct/'
   - '-I./rootstraps/7.0/usr/include/yaca/'
-
   # include EFL directories
   - '-I./rootstraps/7.0/usr/include/ecore-imf-1/'
   - '-I./rootstraps/7.0/usr/include/efl-1/'

--- a/configs/8.0/entrypoints.h
+++ b/configs/8.0/entrypoints.h
@@ -69,6 +69,8 @@
 #include <rpc-port-parcel.h>
 #include <rpc-port.h>
 #include <service_app.h>
+#include <shortcut_error.h>
+#include <shortcut_manager.h>
 
 // Base
 #include <tizen.h>

--- a/configs/8.0/ffigen_accounts_svc.yaml
+++ b/configs/8.0/ffigen_accounts_svc.yaml
@@ -58,6 +58,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_appcore_agent.yaml
+++ b/configs/8.0/ffigen_appcore_agent.yaml
@@ -89,6 +89,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_asp.yaml
+++ b/configs/8.0/ffigen_asp.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_badge.yaml
+++ b/configs/8.0/ffigen_badge.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_bundle.yaml
+++ b/configs/8.0/ffigen_bundle.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_calendar_service2.yaml
+++ b/configs/8.0/ffigen_calendar_service2.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_appfw_alarm.yaml
+++ b/configs/8.0/ffigen_capi_appfw_alarm.yaml
@@ -77,6 +77,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_appfw_app_common.yaml
+++ b/configs/8.0/ffigen_capi_appfw_app_common.yaml
@@ -59,6 +59,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_appfw_app_control.yaml
+++ b/configs/8.0/ffigen_capi_appfw_app_control.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_appfw_app_control_uri.yaml
+++ b/configs/8.0/ffigen_capi_appfw_app_control_uri.yaml
@@ -58,6 +58,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_appfw_app_manager.yaml
+++ b/configs/8.0/ffigen_capi_appfw_app_manager.yaml
@@ -58,6 +58,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_appfw_application.yaml
+++ b/configs/8.0/ffigen_capi_appfw_application.yaml
@@ -76,6 +76,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_appfw_event.yaml
+++ b/configs/8.0/ffigen_capi_appfw_event.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_appfw_job_scheduler.yaml
+++ b/configs/8.0/ffigen_capi_appfw_job_scheduler.yaml
@@ -58,6 +58,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_appfw_package_manager.yaml
+++ b/configs/8.0/ffigen_capi_appfw_package_manager.yaml
@@ -58,6 +58,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_appfw_preference.yaml
+++ b/configs/8.0/ffigen_capi_appfw_preference.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_base_common.yaml
+++ b/configs/8.0/ffigen_capi_base_common.yaml
@@ -57,6 +57,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_content_media_content.yaml
+++ b/configs/8.0/ffigen_capi_content_media_content.yaml
@@ -83,6 +83,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_content_mime_type.yaml
+++ b/configs/8.0/ffigen_capi_content_mime_type.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_context.yaml
+++ b/configs/8.0/ffigen_capi_context.yaml
@@ -67,6 +67,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_geofence_manager.yaml
+++ b/configs/8.0/ffigen_capi_geofence_manager.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_location_manager.yaml
+++ b/configs/8.0/ffigen_capi_location_manager.yaml
@@ -71,6 +71,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_audio_io.yaml
+++ b/configs/8.0/ffigen_capi_media_audio_io.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_camera.yaml
+++ b/configs/8.0/ffigen_capi_media_camera.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_codec.yaml
+++ b/configs/8.0/ffigen_capi_media_codec.yaml
@@ -74,6 +74,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_controller.yaml
+++ b/configs/8.0/ffigen_capi_media_controller.yaml
@@ -69,6 +69,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_editor.yaml
+++ b/configs/8.0/ffigen_capi_media_editor.yaml
@@ -58,6 +58,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_image_util.yaml
+++ b/configs/8.0/ffigen_capi_media_image_util.yaml
@@ -69,6 +69,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_metadata_editor.yaml
+++ b/configs/8.0/ffigen_capi_media_metadata_editor.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_metadata_extractor.yaml
+++ b/configs/8.0/ffigen_capi_media_metadata_extractor.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_player.yaml
+++ b/configs/8.0/ffigen_capi_media_player.yaml
@@ -75,6 +75,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_radio.yaml
+++ b/configs/8.0/ffigen_capi_media_radio.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_recorder.yaml
+++ b/configs/8.0/ffigen_capi_media_recorder.yaml
@@ -75,6 +75,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_screen_mirroring.yaml
+++ b/configs/8.0/ffigen_capi_media_screen_mirroring.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_sound_manager.yaml
+++ b/configs/8.0/ffigen_capi_media_sound_manager.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_sound_pool.yaml
+++ b/configs/8.0/ffigen_capi_media_sound_pool.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_streamer.yaml
+++ b/configs/8.0/ffigen_capi_media_streamer.yaml
@@ -75,6 +75,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_streamrecorder.yaml
+++ b/configs/8.0/ffigen_capi_media_streamrecorder.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_thumbnail_util.yaml
+++ b/configs/8.0/ffigen_capi_media_thumbnail_util.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_tone_player.yaml
+++ b/configs/8.0/ffigen_capi_media_tone_player.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_tool.yaml
+++ b/configs/8.0/ffigen_capi_media_tool.yaml
@@ -68,6 +68,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_wav_player.yaml
+++ b/configs/8.0/ffigen_capi_media_wav_player.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_media_webrtc.yaml
+++ b/configs/8.0/ffigen_capi_media_webrtc.yaml
@@ -82,6 +82,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_mediademuxer.yaml
+++ b/configs/8.0/ffigen_capi_mediademuxer.yaml
@@ -70,6 +70,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_mediamuxer.yaml
+++ b/configs/8.0/ffigen_capi_mediamuxer.yaml
@@ -70,6 +70,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_messaging_email.yaml
+++ b/configs/8.0/ffigen_capi_messaging_email.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_ml_common.yaml
+++ b/configs/8.0/ffigen_capi_ml_common.yaml
@@ -60,6 +60,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_ml_inference_single.yaml
+++ b/configs/8.0/ffigen_capi_ml_inference_single.yaml
@@ -142,6 +142,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_ml_service.yaml
+++ b/configs/8.0/ffigen_capi_ml_service.yaml
@@ -80,6 +80,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_network_bluetooth.yaml
+++ b/configs/8.0/ffigen_capi_network_bluetooth.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_network_connection.yaml
+++ b/configs/8.0/ffigen_capi_network_connection.yaml
@@ -57,6 +57,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_network_http.yaml
+++ b/configs/8.0/ffigen_capi_network_http.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_network_inm.yaml
+++ b/configs/8.0/ffigen_capi_network_inm.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_network_mtp.yaml
+++ b/configs/8.0/ffigen_capi_network_mtp.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_network_softap.yaml
+++ b/configs/8.0/ffigen_capi_network_softap.yaml
@@ -70,6 +70,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_network_stc.yaml
+++ b/configs/8.0/ffigen_capi_network_stc.yaml
@@ -70,6 +70,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_network_wifi_manager.yaml
+++ b/configs/8.0/ffigen_capi_network_wifi_manager.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_nnstreamer.yaml
+++ b/configs/8.0/ffigen_capi_nnstreamer.yaml
@@ -80,6 +80,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_nntrainer.yaml
+++ b/configs/8.0/ffigen_capi_nntrainer.yaml
@@ -72,6 +72,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_privacy_privilege_manager.yaml
+++ b/configs/8.0/ffigen_capi_privacy_privilege_manager.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_system_device.yaml
+++ b/configs/8.0/ffigen_capi_system_device.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_system_info.yaml
+++ b/configs/8.0/ffigen_capi_system_info.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_system_media_key.yaml
+++ b/configs/8.0/ffigen_capi_system_media_key.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_system_peripheral_io.yaml
+++ b/configs/8.0/ffigen_capi_system_peripheral_io.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_system_resource_monitor.yaml
+++ b/configs/8.0/ffigen_capi_system_resource_monitor.yaml
@@ -58,6 +58,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_system_runtime_info.yaml
+++ b/configs/8.0/ffigen_capi_system_runtime_info.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_system_sensor.yaml
+++ b/configs/8.0/ffigen_capi_system_sensor.yaml
@@ -70,6 +70,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_system_system_settings.yaml
+++ b/configs/8.0/ffigen_capi_system_system_settings.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_system_usbhost.yaml
+++ b/configs/8.0/ffigen_capi_system_usbhost.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_ui_autofill.yaml
+++ b/configs/8.0/ffigen_capi_ui_autofill.yaml
@@ -83,6 +83,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_ui_autofill_common.yaml
+++ b/configs/8.0/ffigen_capi_ui_autofill_common.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_ui_autofill_manager.yaml
+++ b/configs/8.0/ffigen_capi_ui_autofill_manager.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_ui_autofill_service.yaml
+++ b/configs/8.0/ffigen_capi_ui_autofill_service.yaml
@@ -82,6 +82,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_ui_inputmethod.yaml
+++ b/configs/8.0/ffigen_capi_ui_inputmethod.yaml
@@ -58,6 +58,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_ui_inputmethod_manager.yaml
+++ b/configs/8.0/ffigen_capi_ui_inputmethod_manager.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_vpnsvc.yaml
+++ b/configs/8.0/ffigen_capi_vpnsvc.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_capi_web_url_download.yaml
+++ b/configs/8.0/ffigen_capi_web_url_download.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_cion.yaml
+++ b/configs/8.0/ffigen_cion.yaml
@@ -58,6 +58,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_contacts_service2.yaml
+++ b/configs/8.0/ffigen_contacts_service2.yaml
@@ -73,6 +73,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_core_sync_client.yaml
+++ b/configs/8.0/ffigen_core_sync_client.yaml
@@ -72,6 +72,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_csr_client.yaml
+++ b/configs/8.0/ffigen_csr_client.yaml
@@ -70,6 +70,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_data_control.yaml
+++ b/configs/8.0/ffigen_data_control.yaml
@@ -72,6 +72,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_device_certificate_manager.yaml
+++ b/configs/8.0/ffigen_device_certificate_manager.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_diagnostics.yaml
+++ b/configs/8.0/ffigen_diagnostics.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_dpm.yaml
+++ b/configs/8.0/ffigen_dpm.yaml
@@ -60,6 +60,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_eom.yaml
+++ b/configs/8.0/ffigen_eom.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_feedback.yaml
+++ b/configs/8.0/ffigen_feedback.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_fido_client.yaml
+++ b/configs/8.0/ffigen_fido_client.yaml
@@ -60,6 +60,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_iotcon.yaml
+++ b/configs/8.0/ffigen_iotcon.yaml
@@ -73,6 +73,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_key_manager_client.yaml
+++ b/configs/8.0/ffigen_key_manager_client.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_ma.yaml
+++ b/configs/8.0/ffigen_ma.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_message_port.yaml
+++ b/configs/8.0/ffigen_message_port.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_mv_3d.yaml
+++ b/configs/8.0/ffigen_mv_3d.yaml
@@ -73,6 +73,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_mv_barcode_detector.yaml
+++ b/configs/8.0/ffigen_mv_barcode_detector.yaml
@@ -82,6 +82,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_mv_barcode_generator.yaml
+++ b/configs/8.0/ffigen_mv_barcode_generator.yaml
@@ -70,6 +70,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_mv_common.yaml
+++ b/configs/8.0/ffigen_mv_common.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_mv_face.yaml
+++ b/configs/8.0/ffigen_mv_face.yaml
@@ -78,6 +78,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_mv_face_recognition.yaml
+++ b/configs/8.0/ffigen_mv_face_recognition.yaml
@@ -69,6 +69,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_mv_image.yaml
+++ b/configs/8.0/ffigen_mv_image.yaml
@@ -78,6 +78,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_mv_inference.yaml
+++ b/configs/8.0/ffigen_mv_inference.yaml
@@ -82,6 +82,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_mv_roi_tracker.yaml
+++ b/configs/8.0/ffigen_mv_roi_tracker.yaml
@@ -77,6 +77,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_mv_surveillance.yaml
+++ b/configs/8.0/ffigen_mv_surveillance.yaml
@@ -74,6 +74,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_notification.yaml
+++ b/configs/8.0/ffigen_notification.yaml
@@ -78,6 +78,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_notification_ex.yaml
+++ b/configs/8.0/ffigen_notification_ex.yaml
@@ -98,6 +98,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_nsd_dns_sd.yaml
+++ b/configs/8.0/ffigen_nsd_dns_sd.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_nsd_ssdp.yaml
+++ b/configs/8.0/ffigen_nsd_ssdp.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_oauth2.yaml
+++ b/configs/8.0/ffigen_oauth2.yaml
@@ -61,6 +61,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_phonenumber_utils.yaml
+++ b/configs/8.0/ffigen_phonenumber_utils.yaml
@@ -59,6 +59,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_privilege_info.yaml
+++ b/configs/8.0/ffigen_privilege_info.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_push.yaml
+++ b/configs/8.0/ffigen_push.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_rpc_port.yaml
+++ b/configs/8.0/ffigen_rpc_port.yaml
@@ -73,6 +73,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_shortcut.yaml
+++ b/configs/8.0/ffigen_shortcut.yaml
@@ -1,12 +1,14 @@
 preamble: |
-  // Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+  // Copyright 2026 Samsung Electronics Co., Ltd. All rights reserved.
   // Use of this source code is governed by a BSD-style license that can be
   // found in the LICENSE file.
   // ignore_for_file: type=lint, unused_element, unused_field
 
-name: 'Tizen80Dlog'
-description: 'Dart bindings for Tizen dlog APIs.'
-output: '../../lib/src/bindings/8.0/generated_bindings_dlog.dart'
+name: 'Tizen80Shortcut'
+
+description: 'Dart bindings for Tizen shortcut APIs.'
+
+output: '../../lib/src/bindings/8.0/generated_bindings_shortcut.dart'
 
 llvm-path:
   - '/usr/lib/llvm-12'
@@ -15,7 +17,7 @@ headers:
   entry-points:
     - 'entrypoints.h'
   include-directives:
-    - '**/dlog.h'
+    - '**/shortcut/*.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/8.0/ffigen_storage.yaml
+++ b/configs/8.0/ffigen_storage.yaml
@@ -59,6 +59,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_stt.yaml
+++ b/configs/8.0/ffigen_stt.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_stt_engine.yaml
+++ b/configs/8.0/ffigen_stt_engine.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_tbm.yaml
+++ b/configs/8.0/ffigen_tbm.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_time.yaml
+++ b/configs/8.0/ffigen_time.yaml
@@ -78,6 +78,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_ttrace.yaml
+++ b/configs/8.0/ffigen_ttrace.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_tts.yaml
+++ b/configs/8.0/ffigen_tts.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_tts_engine.yaml
+++ b/configs/8.0/ffigen_tts_engine.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_update_control.yaml
+++ b/configs/8.0/ffigen_update_control.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_vc.yaml
+++ b/configs/8.0/ffigen_vc.yaml
@@ -58,6 +58,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_vc_engine.yaml
+++ b/configs/8.0/ffigen_vc_engine.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_vc_manager.yaml
+++ b/configs/8.0/ffigen_vc_manager.yaml
@@ -90,6 +90,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_wifi_direct.yaml
+++ b/configs/8.0/ffigen_wifi_direct.yaml
@@ -56,6 +56,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/ffigen_yaca.yaml
+++ b/configs/8.0/ffigen_yaca.yaml
@@ -66,6 +66,7 @@ compiler-opts:
   - '-I./rootstraps/8.0/usr/include/privacy-privilege-manager/'
   - '-I./rootstraps/8.0/usr/include/rpc-port/'
   - '-I./rootstraps/8.0/usr/include/sensor/'
+  - '-I./rootstraps/8.0/usr/include/shortcut/'
   - '-I./rootstraps/8.0/usr/include/storage/'
   - '-I./rootstraps/8.0/usr/include/system/'
   - '-I./rootstraps/8.0/usr/include/web/'

--- a/configs/8.0/symgen.yaml
+++ b/configs/8.0/symgen.yaml
@@ -31,6 +31,7 @@ target-libraries:
   - libcapi-appfw-package-manager.so.0          # Application Framework / Package Manager
   - librpc-port.so.1                            # Application Framework / RPC Port
   - libappcore-agent.so.1                       # Application Framework / Service Application
+  - libshortcut.so.0                            # Application Framework / Shortcut
   - libcapi-base-common.so.0                    # Base / Common Error
   - libcapi-web-url-download.so.0               # Content / Download
   - libcapi-content-mime-type.so.0              # Content / Mime Type

--- a/configs/9.0/entrypoints.h
+++ b/configs/9.0/entrypoints.h
@@ -69,8 +69,8 @@
 #include <rpc-port-parcel.h>
 #include <rpc-port.h>
 #include <service_app.h>
-#include <shortcut/shortcut_manager.h>
 #include <shortcut_error.h>
+#include <shortcut_manager.h>
 #include <tizen_core.h>
 
 // Base

--- a/configs/9.0/ffigen_shortcut.yaml
+++ b/configs/9.0/ffigen_shortcut.yaml
@@ -1,0 +1,84 @@
+preamble: |
+  // Copyright 2026 Samsung Electronics Co., Ltd. All rights reserved.
+  // Use of this source code is governed by a BSD-style license that can be
+  // found in the LICENSE file.
+  // ignore_for_file: type=lint, unused_element, unused_field
+
+name: 'Tizen90Shortcut'
+
+description: 'Dart bindings for Tizen shortcut APIs.'
+
+output: '../../lib/src/bindings/9.0/generated_bindings_shortcut.dart'
+
+llvm-path:
+  - '/usr/lib/llvm-12'
+
+headers:
+  entry-points:
+    - 'entrypoints.h'
+  include-directives:
+    - '**/shortcut/*.h'
+
+compiler-opts:
+  - '-m32'
+  - '-Wno-incomplete-setjmp-declaration'
+
+  # include Tizen API directories
+  - '-I./rootstraps/9.0/usr/include/'
+  - '-I./rootstraps/9.0/usr/include/appcore-agent/'
+  - '-I./rootstraps/9.0/usr/include/appfw/'
+  - '-I./rootstraps/9.0/usr/include/asp/'
+  - '-I./rootstraps/9.0/usr/include/badge/'
+  - '-I./rootstraps/9.0/usr/include/calendar-service2/'
+  - '-I./rootstraps/9.0/usr/include/cion/'
+  - '-I./rootstraps/9.0/usr/include/ckm/'
+  - '-I./rootstraps/9.0/usr/include/contacts-svc/'
+  - '-I./rootstraps/9.0/usr/include/content/'
+  - '-I./rootstraps/9.0/usr/include/context-service/'
+  - '-I./rootstraps/9.0/usr/include/csr/'
+  - '-I./rootstraps/9.0/usr/include/device-certificate-manager/'
+  - '-I./rootstraps/9.0/usr/include/dlog/'
+  - '-I./rootstraps/9.0/usr/include/eom/'
+  - '-I./rootstraps/9.0/usr/include/feedback/'
+  - '-I./rootstraps/9.0/usr/include/geofence/'
+  - '-I./rootstraps/9.0/usr/include/iotcon/'
+  - '-I./rootstraps/9.0/usr/include/location/'
+  - '-I./rootstraps/9.0/usr/include/media/'
+  - '-I./rootstraps/9.0/usr/include/media-content/'
+  - '-I./rootstraps/9.0/usr/include/messaging/'
+  - '-I./rootstraps/9.0/usr/include/metadata-editor/'
+  - '-I./rootstraps/9.0/usr/include/mmi/'
+  - '-I./rootstraps/9.0/usr/include/network/'
+  - '-I./rootstraps/9.0/usr/include/nnstreamer/'
+  - '-I./rootstraps/9.0/usr/include/nntrainer/'
+  - '-I./rootstraps/9.0/usr/include/notification/'
+  - '-I./rootstraps/9.0/usr/include/notification-ex/api/'
+  - '-I./rootstraps/9.0/usr/include/nsd/'
+  - '-I./rootstraps/9.0/usr/include/openssl/'
+  - '-I./rootstraps/9.0/usr/include/phonenumber-utils/'
+  - '-I./rootstraps/9.0/usr/include/privacy-privilege-manager/'
+  - '-I./rootstraps/9.0/usr/include/rpc-port/'
+  - '-I./rootstraps/9.0/usr/include/sensor/'
+  - '-I./rootstraps/9.0/usr/include/shortcut/'
+  - '-I./rootstraps/9.0/usr/include/storage/'
+  - '-I./rootstraps/9.0/usr/include/system/'
+  - '-I./rootstraps/9.0/usr/include/tizen-core/'
+  - '-I./rootstraps/9.0/usr/include/web/'
+  - '-I./rootstraps/9.0/usr/include/wifi-direct/'
+  - '-I./rootstraps/9.0/usr/include/yaca/'
+  # include EFL directories
+  - '-I./rootstraps/9.0/usr/include/ecore-imf-1/'
+  - '-I./rootstraps/9.0/usr/include/efl-1/'
+  - '-I./rootstraps/9.0/usr/include/eina-1/'
+  - '-I./rootstraps/9.0/usr/include/eina-1/eina/'
+  - '-I./rootstraps/9.0/usr/include/emile-1/'
+  - '-I./rootstraps/9.0/usr/include/eo-1/'
+  - '-I./rootstraps/9.0/usr/include/evas-1/'
+
+  # include glib directories
+  - '-I./rootstraps/9.0/usr/include/glib-2.0/'
+  - '-I./rootstraps/9.0/usr/lib/glib-2.0/include/'
+
+enums:
+  rename:
+    '_+(.*)': '$1'

--- a/configs/9.0/symgen.yaml
+++ b/configs/9.0/symgen.yaml
@@ -32,6 +32,7 @@ target-libraries:
   - librpc-port.so.1                            # Application Framework / RPC Port
   - libappcore-agent.so.1                       # Application Framework / Service Application
   - libtizen-core.so.0                          # Application Framework / Tizen Core
+  - libshortcut.so.0                            # Application Framework / Shortcut
   - libcapi-base-common.so.0                    # Base / Common Error
   - libcapi-web-url-download.so.0               # Content / Download
   - libcapi-content-mime-type.so.0              # Content / Mime Type

--- a/lib/src/bindings/6.5/generated_bindings_shortcut.dart
+++ b/lib/src/bindings/6.5/generated_bindings_shortcut.dart
@@ -449,6 +449,46 @@ class Tizen65Shortcut {
       _shortcut_unset_remove_cbPtr.asFunction<void Function()>();
 }
 
+/// @brief Enumeration for values of shortcut response types.
+/// @since_tizen 2.3
+abstract class shortcut_error_e {
+  /// < Successful
+  static const int SHORTCUT_ERROR_NONE = 0;
+
+  /// < Invalid function parameter
+  static const int SHORTCUT_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int SHORTCUT_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < I/O Error
+  static const int SHORTCUT_ERROR_IO_ERROR = -5;
+
+  /// < Permission denied
+  static const int SHORTCUT_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Not supported
+  static const int SHORTCUT_ERROR_NOT_SUPPORTED = -1073741822;
+
+  /// < Device or resource busy
+  static const int SHORTCUT_ERROR_RESOURCE_BUSY = -16;
+
+  /// < There is no space to add a new shortcut
+  static const int SHORTCUT_ERROR_NO_SPACE = -18219007;
+
+  /// < Shortcut is already added
+  static const int SHORTCUT_ERROR_EXIST = -18219006;
+
+  /// < Unrecoverable error
+  static const int SHORTCUT_ERROR_FAULT = -18219004;
+
+  /// < Not exist shortcut(@b Since: 3.0)
+  static const int SHORTCUT_ERROR_NOT_EXIST = -18219000;
+
+  /// < Connection not established or communication problem
+  static const int SHORTCUT_ERROR_COMM = -18218944;
+}
+
 /// @brief Enumeration for shortcut types.
 /// @details Basically, two types of shortcuts are defined.
 /// Every homescreen developer should support these types of shortcuts.

--- a/lib/src/bindings/8.0/generated_bindings_shortcut.dart
+++ b/lib/src/bindings/8.0/generated_bindings_shortcut.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Copyright 2026 Samsung Electronics Co., Ltd. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 // ignore_for_file: type=lint, unused_element, unused_field
@@ -9,17 +9,17 @@
 import 'dart:ffi' as ffi;
 
 /// Dart bindings for Tizen shortcut APIs.
-class Tizen60Shortcut {
+class Tizen80Shortcut {
   /// Holds the symbol lookup function.
   final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
       _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  Tizen60Shortcut(ffi.DynamicLibrary dynamicLibrary)
+  Tizen80Shortcut(ffi.DynamicLibrary dynamicLibrary)
       : _lookup = dynamicLibrary.lookup;
 
   /// The symbols are looked up with [lookup].
-  Tizen60Shortcut.fromLookup(
+  Tizen80Shortcut.fromLookup(
       ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
           lookup)
       : _lookup = lookup;

--- a/lib/src/bindings/8.0/generated_symbols.dart
+++ b/lib/src/bindings/8.0/generated_symbols.dart
@@ -1114,6 +1114,19 @@ const Map<String, List<String>> appcoreAgentSymbols = {
   ],
 };
 
+const Map<String, List<String>> shortcutSymbols = {
+  'libshortcut.so.0': [
+    'shortcut_add_to_home',
+    'shortcut_add_to_home_widget',
+    'shortcut_get_list',
+    'shortcut_remove_from_home',
+    'shortcut_set_remove_cb',
+    'shortcut_set_request_cb',
+    'shortcut_unset_remove_cb',
+    'shortcut_unset_request_cb',
+  ],
+};
+
 const Map<String, List<String>> capiBaseCommonSymbols = {
   'libcapi-base-common.so.0': [
     'get_error_message',

--- a/lib/src/bindings/9.0/generated_bindings_shortcut.dart
+++ b/lib/src/bindings/9.0/generated_bindings_shortcut.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Copyright 2026 Samsung Electronics Co., Ltd. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 // ignore_for_file: type=lint, unused_element, unused_field
@@ -9,21 +9,22 @@
 import 'dart:ffi' as ffi;
 
 /// Dart bindings for Tizen shortcut APIs.
-class Tizen60Shortcut {
+class Tizen90Shortcut {
   /// Holds the symbol lookup function.
   final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
       _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  Tizen60Shortcut(ffi.DynamicLibrary dynamicLibrary)
+  Tizen90Shortcut(ffi.DynamicLibrary dynamicLibrary)
       : _lookup = dynamicLibrary.lookup;
 
   /// The symbols are looked up with [lookup].
-  Tizen60Shortcut.fromLookup(
+  Tizen90Shortcut.fromLookup(
       ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
           lookup)
       : _lookup = lookup;
 
+  /// @deprecated Deprecated since 9.0
   /// @brief Adds a shortcut to home, asynchronously.
   /// @since_tizen 2.3
   /// @privlevel public
@@ -118,6 +119,7 @@ class Tizen60Shortcut {
       int Function(ffi.Pointer<ffi.Char>, int, ffi.Pointer<ffi.Char>,
           ffi.Pointer<ffi.Char>, int, result_cb, ffi.Pointer<ffi.Void>)>();
 
+  /// @deprecated Deprecated since 9.0
   /// @brief Adds a widget to home, asynchronously.
   /// @since_tizen 2.4
   /// @privlevel public
@@ -225,6 +227,7 @@ class Tizen60Shortcut {
               result_cb,
               ffi.Pointer<ffi.Void>)>();
 
+  /// @deprecated Deprecated since 9.0
   /// @brief Removes a shortcut from home, asynchronously.
   /// @details If the callback function registered for a widget, the shortcut deletion is possible.
   /// @since_tizen 3.0
@@ -288,6 +291,7 @@ class Tizen60Shortcut {
           int Function(
               ffi.Pointer<ffi.Char>, result_cb, ffi.Pointer<ffi.Void>)>();
 
+  /// @deprecated Deprecated since 9.0
   /// @brief Gets the preset list of shortcut template from the installed package, synchronously.
   /// @since_tizen 2.4
   /// @privlevel public
@@ -330,6 +334,7 @@ class Tizen60Shortcut {
       int Function(
           ffi.Pointer<ffi.Char>, shortcut_list_cb, ffi.Pointer<ffi.Void>)>();
 
+  /// @deprecated Deprecated since 9.0
   /// @brief Sets a callback function to listen requests from applications.
   /// @since_tizen 2.4
   /// @privlevel public
@@ -368,6 +373,7 @@ class Tizen60Shortcut {
   late final _shortcut_set_request_cb = _shortcut_set_request_cbPtr
       .asFunction<int Function(shortcut_request_cb, ffi.Pointer<ffi.Void>)>();
 
+  /// @deprecated Deprecated since 9.0
   /// @brief Unsets a callback for the shortcut request.
   /// @since_tizen 3.0
   /// @privlevel public
@@ -389,6 +395,7 @@ class Tizen60Shortcut {
   late final _shortcut_unset_request_cb =
       _shortcut_unset_request_cbPtr.asFunction<void Function()>();
 
+  /// @deprecated Deprecated since 9.0
   /// @brief Sets the callback function to listen the remove requests from applications.
   /// @since_tizen 3.0
   /// @privlevel public
@@ -427,6 +434,7 @@ class Tizen60Shortcut {
   late final _shortcut_set_remove_cb = _shortcut_set_remove_cbPtr
       .asFunction<int Function(shortcut_remove_cb, ffi.Pointer<ffi.Void>)>();
 
+  /// @deprecated Deprecated since 9.0
   /// @brief Unsets a callback for the shortcut remove.
   /// @since_tizen 3.0
   /// @privlevel public
@@ -449,6 +457,7 @@ class Tizen60Shortcut {
       _shortcut_unset_remove_cbPtr.asFunction<void Function()>();
 }
 
+/// @deprecated Deprecated since 9.0
 /// @brief Enumeration for values of shortcut response types.
 /// @since_tizen 2.3
 abstract class shortcut_error_e {
@@ -489,6 +498,7 @@ abstract class shortcut_error_e {
   static const int SHORTCUT_ERROR_COMM = -18218944;
 }
 
+/// @deprecated Deprecated since 9.0
 /// @brief Enumeration for shortcut types.
 /// @details Basically, two types of shortcuts are defined.
 /// Every homescreen developer should support these types of shortcuts.
@@ -504,6 +514,7 @@ abstract class shortcut_type {
   static const int LAUNCH_BY_URI = 1;
 }
 
+/// @deprecated Deprecated since 9.0
 /// @brief Enumeration for sizes of shortcut widget.
 /// @since_tizen 2.4
 abstract class shortcut_widget_size {
@@ -550,6 +561,7 @@ abstract class shortcut_widget_size {
   static const int WIDGET_SIZE_EASY_3x3 = 805568512;
 }
 
+/// @deprecated Deprecated since 9.0
 /// @brief Called to receive the result of shortcut_add_to_home().
 /// @since_tizen 2.3
 /// @param[in] ret The result value, it could be @c 0 if it succeeds to add a shortcut,
@@ -564,6 +576,7 @@ typedef result_cbFunction = ffi.Int Function(
 typedef Dartresult_cbFunction = int Function(
     int ret, ffi.Pointer<ffi.Void> user_data);
 
+/// @deprecated Deprecated since 9.0
 /// @brief Called to receive the result of shortcut_get_list().
 /// @since_tizen 2.4
 /// @param[in] package_name The name of package
@@ -591,6 +604,7 @@ typedef Dartshortcut_list_cbFunction = int Function(
     ffi.Pointer<ffi.Char> extra_data,
     ffi.Pointer<ffi.Void> user_data);
 
+/// @deprecated Deprecated since 9.0
 /// @brief Called to the add_to_home request.
 /// @details The homescreen should define a callback as this type and implement the service code
 /// for adding a new application shortcut.
@@ -632,6 +646,7 @@ typedef Dartshortcut_request_cbFunction = int Function(
     int allow_duplicate,
     ffi.Pointer<ffi.Void> user_data);
 
+/// @deprecated Deprecated since 9.0
 /// @brief Called to the shortcut_remove_from_home() request.
 /// @since_tizen 3.0
 /// @param[in] package_name The name of package

--- a/lib/src/bindings/9.0/generated_symbols.dart
+++ b/lib/src/bindings/9.0/generated_symbols.dart
@@ -1179,6 +1179,19 @@ const Map<String, List<String>> tizenCoreSymbols = {
   ],
 };
 
+const Map<String, List<String>> shortcutSymbols = {
+  'libshortcut.so.0': [
+    'shortcut_add_to_home',
+    'shortcut_add_to_home_widget',
+    'shortcut_get_list',
+    'shortcut_remove_from_home',
+    'shortcut_set_remove_cb',
+    'shortcut_set_request_cb',
+    'shortcut_unset_remove_cb',
+    'shortcut_unset_request_cb',
+  ],
+};
+
 const Map<String, List<String>> capiBaseCommonSymbols = {
   'libcapi-base-common.so.0': [
     'get_error_message',


### PR DESCRIPTION
- Add libshortcut.so binding code for tizen 8.0 and 9.0.
- Adds a missing enum to the libshortcut.so binding code in Tizen 6.0 and 6.5.