### PR TITLE
Update generator_callbacks scripts to handle individual modules

### DIFF
--- a/packages/tizen_interop_callbacks/tizen/src/generated_callbacks.cc
+++ b/packages/tizen_interop_callbacks/tizen/src/generated_callbacks.cc
@@ -1593,6 +1593,12 @@ PROXY_GROUP_NON_BLOCKING(ime_option_window_destroyed_cb, void* window, void* use
 PROXY_GROUP_BLOCKING(ime_option_window_destroyed_cb, void* window, void* user_data)
 #undef CB_PARAMS_NAMES
 
+typedef void (*ime_position_align_set_cb)(int x, int y, Ecore_IMF_Input_Panel_Align align, void* user_data);
+#define CB_PARAMS_NAMES x, y, align, user_data
+PROXY_GROUP_NON_BLOCKING(ime_position_align_set_cb, int x, int y, Ecore_IMF_Input_Panel_Align align, void* user_data)
+PROXY_GROUP_BLOCKING(ime_position_align_set_cb, int x, int y, Ecore_IMF_Input_Panel_Align align, void* user_data)
+#undef CB_PARAMS_NAMES
+
 typedef void (*ime_prediction_hint_data_set_cb)(const char* key, const char* value, void* user_data);
 #define CB_PARAMS_NAMES key, value, user_data
 PROXY_GROUP_NON_BLOCKING(ime_prediction_hint_data_set_cb, const char* key, const char* value, void* user_data)
@@ -1603,6 +1609,12 @@ typedef void (*ime_prediction_hint_set_cb)(const char* prediction_hint, void* us
 #define CB_PARAMS_NAMES prediction_hint, user_data
 PROXY_GROUP_NON_BLOCKING(ime_prediction_hint_set_cb, const char* prediction_hint, void* user_data)
 PROXY_GROUP_BLOCKING(ime_prediction_hint_set_cb, const char* prediction_hint, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef void (*ime_process_input_device_event_cb)(some_enum device_type, void* device_event, void* user_data);
+#define CB_PARAMS_NAMES device_type, device_event, user_data
+PROXY_GROUP_NON_BLOCKING(ime_process_input_device_event_cb, some_enum device_type, void* device_event, void* user_data)
+PROXY_GROUP_BLOCKING(ime_process_input_device_event_cb, some_enum device_type, void* device_event, void* user_data)
 #undef CB_PARAMS_NAMES
 
 typedef bool (*ime_process_key_event_cb)(some_enum key_code, some_enum key_mask, void* dev_info, void* user_data);
@@ -2912,6 +2924,36 @@ PROXY_GROUP_NON_BLOCKING(noti_ex_reporter_events_event_cb, void* handle, void* i
 PROXY_GROUP_BLOCKING(noti_ex_reporter_events_event_cb, void* handle, void* info, void* items, int count, void* user_data)
 #undef CB_PARAMS_NAMES
 
+typedef void (*oauth2_access_token_cb)(void* response, void* user_data);
+#define CB_PARAMS_NAMES response, user_data
+PROXY_GROUP_NON_BLOCKING(oauth2_access_token_cb, void* response, void* user_data)
+PROXY_GROUP_BLOCKING(oauth2_access_token_cb, void* response, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef void (*oauth2_auth_grant_cb)(void* response, void* user_data);
+#define CB_PARAMS_NAMES response, user_data
+PROXY_GROUP_NON_BLOCKING(oauth2_auth_grant_cb, void* response, void* user_data)
+PROXY_GROUP_BLOCKING(oauth2_auth_grant_cb, void* response, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef void (*oauth2_refresh_token_cb)(void* response, void* user_data);
+#define CB_PARAMS_NAMES response, user_data
+PROXY_GROUP_NON_BLOCKING(oauth2_refresh_token_cb, void* response, void* user_data)
+PROXY_GROUP_BLOCKING(oauth2_refresh_token_cb, void* response, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef void (*oauth2_token_auth_url_cb)(void* response, void* user_data);
+#define CB_PARAMS_NAMES response, user_data
+PROXY_GROUP_NON_BLOCKING(oauth2_token_auth_url_cb, void* response, void* user_data)
+PROXY_GROUP_BLOCKING(oauth2_token_auth_url_cb, void* response, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef void (*oauth2_token_cb)(void* response, void* user_data);
+#define CB_PARAMS_NAMES response, user_data
+PROXY_GROUP_NON_BLOCKING(oauth2_token_cb, void* response, void* user_data)
+PROXY_GROUP_BLOCKING(oauth2_token_cb, void* response, void* user_data)
+#undef CB_PARAMS_NAMES
+
 typedef bool (*package_info_app_cb)(some_enum comp_type, const char* app_id, void* user_data);
 #define CB_PARAMS_NAMES comp_type, app_id, user_data
 PROXY_GROUP_RETURN(package_info_app_cb, bool, some_enum comp_type, const char* app_id, void* user_data)
@@ -3992,6 +4034,23 @@ PROXY_GROUP_NON_BLOCKING(usb_host_transferred_cb, void* transfer, void* user_dat
 PROXY_GROUP_BLOCKING(usb_host_transferred_cb, void* transfer, void* user_data)
 #undef CB_PARAMS_NAMES
 
+typedef bool (*vc_cmd_list_cb)(void* vc_command, void* user_data);
+#define CB_PARAMS_NAMES vc_command, user_data
+PROXY_GROUP_RETURN(vc_cmd_list_cb, bool, void* vc_command, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef void (*vc_current_language_changed_cb)(const char* previous, const char* current, void* user_data);
+#define CB_PARAMS_NAMES previous, current, user_data
+PROXY_GROUP_NON_BLOCKING(vc_current_language_changed_cb, const char* previous, const char* current, void* user_data)
+PROXY_GROUP_BLOCKING(vc_current_language_changed_cb, const char* previous, const char* current, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef void (*vc_error_cb)(some_enum reason, void* user_data);
+#define CB_PARAMS_NAMES reason, user_data
+PROXY_GROUP_NON_BLOCKING(vc_error_cb, some_enum reason, void* user_data)
+PROXY_GROUP_BLOCKING(vc_error_cb, some_enum reason, void* user_data)
+#undef CB_PARAMS_NAMES
+
 typedef bool (*vc_mgr_all_result_cb)(some_enum event, void* vc_cmd_list, const char* result, const char* msg, void* user_data);
 #define CB_PARAMS_NAMES event, vc_cmd_list, result, msg, user_data
 PROXY_GROUP_RETURN(vc_mgr_all_result_cb, bool, some_enum event, void* vc_cmd_list, const char* result, const char* msg, void* user_data)
@@ -4047,6 +4106,41 @@ typedef void (*vc_mgr_vc_tts_streaming_cb)(int pid, int utt_id, some_enum event,
 #define CB_PARAMS_NAMES pid, utt_id, event, buffer, len, user_data
 PROXY_GROUP_NON_BLOCKING(vc_mgr_vc_tts_streaming_cb, int pid, int utt_id, some_enum event, char* buffer, int len, void* user_data)
 PROXY_GROUP_BLOCKING(vc_mgr_vc_tts_streaming_cb, int pid, int utt_id, some_enum event, char* buffer, int len, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef void (*vc_result_cb)(some_enum event, void* vc_cmd_list, const char* result, void* user_data);
+#define CB_PARAMS_NAMES event, vc_cmd_list, result, user_data
+PROXY_GROUP_NON_BLOCKING(vc_result_cb, some_enum event, void* vc_cmd_list, const char* result, void* user_data)
+PROXY_GROUP_BLOCKING(vc_result_cb, some_enum event, void* vc_cmd_list, const char* result, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef void (*vc_service_state_changed_cb)(some_enum previous, some_enum current, void* user_data);
+#define CB_PARAMS_NAMES previous, current, user_data
+PROXY_GROUP_NON_BLOCKING(vc_service_state_changed_cb, some_enum previous, some_enum current, void* user_data)
+PROXY_GROUP_BLOCKING(vc_service_state_changed_cb, some_enum previous, some_enum current, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef void (*vc_state_changed_cb)(some_enum previous, some_enum current, void* user_data);
+#define CB_PARAMS_NAMES previous, current, user_data
+PROXY_GROUP_NON_BLOCKING(vc_state_changed_cb, some_enum previous, some_enum current, void* user_data)
+PROXY_GROUP_BLOCKING(vc_state_changed_cb, some_enum previous, some_enum current, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef bool (*vc_supported_language_cb)(const char* language, void* user_data);
+#define CB_PARAMS_NAMES language, user_data
+PROXY_GROUP_RETURN(vc_supported_language_cb, bool, const char* language, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef void (*vc_tts_streaming_cb)(some_enum event, char* buffer, int len, int utt_id, void* user_data);
+#define CB_PARAMS_NAMES event, buffer, len, utt_id, user_data
+PROXY_GROUP_NON_BLOCKING(vc_tts_streaming_cb, some_enum event, char* buffer, int len, int utt_id, void* user_data)
+PROXY_GROUP_BLOCKING(vc_tts_streaming_cb, some_enum event, char* buffer, int len, int utt_id, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef void (*vc_tts_utterance_status_cb)(int utt_id, some_enum status, void* user_data);
+#define CB_PARAMS_NAMES utt_id, status, user_data
+PROXY_GROUP_NON_BLOCKING(vc_tts_utterance_status_cb, int utt_id, some_enum status, void* user_data)
+PROXY_GROUP_BLOCKING(vc_tts_utterance_status_cb, int utt_id, some_enum status, void* user_data)
 #undef CB_PARAMS_NAMES
 
 #define BASE_CALLBACK_ID_vce_cancel_cb 155
@@ -4200,6 +4294,30 @@ PROXY_GROUP_RETURN(vce_tts_audio_format_request_cb, int, int* rate, int* channel
 #define BASE_CALLBACK_ID_vce_unset_commands_cb 260
 typedef int (*vce_unset_commands_cb)();
 PROXY_GROUP_RETURN_NO_USER_DATA_NO_PARAM(vce_unset_commands_cb, int)
+
+typedef void (*wauthn_display_qrcode_cb)(const char* qr_contents, void* user_data);
+#define CB_PARAMS_NAMES qr_contents, user_data
+PROXY_GROUP_NON_BLOCKING(wauthn_display_qrcode_cb, const char* qr_contents, void* user_data)
+PROXY_GROUP_BLOCKING(wauthn_display_qrcode_cb, const char* qr_contents, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef void (*wauthn_ga_on_response_cb)(const void* pubkey_cred, some_enum result, void* user_data);
+#define CB_PARAMS_NAMES pubkey_cred, result, user_data
+PROXY_GROUP_NON_BLOCKING(wauthn_ga_on_response_cb, const void* pubkey_cred, some_enum result, void* user_data)
+PROXY_GROUP_BLOCKING(wauthn_ga_on_response_cb, const void* pubkey_cred, some_enum result, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef void (*wauthn_mc_on_response_cb)(const void* pubkey_cred, some_enum result, void* user_data);
+#define CB_PARAMS_NAMES pubkey_cred, result, user_data
+PROXY_GROUP_NON_BLOCKING(wauthn_mc_on_response_cb, const void* pubkey_cred, some_enum result, void* user_data)
+PROXY_GROUP_BLOCKING(wauthn_mc_on_response_cb, const void* pubkey_cred, some_enum result, void* user_data)
+#undef CB_PARAMS_NAMES
+
+typedef void (*wauthn_update_linked_data_cb)(const void* linked_data, some_enum result, void* user_data);
+#define CB_PARAMS_NAMES linked_data, result, user_data
+PROXY_GROUP_NON_BLOCKING(wauthn_update_linked_data_cb, const void* linked_data, some_enum result, void* user_data)
+PROXY_GROUP_BLOCKING(wauthn_update_linked_data_cb, const void* linked_data, some_enum result, void* user_data)
+#undef CB_PARAMS_NAMES
 
 typedef void (*wav_player_playback_completed_cb)(int id, void* user_data);
 #define CB_PARAMS_NAMES id, user_data
@@ -5070,10 +5188,14 @@ std::map<std::string, MultiProxyFunctionsContainer> multi_proxy_map = {
   MULTI_PROXY_MAP_ENTRY(platform_non_blocking_ime_option_window_created_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_ime_option_window_destroyed_cb)
   MULTI_PROXY_MAP_ENTRY(platform_non_blocking_ime_option_window_destroyed_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_ime_position_align_set_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_ime_position_align_set_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_ime_prediction_hint_data_set_cb)
   MULTI_PROXY_MAP_ENTRY(platform_non_blocking_ime_prediction_hint_data_set_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_ime_prediction_hint_set_cb)
   MULTI_PROXY_MAP_ENTRY(platform_non_blocking_ime_prediction_hint_set_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_ime_process_input_device_event_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_ime_process_input_device_event_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_ime_process_key_event_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_ime_process_key_event_with_keycode_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_ime_return_key_state_set_cb)
@@ -5468,6 +5590,16 @@ std::map<std::string, MultiProxyFunctionsContainer> multi_proxy_map = {
   MULTI_PROXY_MAP_ENTRY(platform_non_blocking_noti_ex_reporter_events_error_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_noti_ex_reporter_events_event_cb)
   MULTI_PROXY_MAP_ENTRY(platform_non_blocking_noti_ex_reporter_events_event_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_oauth2_access_token_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_oauth2_access_token_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_oauth2_auth_grant_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_oauth2_auth_grant_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_oauth2_refresh_token_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_oauth2_refresh_token_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_oauth2_token_auth_url_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_oauth2_token_auth_url_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_oauth2_token_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_oauth2_token_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_package_info_app_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_package_info_cert_info_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_package_info_dependency_info_cb)
@@ -5770,6 +5902,11 @@ std::map<std::string, MultiProxyFunctionsContainer> multi_proxy_map = {
   MULTI_PROXY_MAP_ENTRY(platform_non_blocking_usb_host_hotplug_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_usb_host_transferred_cb)
   MULTI_PROXY_MAP_ENTRY(platform_non_blocking_usb_host_transferred_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_vc_cmd_list_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_vc_current_language_changed_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_vc_current_language_changed_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_vc_error_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_vc_error_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_vc_mgr_all_result_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_vc_mgr_begin_speech_detected_cb)
   MULTI_PROXY_MAP_ENTRY(platform_non_blocking_vc_mgr_begin_speech_detected_cb)
@@ -5787,6 +5924,17 @@ std::map<std::string, MultiProxyFunctionsContainer> multi_proxy_map = {
   MULTI_PROXY_MAP_ENTRY(platform_non_blocking_vc_mgr_specific_engine_result_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_vc_mgr_vc_tts_streaming_cb)
   MULTI_PROXY_MAP_ENTRY(platform_non_blocking_vc_mgr_vc_tts_streaming_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_vc_result_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_vc_result_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_vc_service_state_changed_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_vc_service_state_changed_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_vc_state_changed_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_vc_state_changed_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_vc_supported_language_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_vc_tts_streaming_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_vc_tts_streaming_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_vc_tts_utterance_status_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_vc_tts_utterance_status_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_vce_cancel_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_vce_cancel_tts_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_vce_command_cb)
@@ -5815,6 +5963,14 @@ std::map<std::string, MultiProxyFunctionsContainer> multi_proxy_map = {
   MULTI_PROXY_MAP_ENTRY(platform_blocking_vce_supported_language_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_vce_tts_audio_format_request_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_vce_unset_commands_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_wauthn_display_qrcode_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_wauthn_display_qrcode_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_wauthn_ga_on_response_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_wauthn_ga_on_response_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_wauthn_mc_on_response_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_wauthn_mc_on_response_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_blocking_wauthn_update_linked_data_cb)
+  MULTI_PROXY_MAP_ENTRY(platform_non_blocking_wauthn_update_linked_data_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_wav_player_playback_completed_cb)
   MULTI_PROXY_MAP_ENTRY(platform_non_blocking_wav_player_playback_completed_cb)
   MULTI_PROXY_MAP_ENTRY(platform_blocking_webrtc_data_channel_buffered_amount_low_cb)

--- a/packages/tizen_interop_callbacks/tizen/src/types.h
+++ b/packages/tizen_interop_callbacks/tizen/src/types.h
@@ -36,4 +36,16 @@ typedef enum { SOME_ENUM_0 } some_enum;
 
 typedef void *void_pointer;
 
+typedef enum _Ecore_IMF_Input_Panel_Align {
+  ECORE_IMF_INPUT_PANEL_ALIGN_TOP_LEFT,      /**< The top-left corner */
+  ECORE_IMF_INPUT_PANEL_ALIGN_TOP_CENTER,    /**< The top-center position */
+  ECORE_IMF_INPUT_PANEL_ALIGN_TOP_RIGHT,     /**< The top-right corner */
+  ECORE_IMF_INPUT_PANEL_ALIGN_MIDDLE_LEFT,   /**< The middle-left position */
+  ECORE_IMF_INPUT_PANEL_ALIGN_MIDDLE_CENTER, /**< The middle-center position */
+  ECORE_IMF_INPUT_PANEL_ALIGN_MIDDLE_RIGHT,  /**< The middle-right position */
+  ECORE_IMF_INPUT_PANEL_ALIGN_BOTTOM_LEFT,   /**< The bottom-left corner */
+  ECORE_IMF_INPUT_PANEL_ALIGN_BOTTOM_CENTER, /**< The bottom-center position */
+  ECORE_IMF_INPUT_PANEL_ALIGN_BOTTOM_RIGHT,  /**< The bottom-right corner */
+} Ecore_IMF_Input_Panel_Align;
+
 #endif  // TIZEN_INTEROP_CALLBACKS_TYPES_H_

--- a/packages/tizen_interop_callbacks/tizen/src/types.h
+++ b/packages/tizen_interop_callbacks/tizen/src/types.h
@@ -36,6 +36,8 @@ typedef enum { SOME_ENUM_0 } some_enum;
 
 typedef void *void_pointer;
 
+// This enum is used as an argument for the ime_position_align_set_cb callback
+// function added in Tizen 9.0.
 typedef enum _Ecore_IMF_Input_Panel_Align {
   ECORE_IMF_INPUT_PANEL_ALIGN_TOP_LEFT,      /**< The top-left corner */
   ECORE_IMF_INPUT_PANEL_ALIGN_TOP_CENTER,    /**< The top-center position */

--- a/scripts/callbacks_generator/gen_callbacks.py
+++ b/scripts/callbacks_generator/gen_callbacks.py
@@ -694,9 +694,9 @@ class CallbackDataCollector:
 
   def set_bindings_filter(self, bindings_file_paths: List[str]):
     names = set()
-    typedef_re = re.compile(r'^typedef\s+([a-zA-Z0-9_]+)', re.MULTILINE)
+    typedef_re = re.compile(r'^\s*typedef\s+([a-zA-Z0-9_]+)', re.MULTILINE)
     for bindings_path in bindings_file_paths:
-      with open(bindings_path) as bindings_file:
+      with open(bindings_path, encoding='utf-8') as bindings_file:
         content = bindings_file.read()
         for match in typedef_re.finditer(content):
           names.add(match.group(1))
@@ -930,7 +930,7 @@ def find_headers_by_config(config_path):
         raise NotImplementedError(
           f'config include-directives `{pattern}` not supported')
     else:
-      log.debug('Skipping pattern %s', pattern)
+      log.warning('Skipping unsupported pattern %s', pattern)
 
   items = set()
 

--- a/scripts/callbacks_generator/gen_callbacks.py
+++ b/scripts/callbacks_generator/gen_callbacks.py
@@ -10,6 +10,7 @@ import glob
 import yaml
 import logging
 import argparse
+import re
 from io import StringIO
 from typing import List, Mapping, Callable, Set
 
@@ -488,11 +489,12 @@ class CodeReader:
     # Move until '*/' is found.
     # We assume that comments have the closing '*/'.
     t = self.tokens
-    while t[idx]._type != self.TOKEN_COMMENT_END:
+    while idx < len(t) and t[idx]._type != self.TOKEN_COMMENT_END:
       idx += 1
 
     # Move to the token after '*/'.
-    idx += 1
+    if idx < len(t):
+      idx += 1
 
     return idx
 
@@ -692,11 +694,12 @@ class CallbackDataCollector:
 
   def set_bindings_filter(self, bindings_file_paths: List[str]):
     names = set()
+    typedef_re = re.compile(r'^typedef\s+([a-zA-Z0-9_]+)', re.MULTILINE)
     for bindings_path in bindings_file_paths:
       with open(bindings_path) as bindings_file:
-        for line in bindings_file:
-          if line.startswith('typedef '):
-            names.add(line.split()[1])
+        content = bindings_file.read()
+        for match in typedef_re.finditer(content):
+          names.add(match.group(1))
 
     self.allowed_names = names
 
@@ -916,16 +919,18 @@ def find_headers_by_config(config_path):
   files_to_find = set()
   dirs_to_find = set()
   for pattern in selected:
-    assert pattern.startswith('**/')
-    if pattern.endswith('/*.h'):
-      log.debug('DIR %s', pattern[3:-4])
-      dirs_to_find.add('/' + pattern[3:-4])
-    elif pattern.endswith('.h') and pattern.count('/') == 1:
-      log.debug('FILE %s', pattern[3:])
-      files_to_find.add(pattern[3:])
+    if pattern.startswith('**/'):
+      if pattern.endswith('/*.h'):
+        log.debug('DIR %s', pattern[3:-4])
+        dirs_to_find.add('/' + pattern[3:-4])
+      elif pattern.endswith('.h') and pattern.count('/') == 1:
+        log.debug('FILE %s', pattern[3:])
+        files_to_find.add(pattern[3:])
+      else:
+        raise NotImplementedError(
+          f'config include-directives `{pattern}` not supported')
     else:
-      raise NotImplementedError(
-        f'config include-directives `{pattern}` not supported')
+      log.debug('Skipping pattern %s', pattern)
 
   items = set()
 
@@ -933,7 +938,8 @@ def find_headers_by_config(config_path):
     match = files_to_find.intersection(files)
     if match:
       log.debug('%s %d %d', match, len(match), len(files_to_find))
-      items.update(os.path.join(directory, m) for m in match)
+      # Include all headers in the directory to find related types (e.g. _common.h, _type.h)
+      items.add(os.path.join(directory, '*.h'))
     for p in dirs_to_find:
       if directory.endswith(p):
         log.debug('--- %s [%s] %s', directory, p, files)

--- a/scripts/generate_callbacks.sh
+++ b/scripts/generate_callbacks.sh
@@ -39,19 +39,36 @@ fi
 
 CONFIGS=""
 declare -a VERIFY_RESULT
-for C in "$SCRIPT_DIR"/../configs/*/ffigen.yaml; do
-  echo $C
-  VERSION="${C%/ffigen.yaml}"
-  VERSION="${VERSION##*/}"
+for V_DIR in "$SCRIPT_DIR"/../configs/*; do
+  [ -d "$V_DIR" ] || continue
+  VERSION="${V_DIR##*/}"
   echo "==== Found Tizen $VERSION config"
   D="$ROOTSTRAPS/$VERSION"
   if [ -d "$D" ]; then
+    VERSION_ARGS=""
+    if [ -f "$V_DIR/ffigen.yaml" ]; then
+      VERSION_ARGS="-c $V_DIR/ffigen.yaml -b $SCRIPT_DIR/../lib/src/bindings/$VERSION/generated_bindings.dart"
+    else
+      for config_file in "$V_DIR"/ffigen_*.yaml; do
+        [ -e "$config_file" ] || continue
+        filename=$(basename -- "$config_file")
+        module_name="${filename#ffigen_}"
+        module_name="${module_name%.yaml}"
+        VERSION_ARGS="$VERSION_ARGS -c $config_file -b $SCRIPT_DIR/../lib/src/bindings/$VERSION/generated_bindings_${module_name}.dart"
+      done
+    fi
+
+    if [ -z "$VERSION_ARGS" ]; then
+      echo "WARNING: No ffigen configs found for $VERSION, skipping"
+      continue
+    fi
+
     if [ "$VERIFY" = "yes" ]; then
       if [ -n "${SKIP_VERIFY_VERSIONS[$VERSION]}" ]; then
         VERIFY_RESULT[${#VERIFY_RESULT[@]}]="all   	-	$VERSION	skip"
         continue
       fi
-      "$GENERATOR_ROOT/gen_callbacks.py" --asserts="$VERSION" -c $SCRIPT_DIR/../configs/$VERSION/ffigen.yaml -b $SCRIPT_DIR/../lib/src/bindings/$VERSION/generated_bindings.dart -o "$TARGET"
+      "$GENERATOR_ROOT/gen_callbacks.py" --asserts="$VERSION" $VERSION_ARGS -o "$TARGET"
       sed -i '/manifest/ s/api-version="[0-9.]*"/api-version="'$VERSION'"/' "$EXAMPLE_DIR/tizen/tizen-manifest.xml"
       for PROFILE in $PROFILES; do
         for ARCH in $ARCHS; do
@@ -72,7 +89,7 @@ for C in "$SCRIPT_DIR"/../configs/*/ffigen.yaml; do
         done
       done
     else
-      CONFIGS="-c $SCRIPT_DIR/../configs/$VERSION/ffigen.yaml -b $SCRIPT_DIR/../lib/src/bindings/$VERSION/generated_bindings.dart $CONFIGS"
+      CONFIGS="$VERSION_ARGS $CONFIGS"
     fi
   else
     echo "ERROR: Rootstrap $ROOTSTRAPS/$VERSION not found."

--- a/scripts/generate_callbacks.sh
+++ b/scripts/generate_callbacks.sh
@@ -37,7 +37,7 @@ if [ ! -d $ROOTSTRAPS ]; then
   exit 1
 fi
 
-CONFIGS=""
+CONFIGS=()
 declare -a VERIFY_RESULT
 for V_DIR in "$SCRIPT_DIR"/../configs/*; do
   [ -d "$V_DIR" ] || continue
@@ -45,20 +45,20 @@ for V_DIR in "$SCRIPT_DIR"/../configs/*; do
   echo "==== Found Tizen $VERSION config"
   D="$ROOTSTRAPS/$VERSION"
   if [ -d "$D" ]; then
-    VERSION_ARGS=""
+    VERSION_ARGS=()
     if [ -f "$V_DIR/ffigen.yaml" ]; then
-      VERSION_ARGS="-c $V_DIR/ffigen.yaml -b $SCRIPT_DIR/../lib/src/bindings/$VERSION/generated_bindings.dart"
+      VERSION_ARGS=("-c" "$V_DIR/ffigen.yaml" "-b" "$SCRIPT_DIR/../lib/src/bindings/$VERSION/generated_bindings.dart")
     else
       for config_file in "$V_DIR"/ffigen_*.yaml; do
         [ -e "$config_file" ] || continue
         filename=$(basename -- "$config_file")
         module_name="${filename#ffigen_}"
         module_name="${module_name%.yaml}"
-        VERSION_ARGS="$VERSION_ARGS -c $config_file -b $SCRIPT_DIR/../lib/src/bindings/$VERSION/generated_bindings_${module_name}.dart"
+        VERSION_ARGS+=("-c" "$config_file" "-b" "$SCRIPT_DIR/../lib/src/bindings/$VERSION/generated_bindings_${module_name}.dart")
       done
     fi
 
-    if [ -z "$VERSION_ARGS" ]; then
+    if [ ${#VERSION_ARGS[@]} -eq 0 ]; then
       echo "WARNING: No ffigen configs found for $VERSION, skipping"
       continue
     fi
@@ -68,7 +68,7 @@ for V_DIR in "$SCRIPT_DIR"/../configs/*; do
         VERIFY_RESULT[${#VERIFY_RESULT[@]}]="all   	-	$VERSION	skip"
         continue
       fi
-      "$GENERATOR_ROOT/gen_callbacks.py" --asserts="$VERSION" $VERSION_ARGS -o "$TARGET"
+      "$GENERATOR_ROOT/gen_callbacks.py" --asserts="$VERSION" "${VERSION_ARGS[@]}" -o "$TARGET"
       sed -i '/manifest/ s/api-version="[0-9.]*"/api-version="'$VERSION'"/' "$EXAMPLE_DIR/tizen/tizen-manifest.xml"
       for PROFILE in $PROFILES; do
         for ARCH in $ARCHS; do
@@ -89,7 +89,7 @@ for V_DIR in "$SCRIPT_DIR"/../configs/*; do
         done
       done
     else
-      CONFIGS="$VERSION_ARGS $CONFIGS"
+      CONFIGS+=("${VERSION_ARGS[@]}")
     fi
   else
     echo "ERROR: Rootstrap $ROOTSTRAPS/$VERSION not found."
@@ -100,8 +100,8 @@ if [ "$VERIFY" == "yes" ]; then
   echo "======== Results of the verification"
   for x in "${!VERIFY_RESULT[@]}"; do printf "  %s\n" "${VERIFY_RESULT[$x]}" ; done
   exit
-elif [ -z "$CONFIGS" ]; then
+elif [ ${#CONFIGS[@]} -eq 0 ]; then
   echo "ERROR: No rootstrap found. Run copy_rootstrap.sh first."
   exit 1
 fi
-"$GENERATOR_ROOT/gen_callbacks.py" $CONFIGS -o "$TARGET"
+"$GENERATOR_ROOT/gen_callbacks.py" "${CONFIGS[@]}" -o "$TARGET"


### PR DESCRIPTION
* Modify generate_callbacks.sh to process individual ffigen_*.yaml configs.
* Replace line-based parsing with regex to correctly handle multi-line typedef declarations.
* Add missing callback functions.