### PR TITLE
Add missing headers for individual modules

### DIFF
--- a/configs/10.0/entrypoints.h
+++ b/configs/10.0/entrypoints.h
@@ -42,6 +42,7 @@
 #include <job_scheduler.h>
 #include <message_port.h>
 #include <notification.h>
+#include <notification_error.h>
 #include <notification_ex.h>
 #include <notification_ex_app_control_action.h>
 #include <notification_ex_button.h>
@@ -61,6 +62,8 @@
 #include <notification_ex_text.h>
 #include <notification_ex_time.h>
 #include <notification_ex_visibility_action.h>
+#include <notification_status.h>
+#include <notification_type.h>
 #include <package_archive_info.h>
 #include <package_manager.h>
 #include <rpc-port-parcel.h>
@@ -110,35 +113,52 @@
 #include <media_controller_metadata.h>
 #include <media_controller_playlist.h>
 #include <media_controller_server.h>
+#include <media_controller_type.h>
 #include <media_editor.h>
 #include <media_format.h>
 #include <media_packet.h>
 #include <mediademuxer.h>
 #include <mediamuxer.h>
-#include <metadata_editor.h>  //deprecated
+#include <metadata_editor.h>       //deprecated
+#include <metadata_editor_type.h>  //deprecated
 #include <metadata_extractor.h>
+#include <metadata_extractor_type.h>
 #include <mv_3d.h>
 #include <mv_barcode.h>
 #include <mv_barcode_detect.h>
 #include <mv_barcode_generate.h>
+#include <mv_barcode_type.h>
 #include <mv_common.h>
 #include <mv_face.h>  //deprecated
+#include <mv_face_detection.h>
+#include <mv_face_detection_type.h>
 #include <mv_face_recognition.h>
+#include <mv_face_recognition_type.h>
+#include <mv_face_type.h>  //deprecated
 #include <mv_facial_landmark.h>
+#include <mv_facial_landmark_type.h>
 #include <mv_image.h>  //deprecated
 #include <mv_image_classification.h>
-#include <mv_inference.h>  //deprecated
+#include <mv_image_classification_type.h>
+#include <mv_image_type.h>      //deprecated
+#include <mv_inference.h>       //deprecated
+#include <mv_inference_type.h>  //deprecated
 #include <mv_object_detection.h>
+#include <mv_object_detection_type.h>
 #include <mv_pose_landmark.h>
+#include <mv_pose_landmark_type.h>
 #include <mv_roi_tracker.h>
 #include <mv_surveillance.h>  //deprecated
 #include <player.h>
 #include <radio.h>
 #include <recorder.h>
 #include <scmirroring_sink.h>
+#include <scmirroring_type.h>
 #include <sound_manager.h>
 #include <sound_pool.h>
+#include <sound_pool_type.h>
 #include <thumbnail_util.h>
+#include <thumbnail_util_type.h>
 #include <tone_player.h>
 #include <wav_player.h>
 #include <webrtc.h>
@@ -146,6 +166,7 @@
 // Network
 #include <asp.h>  //deprecated
 #include <bluetooth.h>
+#include <bluetooth_type.h>
 #include <dns-sd.h>
 #include <inm.h>
 #include <iotcon.h>
@@ -237,6 +258,7 @@
 #include <storage.h>
 #include <system/resource-monitor.h>
 #include <system_info.h>
+#include <system_info_type.h>
 #include <system_settings.h>
 #include <trace.h>
 #include <update_control.h>
@@ -244,6 +266,7 @@
 
 // UI
 #include <tbm_surface.h>
+#include <tbm_type.h>
 
 // UIX
 #include <autofill.h>

--- a/configs/10.0/ffigen_capi_base_common.yaml
+++ b/configs/10.0/ffigen_capi_base_common.yaml
@@ -17,6 +17,7 @@ headers:
   include-directives:
     - '**/tizen.h'
     - '**/tizen_error.h'
+    - '**tizen_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/10.0/ffigen_capi_media_controller.yaml
+++ b/configs/10.0/ffigen_capi_media_controller.yaml
@@ -19,6 +19,7 @@ headers:
     - '**/media_controller_metadata.h'
     - '**/media_controller_playlist.h'
     - '**/media_controller_server.h'
+    - '**/media_controller_type.h'
 
 library-imports:
   bundle: 'generated_bindings_bundle.dart'

--- a/configs/10.0/ffigen_capi_media_metadata_editor.yaml
+++ b/configs/10.0/ffigen_capi_media_metadata_editor.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/metadata_editor.h'
+    - '**/metadata_editor_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/10.0/ffigen_capi_media_metadata_extractor.yaml
+++ b/configs/10.0/ffigen_capi_media_metadata_extractor.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/metadata_extractor.h'
+    - '**/metadata_extractor_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/10.0/ffigen_capi_media_screen_mirroring.yaml
+++ b/configs/10.0/ffigen_capi_media_screen_mirroring.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/scmirroring_sink.h'
+    - '**/scmirroring_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/10.0/ffigen_capi_media_sound_pool.yaml
+++ b/configs/10.0/ffigen_capi_media_sound_pool.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/sound_pool.h'
+    - '**/sound_pool_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/10.0/ffigen_capi_media_thumbnail_util.yaml
+++ b/configs/10.0/ffigen_capi_media_thumbnail_util.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/thumbnail_util.h'
+    - '**/thumbnail_util_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/10.0/ffigen_capi_network_bluetooth.yaml
+++ b/configs/10.0/ffigen_capi_network_bluetooth.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/bluetooth.h'
+    - '**/bluetooth_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/10.0/ffigen_capi_system_info.yaml
+++ b/configs/10.0/ffigen_capi_system_info.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/system_info.h'
+    - '**/system_info_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/10.0/ffigen_mv_barcode_detector.yaml
+++ b/configs/10.0/ffigen_mv_barcode_detector.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_barcode_detect.h'
+    - '**/mv_barcode_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/10.0/ffigen_mv_barcode_generator.yaml
+++ b/configs/10.0/ffigen_mv_barcode_generator.yaml
@@ -91,3 +91,6 @@ enums:
   rename:
     '_+(.*)': '$1'
     'mv_barcode_type_e': '_mv_barcode_type_e'
+    'mv_barcode_qr_mode_e': '_mv_barcode_qr_mode_e'
+    'mv_barcode_qr_ecc_e': '_mv_barcode_qr_ecc_e'
+    'mv_barcode_image_format_e': '_mv_barcode_image_format_e'

--- a/configs/10.0/ffigen_mv_face.yaml
+++ b/configs/10.0/ffigen_mv_face.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_face.h'
+    - '**/mv_face_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/10.0/ffigen_mv_image.yaml
+++ b/configs/10.0/ffigen_mv_image.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_image.h'
+    - '**/mv_image_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/10.0/ffigen_mv_inference.yaml
+++ b/configs/10.0/ffigen_mv_inference.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_inference.h'
+    - '**/mv_inference_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/10.0/ffigen_mv_landmark_detection.yaml
+++ b/configs/10.0/ffigen_mv_landmark_detection.yaml
@@ -19,6 +19,8 @@ headers:
   include-directives:
     - '**/mv_facial_landmark.h'
     - '**/mv_facial_landmark_type.h'
+    - '**/mv_pose_landmark.h'
+    - '**/mv_pose_landmark_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/10.0/ffigen_tbm.yaml
+++ b/configs/10.0/ffigen_tbm.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/tbm_surface.h'
+    - '**/tbm_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.0/entrypoints.h
+++ b/configs/6.0/entrypoints.h
@@ -33,6 +33,7 @@
 #include <job_scheduler.h>
 #include <message_port.h>
 #include <notification.h>
+#include <notification_error.h>
 #include <notification_ex.h>
 #include <notification_ex_app_control_action.h>
 #include <notification_ex_button.h>
@@ -52,6 +53,8 @@
 #include <notification_ex_text.h>
 #include <notification_ex_time.h>
 #include <notification_ex_visibility_action.h>
+#include <notification_status.h>
+#include <notification_type.h>
 #include <package_archive_info.h>
 #include <package_manager.h>
 #include <rpc-port-parcel.h>
@@ -62,6 +65,7 @@
 // Base
 #include <tizen.h>
 #include <tizen_error.h>
+#include <tizen_type.h>
 
 // Content
 #include <download.h>
@@ -76,6 +80,7 @@
 
 // Location
 #include <geofence_manager.h>
+#include <geofence_type.h>
 #include <locations.h>
 
 // Messaging
@@ -91,35 +96,46 @@
 #include <media_controller_metadata.h>
 #include <media_controller_playlist.h>
 #include <media_controller_server.h>
+#include <media_controller_type.h>
 #include <media_format.h>
 #include <media_packet.h>
 #include <media_streamer.h>
 #include <mediademuxer.h>
 #include <mediamuxer.h>
 #include <metadata_editor.h>
+#include <metadata_editor_type.h>
 #include <metadata_extractor.h>
+#include <metadata_extractor_type.h>
 #include <mv_barcode.h>
 #include <mv_barcode_detect.h>
 #include <mv_barcode_generate.h>
+#include <mv_barcode_type.h>
 #include <mv_common.h>
 #include <mv_face.h>
+#include <mv_face_type.h>
 #include <mv_image.h>
+#include <mv_image_type.h>
 #include <mv_inference.h>
+#include <mv_inference_type.h>
 #include <mv_surveillance.h>
 #include <player.h>
 #include <radio.h>
 #include <recorder.h>
 #include <scmirroring_sink.h>
+#include <scmirroring_type.h>
 #include <sound_manager.h>
 #include <sound_pool.h>
+#include <sound_pool_type.h>
 #include <streamrecorder.h>
 #include <thumbnail_util.h>
+#include <thumbnail_util_type.h>
 #include <tone_player.h>
 #include <wav_player.h>
 
 // Network
 #include <asp.h>
 #include <bluetooth.h>
+#include <bluetooth_type.h>
 #include <dns-sd.h>
 #include <http.h>
 #include <inm.h>
@@ -212,6 +228,7 @@
 #include <storage-expand.h>
 #include <storage.h>
 #include <system_info.h>
+#include <system_info_type.h>
 #include <system_settings.h>
 #include <trace.h>
 #include <update_control.h>
@@ -221,6 +238,7 @@
 #include <cbhm.h>
 #include <eom.h>
 #include <tbm_surface.h>
+#include <tbm_type.h>
 
 // UIX
 #include <autofill.h>

--- a/configs/6.0/ffigen_capi_base_common.yaml
+++ b/configs/6.0/ffigen_capi_base_common.yaml
@@ -17,6 +17,7 @@ headers:
   include-directives:
     - '**/tizen.h'
     - '**/tizen_error.h'
+    - '**tizen_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.0/ffigen_capi_geofence_manager.yaml
+++ b/configs/6.0/ffigen_capi_geofence_manager.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/geofence_manager.h'
+    - '**/geofence_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.0/ffigen_capi_media_controller.yaml
+++ b/configs/6.0/ffigen_capi_media_controller.yaml
@@ -19,6 +19,7 @@ headers:
     - '**/media_controller_metadata.h'
     - '**/media_controller_playlist.h'
     - '**/media_controller_server.h'
+    - '**/media_controller_type.h'
 
 library-imports:
   bundle: 'generated_bindings_bundle.dart'

--- a/configs/6.0/ffigen_capi_media_metadata_editor.yaml
+++ b/configs/6.0/ffigen_capi_media_metadata_editor.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/metadata_editor.h'
+    - '**/metadata_editor_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.0/ffigen_capi_media_metadata_extractor.yaml
+++ b/configs/6.0/ffigen_capi_media_metadata_extractor.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/metadata_extractor.h'
+    - '**/metadata_extractor_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.0/ffigen_capi_media_screen_mirroring.yaml
+++ b/configs/6.0/ffigen_capi_media_screen_mirroring.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/scmirroring_sink.h'
+    - '**/scmirroring_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.0/ffigen_capi_media_sound_pool.yaml
+++ b/configs/6.0/ffigen_capi_media_sound_pool.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/sound_pool.h'
+    - '**/sound_pool_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.0/ffigen_capi_media_thumbnail_util.yaml
+++ b/configs/6.0/ffigen_capi_media_thumbnail_util.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/thumbnail_util.h'
+    - '**/thumbnail_util_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.0/ffigen_capi_network_bluetooth.yaml
+++ b/configs/6.0/ffigen_capi_network_bluetooth.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/bluetooth.h'
+    - '**/bluetooth_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.0/ffigen_capi_system_info.yaml
+++ b/configs/6.0/ffigen_capi_system_info.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/system_info.h'
+    - '**/system_info_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.0/ffigen_mv_barcode_detector.yaml
+++ b/configs/6.0/ffigen_mv_barcode_detector.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_barcode_detect.h'
+    - '**/mv_barcode_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/6.0/ffigen_mv_barcode_generator.yaml
+++ b/configs/6.0/ffigen_mv_barcode_generator.yaml
@@ -91,3 +91,6 @@ enums:
   rename:
     '_+(.*)': '$1'
     'mv_barcode_type_e': '_mv_barcode_type_e'
+    'mv_barcode_qr_mode_e': '_mv_barcode_qr_mode_e'
+    'mv_barcode_qr_ecc_e': '_mv_barcode_qr_ecc_e'
+    'mv_barcode_image_format_e': '_mv_barcode_image_format_e'

--- a/configs/6.0/ffigen_mv_face.yaml
+++ b/configs/6.0/ffigen_mv_face.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_face.h'
+    - '**/mv_face_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/6.0/ffigen_mv_image.yaml
+++ b/configs/6.0/ffigen_mv_image.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_image.h'
+    - '**/mv_image_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/6.0/ffigen_mv_inference.yaml
+++ b/configs/6.0/ffigen_mv_inference.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_inference.h'
+    - '**/mv_inference_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/6.0/ffigen_tbm.yaml
+++ b/configs/6.0/ffigen_tbm.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/tbm_surface.h'
+    - '**/tbm_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.5/entrypoints.h
+++ b/configs/6.5/entrypoints.h
@@ -44,6 +44,7 @@
 #include <job_scheduler.h>
 #include <message_port.h>
 #include <notification.h>
+#include <notification_error.h>
 #include <notification_ex.h>
 #include <notification_ex_app_control_action.h>
 #include <notification_ex_button.h>
@@ -63,6 +64,8 @@
 #include <notification_ex_text.h>
 #include <notification_ex_time.h>
 #include <notification_ex_visibility_action.h>
+#include <notification_status.h>
+#include <notification_type.h>
 #include <package_archive_info.h>
 #include <package_manager.h>
 #include <rpc-port-parcel.h>
@@ -73,6 +76,7 @@
 // Base
 #include <tizen.h>
 #include <tizen_error.h>
+#include <tizen_type.h>
 
 // Content
 #include <download.h>
@@ -87,6 +91,7 @@
 
 // Location
 #include <geofence_manager.h>
+#include <geofence_type.h>
 #include <locations.h>
 
 // Machine Learning
@@ -107,29 +112,39 @@
 #include <media_controller_metadata.h>
 #include <media_controller_playlist.h>
 #include <media_controller_server.h>
+#include <media_controller_type.h>
 #include <media_format.h>
 #include <media_packet.h>
 #include <media_streamer.h>
 #include <mediademuxer.h>
 #include <mediamuxer.h>
 #include <metadata_editor.h>
+#include <metadata_editor_type.h>
 #include <metadata_extractor.h>
+#include <metadata_extractor_type.h>
 #include <mv_barcode.h>
 #include <mv_barcode_detect.h>
 #include <mv_barcode_generate.h>
+#include <mv_barcode_type.h>
 #include <mv_common.h>
 #include <mv_face.h>
+#include <mv_face_type.h>
 #include <mv_image.h>
+#include <mv_image_type.h>
 #include <mv_inference.h>
+#include <mv_inference_type.h>
 #include <mv_surveillance.h>
 #include <player.h>
 #include <radio.h>
 #include <recorder.h>
 #include <scmirroring_sink.h>
+#include <scmirroring_type.h>
 #include <sound_manager.h>
 #include <sound_pool.h>
+#include <sound_pool_type.h>
 #include <streamrecorder.h>
 #include <thumbnail_util.h>
+#include <thumbnail_util_type.h>
 #include <tone_player.h>
 #include <wav_player.h>
 #include <webrtc.h>
@@ -137,6 +152,7 @@
 // Network
 #include <asp.h>
 #include <bluetooth.h>
+#include <bluetooth_type.h>
 #include <dns-sd.h>
 #include <http.h>
 #include <inm.h>
@@ -228,6 +244,7 @@
 #include <sensor.h>
 #include <storage.h>
 #include <system_info.h>
+#include <system_info_type.h>
 #include <system_settings.h>
 #include <trace.h>
 #include <update_control.h>
@@ -237,6 +254,7 @@
 #include <cbhm.h>
 #include <eom.h>
 #include <tbm_surface.h>
+#include <tbm_type.h>
 
 // UIX
 #include <autofill.h>

--- a/configs/6.5/ffigen_capi_base_common.yaml
+++ b/configs/6.5/ffigen_capi_base_common.yaml
@@ -17,6 +17,7 @@ headers:
   include-directives:
     - '**/tizen.h'
     - '**/tizen_error.h'
+    - '**tizen_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.5/ffigen_capi_geofence_manager.yaml
+++ b/configs/6.5/ffigen_capi_geofence_manager.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/geofence_manager.h'
+    - '**/geofence_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.5/ffigen_capi_media_controller.yaml
+++ b/configs/6.5/ffigen_capi_media_controller.yaml
@@ -19,6 +19,7 @@ headers:
     - '**/media_controller_metadata.h'
     - '**/media_controller_playlist.h'
     - '**/media_controller_server.h'
+    - '**/media_controller_type.h'
 
 library-imports:
   bundle: 'generated_bindings_bundle.dart'

--- a/configs/6.5/ffigen_capi_media_metadata_editor.yaml
+++ b/configs/6.5/ffigen_capi_media_metadata_editor.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/metadata_editor.h'
+    - '**/metadata_editor_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.5/ffigen_capi_media_metadata_extractor.yaml
+++ b/configs/6.5/ffigen_capi_media_metadata_extractor.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/metadata_extractor.h'
+    - '**/metadata_extractor_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.5/ffigen_capi_media_screen_mirroring.yaml
+++ b/configs/6.5/ffigen_capi_media_screen_mirroring.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/scmirroring_sink.h'
+    - '**/scmirroring_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.5/ffigen_capi_media_sound_pool.yaml
+++ b/configs/6.5/ffigen_capi_media_sound_pool.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/sound_pool.h'
+    - '**/sound_pool_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.5/ffigen_capi_media_thumbnail_util.yaml
+++ b/configs/6.5/ffigen_capi_media_thumbnail_util.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/thumbnail_util.h'
+    - '**/thumbnail_util_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.5/ffigen_capi_network_bluetooth.yaml
+++ b/configs/6.5/ffigen_capi_network_bluetooth.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/bluetooth.h'
+    - '**/bluetooth_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.5/ffigen_capi_system_info.yaml
+++ b/configs/6.5/ffigen_capi_system_info.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/system_info.h'
+    - '**/system_info_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/6.5/ffigen_mv_barcode_detector.yaml
+++ b/configs/6.5/ffigen_mv_barcode_detector.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_barcode_detect.h'
+    - '**/mv_barcode_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/6.5/ffigen_mv_barcode_generator.yaml
+++ b/configs/6.5/ffigen_mv_barcode_generator.yaml
@@ -93,3 +93,6 @@ enums:
   rename:
     '_+(.*)': '$1'
     'mv_barcode_type_e': '_mv_barcode_type_e'
+    'mv_barcode_qr_mode_e': '_mv_barcode_qr_mode_e'
+    'mv_barcode_qr_ecc_e': '_mv_barcode_qr_ecc_e'
+    'mv_barcode_image_format_e': '_mv_barcode_image_format_e'

--- a/configs/6.5/ffigen_mv_face.yaml
+++ b/configs/6.5/ffigen_mv_face.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_face.h'
+    - '**/mv_face_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/6.5/ffigen_mv_image.yaml
+++ b/configs/6.5/ffigen_mv_image.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_image.h'
+    - '**/mv_image_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/6.5/ffigen_mv_inference.yaml
+++ b/configs/6.5/ffigen_mv_inference.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_inference.h'
+    - '**/mv_inference_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/6.5/ffigen_tbm.yaml
+++ b/configs/6.5/ffigen_tbm.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/tbm_surface.h'
+    - '**/tbm_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/7.0/entrypoints.h
+++ b/configs/7.0/entrypoints.h
@@ -45,6 +45,7 @@
 #include <job_scheduler.h>
 #include <message_port.h>
 #include <notification.h>
+#include <notification_error.h>
 #include <notification_ex.h>
 #include <notification_ex_app_control_action.h>
 #include <notification_ex_button.h>
@@ -64,6 +65,8 @@
 #include <notification_ex_text.h>
 #include <notification_ex_time.h>
 #include <notification_ex_visibility_action.h>
+#include <notification_status.h>
+#include <notification_type.h>
 #include <package_archive_info.h>
 #include <package_manager.h>
 #include <rpc-port-parcel.h>
@@ -73,6 +76,7 @@
 // Base
 #include <tizen.h>
 #include <tizen_error.h>
+#include <tizen_type.h>
 
 // Content
 #include <download.h>
@@ -85,6 +89,7 @@
 
 // Location
 #include <geofence_manager.h>
+#include <geofence_type.h>
 #include <locations.h>
 
 // Machine Learning
@@ -107,6 +112,7 @@
 #include <media_controller_metadata.h>
 #include <media_controller_playlist.h>
 #include <media_controller_server.h>
+#include <media_controller_type.h>
 #include <media_editor.h>
 #include <media_format.h>
 #include <media_packet.h>
@@ -114,26 +120,36 @@
 #include <mediademuxer.h>
 #include <mediamuxer.h>
 #include <metadata_editor.h>
+#include <metadata_editor_type.h>
 #include <metadata_extractor.h>
+#include <metadata_extractor_type.h>
 #include <mv_3d.h>
 #include <mv_barcode.h>
 #include <mv_barcode_detect.h>
 #include <mv_barcode_generate.h>
+#include <mv_barcode_type.h>
 #include <mv_common.h>
 #include <mv_face.h>
 #include <mv_face_recognition.h>
+#include <mv_face_recognition_type.h>
+#include <mv_face_type.h>
 #include <mv_image.h>
+#include <mv_image_type.h>
 #include <mv_inference.h>
+#include <mv_inference_type.h>
 #include <mv_roi_tracker.h>
 #include <mv_surveillance.h>
 #include <player.h>
 #include <radio.h>
 #include <recorder.h>
 #include <scmirroring_sink.h>
+#include <scmirroring_type.h>
 #include <sound_manager.h>
 #include <sound_pool.h>
+#include <sound_pool_type.h>
 #include <streamrecorder.h>
 #include <thumbnail_util.h>
+#include <thumbnail_util_type.h>
 #include <tone_player.h>
 #include <wav_player.h>
 #include <webrtc.h>
@@ -141,6 +157,7 @@
 // Network
 #include <asp.h>
 #include <bluetooth.h>
+#include <bluetooth_type.h>
 #include <dns-sd.h>
 #include <http.h>
 #include <inm.h>
@@ -234,6 +251,7 @@
 #include <sensor.h>
 #include <storage.h>
 #include <system_info.h>
+#include <system_info_type.h>
 #include <system_settings.h>
 #include <trace.h>
 #include <update_control.h>
@@ -243,6 +261,7 @@
 #include <cbhm.h>
 #include <eom.h>
 #include <tbm_surface.h>
+#include <tbm_type.h>
 
 // UIX
 #include <autofill.h>

--- a/configs/7.0/ffigen_capi_base_common.yaml
+++ b/configs/7.0/ffigen_capi_base_common.yaml
@@ -17,6 +17,7 @@ headers:
   include-directives:
     - '**/tizen.h'
     - '**/tizen_error.h'
+    - '**tizen_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/7.0/ffigen_capi_geofence_manager.yaml
+++ b/configs/7.0/ffigen_capi_geofence_manager.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/geofence_manager.h'
+    - '**/geofence_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/7.0/ffigen_capi_media_controller.yaml
+++ b/configs/7.0/ffigen_capi_media_controller.yaml
@@ -19,6 +19,7 @@ headers:
     - '**/media_controller_metadata.h'
     - '**/media_controller_playlist.h'
     - '**/media_controller_server.h'
+    - '**/media_controller_type.h'
 
 library-imports:
   bundle: 'generated_bindings_bundle.dart'

--- a/configs/7.0/ffigen_capi_media_metadata_editor.yaml
+++ b/configs/7.0/ffigen_capi_media_metadata_editor.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/metadata_editor.h'
+    - '**/metadata_editor_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/7.0/ffigen_capi_media_metadata_extractor.yaml
+++ b/configs/7.0/ffigen_capi_media_metadata_extractor.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/metadata_extractor.h'
+    - '**/metadata_extractor_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/7.0/ffigen_capi_media_screen_mirroring.yaml
+++ b/configs/7.0/ffigen_capi_media_screen_mirroring.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/scmirroring_sink.h'
+    - '**/scmirroring_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/7.0/ffigen_capi_media_sound_pool.yaml
+++ b/configs/7.0/ffigen_capi_media_sound_pool.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/sound_pool.h'
+    - '**/sound_pool_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/7.0/ffigen_capi_media_thumbnail_util.yaml
+++ b/configs/7.0/ffigen_capi_media_thumbnail_util.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/thumbnail_util.h'
+    - '**/thumbnail_util_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/7.0/ffigen_capi_network_bluetooth.yaml
+++ b/configs/7.0/ffigen_capi_network_bluetooth.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/bluetooth.h'
+    - '**/bluetooth_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/7.0/ffigen_capi_system_info.yaml
+++ b/configs/7.0/ffigen_capi_system_info.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/system_info.h'
+    - '**/system_info_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/7.0/ffigen_mv_barcode_detector.yaml
+++ b/configs/7.0/ffigen_mv_barcode_detector.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_barcode_detect.h'
+    - '**/mv_barcode_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/7.0/ffigen_mv_barcode_generator.yaml
+++ b/configs/7.0/ffigen_mv_barcode_generator.yaml
@@ -92,3 +92,6 @@ enums:
   rename:
     '_+(.*)': '$1'
     'mv_barcode_type_e': '_mv_barcode_type_e'
+    'mv_barcode_qr_mode_e': '_mv_barcode_qr_mode_e'
+    'mv_barcode_qr_ecc_e': '_mv_barcode_qr_ecc_e'
+    'mv_barcode_image_format_e': '_mv_barcode_image_format_e'

--- a/configs/7.0/ffigen_mv_face.yaml
+++ b/configs/7.0/ffigen_mv_face.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_face.h'
+    - '**/mv_face_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/7.0/ffigen_mv_image.yaml
+++ b/configs/7.0/ffigen_mv_image.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_image.h'
+    - '**/mv_image_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/7.0/ffigen_mv_inference.yaml
+++ b/configs/7.0/ffigen_mv_inference.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_inference.h'
+    - '**/mv_inference_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/7.0/ffigen_tbm.yaml
+++ b/configs/7.0/ffigen_tbm.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/tbm_surface.h'
+    - '**/tbm_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/8.0/entrypoints.h
+++ b/configs/8.0/entrypoints.h
@@ -45,6 +45,7 @@
 #include <job_scheduler.h>
 #include <message_port.h>
 #include <notification.h>
+#include <notification_error.h>
 #include <notification_ex.h>
 #include <notification_ex_app_control_action.h>
 #include <notification_ex_button.h>
@@ -64,6 +65,8 @@
 #include <notification_ex_text.h>
 #include <notification_ex_time.h>
 #include <notification_ex_visibility_action.h>
+#include <notification_status.h>
+#include <notification_type.h>
 #include <package_archive_info.h>
 #include <package_manager.h>
 #include <rpc-port-parcel.h>
@@ -109,6 +112,7 @@
 #include <media_controller_metadata.h>
 #include <media_controller_playlist.h>
 #include <media_controller_server.h>
+#include <media_controller_type.h>
 #include <media_editor.h>
 #include <media_format.h>
 #include <media_packet.h>
@@ -116,26 +120,36 @@
 #include <mediademuxer.h>
 #include <mediamuxer.h>
 #include <metadata_editor.h>
+#include <metadata_editor_type.h>
 #include <metadata_extractor.h>
+#include <metadata_extractor_type.h>
 #include <mv_3d.h>
 #include <mv_barcode.h>
 #include <mv_barcode_detect.h>
 #include <mv_barcode_generate.h>
+#include <mv_barcode_type.h>
 #include <mv_common.h>
 #include <mv_face.h>
 #include <mv_face_recognition.h>
+#include <mv_face_recognition_type.h>
+#include <mv_face_type.h>
 #include <mv_image.h>
+#include <mv_image_type.h>
 #include <mv_inference.h>
+#include <mv_inference_type.h>
 #include <mv_roi_tracker.h>
 #include <mv_surveillance.h>
 #include <player.h>
 #include <radio.h>
 #include <recorder.h>
 #include <scmirroring_sink.h>
+#include <scmirroring_type.h>
 #include <sound_manager.h>
 #include <sound_pool.h>
+#include <sound_pool_type.h>
 #include <streamrecorder.h>  //deprecated
 #include <thumbnail_util.h>
+#include <thumbnail_util_type.h>
 #include <tone_player.h>
 #include <wav_player.h>
 #include <webrtc.h>
@@ -143,6 +157,7 @@
 // Network
 #include <asp.h>
 #include <bluetooth.h>
+#include <bluetooth_type.h>
 #include <dns-sd.h>
 #include <http.h>
 #include <inm.h>
@@ -236,6 +251,7 @@
 #include <sensor.h>
 #include <storage.h>
 #include <system_info.h>
+#include <system_info_type.h>
 #include <system_settings.h>
 #include <trace.h>
 #include <update_control.h>
@@ -244,6 +260,7 @@
 // UI
 #include <eom.h>  // deprecated
 #include <tbm_surface.h>
+#include <tbm_type.h>
 
 // UIX
 #include <autofill.h>

--- a/configs/8.0/ffigen_capi_base_common.yaml
+++ b/configs/8.0/ffigen_capi_base_common.yaml
@@ -17,6 +17,7 @@ headers:
   include-directives:
     - '**/tizen.h'
     - '**/tizen_error.h'
+    - '**tizen_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/8.0/ffigen_capi_geofence_manager.yaml
+++ b/configs/8.0/ffigen_capi_geofence_manager.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/geofence_manager.h'
+    - '**/geofence_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/8.0/ffigen_capi_media_controller.yaml
+++ b/configs/8.0/ffigen_capi_media_controller.yaml
@@ -19,6 +19,7 @@ headers:
     - '**/media_controller_metadata.h'
     - '**/media_controller_playlist.h'
     - '**/media_controller_server.h'
+    - '**/media_controller_type.h'
 
 library-imports:
   bundle: 'generated_bindings_bundle.dart'

--- a/configs/8.0/ffigen_capi_media_metadata_editor.yaml
+++ b/configs/8.0/ffigen_capi_media_metadata_editor.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/metadata_editor.h'
+    - '**/metadata_editor_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/8.0/ffigen_capi_media_metadata_extractor.yaml
+++ b/configs/8.0/ffigen_capi_media_metadata_extractor.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/metadata_extractor.h'
+    - '**/metadata_extractor_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/8.0/ffigen_capi_media_screen_mirroring.yaml
+++ b/configs/8.0/ffigen_capi_media_screen_mirroring.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/scmirroring_sink.h'
+    - '**/scmirroring_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/8.0/ffigen_capi_media_sound_pool.yaml
+++ b/configs/8.0/ffigen_capi_media_sound_pool.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/sound_pool.h'
+    - '**/sound_pool_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/8.0/ffigen_capi_media_thumbnail_util.yaml
+++ b/configs/8.0/ffigen_capi_media_thumbnail_util.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/thumbnail_util.h'
+    - '**/thumbnail_util_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/8.0/ffigen_capi_network_bluetooth.yaml
+++ b/configs/8.0/ffigen_capi_network_bluetooth.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/bluetooth.h'
+    - '**/bluetooth_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/8.0/ffigen_capi_system_info.yaml
+++ b/configs/8.0/ffigen_capi_system_info.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/system_info.h'
+    - '**/system_info_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/8.0/ffigen_mv_barcode_detector.yaml
+++ b/configs/8.0/ffigen_mv_barcode_detector.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_barcode_detect.h'
+    - '**/mv_barcode_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/8.0/ffigen_mv_barcode_generator.yaml
+++ b/configs/8.0/ffigen_mv_barcode_generator.yaml
@@ -92,3 +92,6 @@ enums:
   rename:
     '_+(.*)': '$1'
     'mv_barcode_type_e': '_mv_barcode_type_e'
+    'mv_barcode_qr_mode_e': '_mv_barcode_qr_mode_e'
+    'mv_barcode_qr_ecc_e': '_mv_barcode_qr_ecc_e'
+    'mv_barcode_image_format_e': '_mv_barcode_image_format_e'

--- a/configs/8.0/ffigen_mv_face.yaml
+++ b/configs/8.0/ffigen_mv_face.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_face.h'
+    - '**/mv_face_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/8.0/ffigen_mv_image.yaml
+++ b/configs/8.0/ffigen_mv_image.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_image.h'
+    - '**/mv_image_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/8.0/ffigen_mv_inference.yaml
+++ b/configs/8.0/ffigen_mv_inference.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_inference.h'
+    - '**/mv_inference_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/8.0/ffigen_tbm.yaml
+++ b/configs/8.0/ffigen_tbm.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/tbm_surface.h'
+    - '**/tbm_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/9.0/entrypoints.h
+++ b/configs/9.0/entrypoints.h
@@ -45,6 +45,7 @@
 #include <job_scheduler.h>
 #include <message_port.h>
 #include <notification.h>
+#include <notification_error.h>
 #include <notification_ex.h>
 #include <notification_ex_app_control_action.h>
 #include <notification_ex_button.h>
@@ -64,6 +65,8 @@
 #include <notification_ex_text.h>
 #include <notification_ex_time.h>
 #include <notification_ex_visibility_action.h>
+#include <notification_status.h>
+#include <notification_type.h>
 #include <package_archive_info.h>
 #include <package_manager.h>
 #include <rpc-port-parcel.h>
@@ -112,35 +115,52 @@
 #include <media_controller_metadata.h>
 #include <media_controller_playlist.h>
 #include <media_controller_server.h>
+#include <media_controller_type.h>
 #include <media_editor.h>
 #include <media_format.h>
 #include <media_packet.h>
 #include <mediademuxer.h>
 #include <mediamuxer.h>
-#include <metadata_editor.h>  //deprecated
+#include <metadata_editor.h>       //deprecated
+#include <metadata_editor_type.h>  //deprecated
 #include <metadata_extractor.h>
+#include <metadata_extractor_type.h>
 #include <mv_3d.h>
 #include <mv_barcode.h>
 #include <mv_barcode_detect.h>
 #include <mv_barcode_generate.h>
+#include <mv_barcode_type.h>
 #include <mv_common.h>
 #include <mv_face.h>  //deprecated
+#include <mv_face_detection.h>
+#include <mv_face_detection_type.h>
 #include <mv_face_recognition.h>
+#include <mv_face_recognition_type.h>
+#include <mv_face_type.h>  //deprecated
 #include <mv_facial_landmark.h>
+#include <mv_facial_landmark_type.h>
 #include <mv_image.h>  //deprecated
 #include <mv_image_classification.h>
-#include <mv_inference.h>  //deprecated
+#include <mv_image_classification_type.h>
+#include <mv_image_type.h>      //deprecated
+#include <mv_inference.h>       //deprecated
+#include <mv_inference_type.h>  //deprecated
 #include <mv_object_detection.h>
+#include <mv_object_detection_type.h>
 #include <mv_pose_landmark.h>
+#include <mv_pose_landmark_type.h>
 #include <mv_roi_tracker.h>
 #include <mv_surveillance.h>  //deprecated
 #include <player.h>
 #include <radio.h>
 #include <recorder.h>
 #include <scmirroring_sink.h>
+#include <scmirroring_type.h>
 #include <sound_manager.h>
 #include <sound_pool.h>
+#include <sound_pool_type.h>
 #include <thumbnail_util.h>
+#include <thumbnail_util_type.h>
 #include <tone_player.h>
 #include <wav_player.h>
 #include <webrtc.h>
@@ -148,6 +168,7 @@
 // Network
 #include <asp.h>  //deprecated
 #include <bluetooth.h>
+#include <bluetooth_type.h>
 #include <dns-sd.h>
 #include <inm.h>
 #include <iotcon.h>
@@ -245,6 +266,7 @@
 #include <storage.h>
 #include <system/resource-monitor.h>
 #include <system_info.h>
+#include <system_info_type.h>
 #include <system_settings.h>
 #include <trace.h>
 #include <update_control.h>
@@ -253,6 +275,7 @@
 // UI
 #include <eom.h>  // deprecated
 #include <tbm_surface.h>
+#include <tbm_type.h>
 
 // UIX
 #include <autofill.h>

--- a/configs/9.0/ffigen_capi_base_common.yaml
+++ b/configs/9.0/ffigen_capi_base_common.yaml
@@ -17,6 +17,7 @@ headers:
   include-directives:
     - '**/tizen.h'
     - '**/tizen_error.h'
+    - '**tizen_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/9.0/ffigen_capi_geofence_manager.yaml
+++ b/configs/9.0/ffigen_capi_geofence_manager.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/geofence_manager.h'
+    - '**/geofence_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/9.0/ffigen_capi_media_controller.yaml
+++ b/configs/9.0/ffigen_capi_media_controller.yaml
@@ -19,6 +19,7 @@ headers:
     - '**/media_controller_metadata.h'
     - '**/media_controller_playlist.h'
     - '**/media_controller_server.h'
+    - '**/media_controller_type.h'
 
 library-imports:
   bundle: 'generated_bindings_bundle.dart'

--- a/configs/9.0/ffigen_capi_media_metadata_editor.yaml
+++ b/configs/9.0/ffigen_capi_media_metadata_editor.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/metadata_editor.h'
+    - '**/metadata_editor_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/9.0/ffigen_capi_media_metadata_extractor.yaml
+++ b/configs/9.0/ffigen_capi_media_metadata_extractor.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/metadata_extractor.h'
+    - '**/metadata_extractor_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/9.0/ffigen_capi_media_screen_mirroring.yaml
+++ b/configs/9.0/ffigen_capi_media_screen_mirroring.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/scmirroring_sink.h'
+    - '**/scmirroring_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/9.0/ffigen_capi_media_sound_pool.yaml
+++ b/configs/9.0/ffigen_capi_media_sound_pool.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/sound_pool.h'
+    - '**/sound_pool_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/9.0/ffigen_capi_media_thumbnail_util.yaml
+++ b/configs/9.0/ffigen_capi_media_thumbnail_util.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/thumbnail_util.h'
+    - '**/thumbnail_util_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/9.0/ffigen_capi_network_bluetooth.yaml
+++ b/configs/9.0/ffigen_capi_network_bluetooth.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/bluetooth.h'
+    - '**/bluetooth_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/9.0/ffigen_capi_system_info.yaml
+++ b/configs/9.0/ffigen_capi_system_info.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/system_info.h'
+    - '**/system_info_type.h'
 
 compiler-opts:
   - '-m32'

--- a/configs/9.0/ffigen_mv_barcode_detector.yaml
+++ b/configs/9.0/ffigen_mv_barcode_detector.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_barcode_detect.h'
+    - '**/mv_barcode_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/9.0/ffigen_mv_barcode_generator.yaml
+++ b/configs/9.0/ffigen_mv_barcode_generator.yaml
@@ -95,3 +95,6 @@ enums:
   rename:
     '_+(.*)': '$1'
     'mv_barcode_type_e': '_mv_barcode_type_e'
+    'mv_barcode_qr_mode_e': '_mv_barcode_qr_mode_e'
+    'mv_barcode_qr_ecc_e': '_mv_barcode_qr_ecc_e'
+    'mv_barcode_image_format_e': '_mv_barcode_image_format_e'

--- a/configs/9.0/ffigen_mv_face.yaml
+++ b/configs/9.0/ffigen_mv_face.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_face.h'
+    - '**/mv_face_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/9.0/ffigen_mv_image.yaml
+++ b/configs/9.0/ffigen_mv_image.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_image.h'
+    - '**/mv_image_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/9.0/ffigen_mv_inference.yaml
+++ b/configs/9.0/ffigen_mv_inference.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/mv_inference.h'
+    - '**/mv_inference_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/9.0/ffigen_mv_landmark_detection.yaml
+++ b/configs/9.0/ffigen_mv_landmark_detection.yaml
@@ -19,6 +19,8 @@ headers:
   include-directives:
     - '**/mv_facial_landmark.h'
     - '**/mv_facial_landmark_type.h'
+    - '**/mv_pose_landmark.h'
+    - '**/mv_pose_landmark_type.h'
 
 library-imports:
   mv_common: 'generated_bindings_mv_common.dart'

--- a/configs/9.0/ffigen_tbm.yaml
+++ b/configs/9.0/ffigen_tbm.yaml
@@ -16,6 +16,7 @@ headers:
     - 'entrypoints.h'
   include-directives:
     - '**/tbm_surface.h'
+    - '**/tbm_type.h'
 
 compiler-opts:
   - '-m32'

--- a/lib/src/bindings/10.0/generated_bindings_capi_base_common.dart
+++ b/lib/src/bindings/10.0/generated_bindings_capi_base_common.dart
@@ -386,6 +386,8 @@ abstract class tizen_error_e {
   static const int TIZEN_ERROR_END_OF_COLLECTION = -1073741819;
 }
 
+const int NULL = 0;
+
 const int TIZEN_ERROR_MAX_PLATFORM_ERROR = 0;
 
 const int TIZEN_ERROR_MIN_PLATFORM_ERROR = -1073741824;

--- a/lib/src/bindings/10.0/generated_bindings_capi_media_controller.dart
+++ b/lib/src/bindings/10.0/generated_bindings_capi_media_controller.dart
@@ -6452,6 +6452,535 @@ class Tizen100CapiMediaController {
       .asFunction<int Function(mc_server_h, ffi.Pointer<ffi.Char>)>();
 }
 
+/// @brief Enumeration for the media controller error.
+/// @since_tizen 2.4
+abstract class mc_error_e {
+  /// < Successful
+  static const int MEDIA_CONTROLLER_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int MEDIA_CONTROLLER_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int MEDIA_CONTROLLER_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Invalid Operation
+  static const int MEDIA_CONTROLLER_ERROR_INVALID_OPERATION = -38;
+
+  /// < No space left on device
+  static const int MEDIA_CONTROLLER_ERROR_FILE_NO_SPACE_ON_DEVICE = -28;
+
+  /// < Permission denied
+  static const int MEDIA_CONTROLLER_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Limited by server application (since 5.5)
+  static const int MEDIA_CONTROLLER_ERROR_ABILITY_LIMITED_BY_SERVER_APP =
+      -50462719;
+}
+
+/// @brief Enumeration for the media controller server state.
+/// @since_tizen 2.4
+///
+/// @see mc_client_get_latest_server_info()
+/// @see mc_server_state_updated_cb()
+abstract class mc_server_state_e {
+  /// < None state
+  static const int MC_SERVER_STATE_NONE = 0;
+
+  /// < Activate state
+  static const int MC_SERVER_STATE_ACTIVATE = 1;
+
+  /// < Deactivate state
+  static const int MC_SERVER_STATE_DEACTIVATE = 2;
+}
+
+/// @brief Enumeration for the media meta info.
+/// @since_tizen 2.4
+///
+/// @see mc_server_set_metadata()
+/// @see mc_server_add_item_to_playlist()
+/// @see mc_metadata_get()
+abstract class mc_meta_e {
+  /// < Title
+  static const int MC_META_MEDIA_TITLE = 0;
+
+  /// < Artist
+  static const int MC_META_MEDIA_ARTIST = 1;
+
+  /// < Album
+  static const int MC_META_MEDIA_ALBUM = 2;
+
+  /// < Author
+  static const int MC_META_MEDIA_AUTHOR = 3;
+
+  /// < Genre
+  static const int MC_META_MEDIA_GENRE = 4;
+
+  /// < Duration
+  static const int MC_META_MEDIA_DURATION = 5;
+
+  /// < Date
+  static const int MC_META_MEDIA_DATE = 6;
+
+  /// < Copyright
+  static const int MC_META_MEDIA_COPYRIGHT = 7;
+
+  /// < Description
+  static const int MC_META_MEDIA_DESCRIPTION = 8;
+
+  /// < Track Number
+  static const int MC_META_MEDIA_TRACK_NUM = 9;
+
+  /// < Picture. Album Art
+  static const int MC_META_MEDIA_PICTURE = 10;
+
+  /// < Season (Since 5.5)
+  static const int MC_META_MEDIA_SEASON = 11;
+
+  /// < Episode (Since 5.5)
+  static const int MC_META_MEDIA_EPISODE = 12;
+
+  /// < Content resolution (Since 5.5)
+  static const int MC_META_MEDIA_RESOLUTION = 13;
+}
+
+/// @brief Enumeration for the media playback state of the media controller server.
+/// @since_tizen 2.4
+///
+/// @see mc_server_set_playback_state()
+/// @see mc_client_get_playback_state()
+abstract class mc_playback_states_e {
+  /// < None
+  static const int MC_PLAYBACK_STATE_NONE = 0;
+
+  /// < Playing
+  static const int MC_PLAYBACK_STATE_PLAYING = 1;
+
+  /// < Paused
+  static const int MC_PLAYBACK_STATE_PAUSED = 2;
+
+  /// < Stopped
+  static const int MC_PLAYBACK_STATE_STOPPED = 3;
+
+  /// < Moving to the next item (Since 4.0)
+  static const int MC_PLAYBACK_STATE_MOVING_TO_NEXT = 8;
+
+  /// < Moving to the previous item (Since 4.0)
+  static const int MC_PLAYBACK_STATE_MOVING_TO_PREVIOUS = 9;
+
+  /// < Fast forwarding (Since 4.0)
+  static const int MC_PLAYBACK_STATE_FAST_FORWARDING = 10;
+
+  /// < Rewinding (Since 4.0)
+  static const int MC_PLAYBACK_STATE_REWINDING = 11;
+
+  /// < Connecting (Since 6.0)
+  static const int MC_PLAYBACK_STATE_CONNECTING = 12;
+
+  /// < Buffering (Since 6.0)
+  static const int MC_PLAYBACK_STATE_BUFFERING = 13;
+
+  /// < Error (Since 6.0)
+  static const int MC_PLAYBACK_STATE_ERROR = 14;
+}
+
+/// @brief Enumeration for the media playback action.
+/// @details Media controller clients can control media controller server's playback by calling mc_client_send_playback_action_cmd() or mc_client_send_playlist_cmd(). \n
+/// Media controller servers have to set proper playback ability by using mc_server_set_playback_ability().
+/// @since_tizen 4.0
+///
+/// @see mc_server_set_playback_ability()
+/// @see mc_client_send_playback_action_cmd()
+/// @see mc_client_send_playlist_cmd()
+/// @see mc_playback_action_is_supported()
+/// @see mc_server_playback_action_cmd_received_cb()
+/// @see mc_server_playlist_cmd_received_cb()
+abstract class mc_playback_action_e {
+  /// < Play
+  static const int MC_PLAYBACK_ACTION_PLAY = 0;
+
+  /// < Pause
+  static const int MC_PLAYBACK_ACTION_PAUSE = 1;
+
+  /// < Stop
+  static const int MC_PLAYBACK_ACTION_STOP = 2;
+
+  /// < Next item
+  static const int MC_PLAYBACK_ACTION_NEXT = 3;
+
+  /// < Previous item
+  static const int MC_PLAYBACK_ACTION_PREV = 4;
+
+  /// < Fast forward
+  static const int MC_PLAYBACK_ACTION_FAST_FORWARD = 5;
+
+  /// < Rewind
+  static const int MC_PLAYBACK_ACTION_REWIND = 6;
+
+  /// < Play/Pause toggle
+  static const int MC_PLAYBACK_ACTION_TOGGLE_PLAY_PAUSE = 7;
+}
+
+/// @brief Enumeration for the shuffle mode of the media controller server.
+/// @since_tizen 2.4
+///
+/// @see mc_server_update_shuffle_mode()
+/// @see mc_server_shuffle_mode_cmd_received_cb()
+/// @see mc_client_get_server_shuffle_mode()
+/// @see mc_client_send_shuffle_mode_cmd()
+/// @see mc_shuffle_mode_updated_cb()
+abstract class mc_shuffle_mode_e {
+  /// < Shuffle mode on
+  static const int MC_SHUFFLE_MODE_ON = 0;
+
+  /// < Shuffle mode off
+  static const int MC_SHUFFLE_MODE_OFF = 1;
+}
+
+/// @brief Enumeration for the repeat mode of the media controller server.
+/// @since_tizen 2.4
+///
+/// @see mc_server_update_repeat_mode()
+/// @see mc_server_repeat_mode_cmd_received_cb()
+/// @see mc_client_get_server_repeat_mode()
+/// @see mc_client_send_repeat_mode_cmd()
+/// @see mc_repeat_mode_updated_cb()
+abstract class mc_repeat_mode_e {
+  /// < Repeat mode on for all media
+  static const int MC_REPEAT_MODE_ON = 0;
+
+  /// < Repeat mode off
+  static const int MC_REPEAT_MODE_OFF = 1;
+
+  /// < Repeat mode on for one media (Since 4.0)
+  static const int MC_REPEAT_MODE_ONE_MEDIA = 2;
+}
+
+/// @brief Enumeration for the subscription type of the media controller client.
+/// @since_tizen 2.4
+///
+/// @see mc_client_subscribe()
+/// @see mc_client_unsubscribe()
+/// @see mc_client_foreach_server_subscribed()
+abstract class mc_subscription_type_e {
+  /// < Server state
+  static const int MC_SUBSCRIPTION_TYPE_SERVER_STATE = 0;
+
+  /// < Playback
+  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK = 1;
+
+  /// < Metadata
+  static const int MC_SUBSCRIPTION_TYPE_METADATA = 2;
+
+  /// < Shuffle mode
+  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_MODE = 3;
+
+  /// < Repeat mode
+  static const int MC_SUBSCRIPTION_TYPE_REPEAT_MODE = 4;
+
+  /// < Playlist (Since 4.0)
+  static const int MC_SUBSCRIPTION_TYPE_PLAYLIST = 5;
+
+  /// < Playback ability (Since 5.0)
+  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK_ABILITY = 6;
+
+  /// < Ability support (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT = 9;
+
+  /// < Display mode ability (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_MODE_ABILITY = 10;
+
+  /// < Display rotation ability (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_ROTATION_ABILITY = 11;
+}
+
+/// @brief Enumeration for the playlist update mode.
+/// @details Media controller clients can know the playlist change status of the media controller server by calling mc_client_set_playlist_updated_cb(). \n
+/// @since_tizen 4.0
+///
+/// @see mc_client_set_playlist_updated_cb()
+/// @see mc_playlist_updated_cb()
+/// @see mc_server_update_playlist_done()
+/// @see mc_server_delete_playlist()
+abstract class mc_playlist_update_mode_e {
+  /// < Create or Update playlist
+  static const int MC_PLAYLIST_UPDATED = 0;
+
+  /// < Remove playlist
+  static const int MC_PLAYLIST_REMOVED = 1;
+}
+
+/// @brief Enumeration for the content type of the media content by the media controller server.
+/// @details Media controller clients can use this to know the playback status of the media controller server. \n
+/// And media controller clients can also use to search for the content provided by the media controller server.
+/// @since_tizen 5.0
+///
+/// @see mc_server_set_playback_content_type()
+/// @see mc_client_get_playback_content_type()
+/// @see mc_search_set_condition()
+abstract class mc_content_type_e {
+  /// < Image content type
+  static const int MC_CONTENT_TYPE_IMAGE = 0;
+
+  /// < Video content type
+  static const int MC_CONTENT_TYPE_VIDEO = 1;
+
+  /// < Music content type
+  static const int MC_CONTENT_TYPE_MUSIC = 2;
+
+  /// < Other content type
+  static const int MC_CONTENT_TYPE_OTHER = 3;
+
+  /// < Not decided
+  static const int MC_CONTENT_TYPE_UNDECIDED = 4;
+}
+
+/// @brief Enumeration for the content age rating of the media content by the media controller server.
+/// @since_tizen 5.0
+///
+/// @see mc_server_set_content_age_rating()
+/// @see mc_client_get_age_rating()
+abstract class mc_content_age_rating_e {
+  /// < Suitable for all ages
+  static const int MC_CONTENT_RATING_ALL = 0;
+
+  /// < Suitable for ages 1 and up
+  static const int MC_CONTENT_RATING_1_PLUS = 1;
+
+  /// < Suitable for ages 2 and up
+  static const int MC_CONTENT_RATING_2_PLUS = 2;
+
+  /// < Suitable for ages 3 and up
+  static const int MC_CONTENT_RATING_3_PLUS = 3;
+
+  /// < Suitable for ages 4 and up
+  static const int MC_CONTENT_RATING_4_PLUS = 4;
+
+  /// < Suitable for ages 5 and up
+  static const int MC_CONTENT_RATING_5_PLUS = 5;
+
+  /// < Suitable for ages 6 and up
+  static const int MC_CONTENT_RATING_6_PLUS = 6;
+
+  /// < Suitable for ages 7 and up
+  static const int MC_CONTENT_RATING_7_PLUS = 7;
+
+  /// < Suitable for ages 8 and up
+  static const int MC_CONTENT_RATING_8_PLUS = 8;
+
+  /// < Suitable for ages 9 and up
+  static const int MC_CONTENT_RATING_9_PLUS = 9;
+
+  /// < Suitable for ages 10 and up
+  static const int MC_CONTENT_RATING_10_PLUS = 10;
+
+  /// < Suitable for ages 11 and up
+  static const int MC_CONTENT_RATING_11_PLUS = 11;
+
+  /// < Suitable for ages 12 and up
+  static const int MC_CONTENT_RATING_12_PLUS = 12;
+
+  /// < Suitable for ages 13 and up
+  static const int MC_CONTENT_RATING_13_PLUS = 13;
+
+  /// < Suitable for ages 14 and up
+  static const int MC_CONTENT_RATING_14_PLUS = 14;
+
+  /// < Suitable for ages 15 and up
+  static const int MC_CONTENT_RATING_15_PLUS = 15;
+
+  /// < Suitable for ages 16 and up
+  static const int MC_CONTENT_RATING_16_PLUS = 16;
+
+  /// < Suitable for ages 17 and up
+  static const int MC_CONTENT_RATING_17_PLUS = 17;
+
+  /// < Suitable for ages 18 and up
+  static const int MC_CONTENT_RATING_18_PLUS = 18;
+
+  /// < Suitable for ages 19 and up
+  static const int MC_CONTENT_RATING_19_PLUS = 19;
+}
+
+/// @brief Enumeration for the support of the ability by the media controller server.
+/// @since_tizen 5.0
+///
+/// @remarks The media controller server should set the proper abilities. \n
+/// Only then can media controller clients send the appropriate control commands.
+///
+/// @see mc_server_set_playback_ability()
+/// @see mc_server_set_ability_support()
+/// @see mc_server_set_display_mode_ability()
+/// @see mc_server_set_display_rotation_ability()
+/// @see mc_client_get_server_ability_support()
+/// @see mc_ability_support_updated_cb()
+/// @see mc_playback_action_is_supported()
+abstract class mc_ability_support_e {
+  /// < Supported
+  static const int MC_ABILITY_SUPPORTED_YES = 0;
+
+  /// < Not supported
+  static const int MC_ABILITY_SUPPORTED_NO = 1;
+
+  /// < Not decided
+  static const int MC_ABILITY_SUPPORTED_UNDECIDED = 2;
+}
+
+/// @brief Enumeration for the ability of the media controller server.
+/// @since_tizen 5.5
+///
+/// @see mc_server_set_ability_support()
+/// @see mc_client_get_server_ability_support()
+/// @see mc_ability_support_updated_cb()
+abstract class mc_ability_e {
+  /// < Shuffle
+  static const int MC_ABILITY_SHUFFLE = 0;
+
+  /// < Repeat
+  static const int MC_ABILITY_REPEAT = 1;
+
+  /// < Playback Position
+  static const int MC_ABILITY_PLAYBACK_POSITION = 2;
+
+  /// < Playlist
+  static const int MC_ABILITY_PLAYLIST = 3;
+
+  /// < Custom command from a client
+  static const int MC_ABILITY_CLIENT_CUSTOM = 4;
+
+  /// < Search
+  static const int MC_ABILITY_SEARCH = 5;
+
+  /// < Subtitles display
+  static const int MC_ABILITY_SUBTITLES = 6;
+
+  /// < 360 content mode display
+  static const int MC_ABILITY_360_MODE = 7;
+}
+
+/// @brief Enumeration for the search category.
+/// @details Media controller clients can use this to search for the content provided by the media controller server.
+/// @since_tizen 5.0
+///
+/// @see mc_search_set_condition()
+abstract class mc_search_category_e {
+  /// < No search category
+  static const int MC_SEARCH_NO_CATEGORY = 0;
+
+  /// < Search by content title
+  static const int MC_SEARCH_TITLE = 1;
+
+  /// < Search by content artist
+  static const int MC_SEARCH_ARTIST = 2;
+
+  /// < Search by content album
+  static const int MC_SEARCH_ALBUM = 3;
+
+  /// < Search by content genre
+  static const int MC_SEARCH_GENRE = 4;
+
+  /// < Search by Time Place Occasion
+  static const int MC_SEARCH_TPO = 5;
+}
+
+/// @brief Enumeration for the display mode of the media controller server.
+/// @since_tizen 5.5
+///
+/// @see mc_server_update_display_mode()
+/// @see mc_server_display_mode_cmd_received_cb()
+/// @see mc_client_get_server_display_mode()
+/// @see mc_client_send_display_mode_cmd()
+/// @see mc_display_mode_updated_cb()
+abstract class mc_display_mode_e {
+  /// < Letter box
+  static const int MC_DISPLAY_MODE_LETTER_BOX = 1;
+
+  /// < Origin size
+  static const int MC_DISPLAY_MODE_ORIGIN_SIZE = 2;
+
+  /// < Full-screen
+  static const int MC_DISPLAY_MODE_FULL_SCREEN = 4;
+
+  /// < Cropped full-screen
+  static const int MC_DISPLAY_MODE_CROPPED_FULL = 8;
+}
+
+/// @brief Enumeration for the display rotation of the media controller server.
+/// @since_tizen 5.5
+///
+/// @see mc_server_update_display_rotation()
+/// @see mc_server_display_rotation_cmd_received_cb()
+/// @see mc_client_get_server_display_rotation()
+/// @see mc_client_send_display_rotation_cmd()
+/// @see mc_display_rotation_updated_cb()
+abstract class mc_display_rotation_e {
+  /// < Display is not rotated
+  static const int MC_DISPLAY_ROTATION_NONE = 1;
+
+  /// < Display is rotated 90 degrees
+  static const int MC_DISPLAY_ROTATION_90 = 2;
+
+  /// < Display is rotated 180 degrees
+  static const int MC_DISPLAY_ROTATION_180 = 4;
+
+  /// < Display is rotated 270 degrees
+  static const int MC_DISPLAY_ROTATION_270 = 8;
+}
+
+/// @brief The result codes of the reply for the command or the event.
+/// @since_tizen 6.0
+///
+/// @see mc_cmd_reply_received_cb()
+/// @see mc_client_send_event_reply()
+/// @see mc_server_event_reply_received_cb()
+/// @see mc_server_send_cmd_reply()
+abstract class mc_result_code_e {
+  /// < The command or the event has been successfully completed.
+  static const int MC_RESULT_CODE_SUCCESS = 0;
+
+  /// < The command or the event had already been completed.
+  static const int MC_RESULT_CODE_ALREADY_DONE = 200;
+
+  /// < The command or the event is aborted by some external event (e.g. aborted play command by incoming call).
+  static const int MC_RESULT_CODE_ABORTED = 300;
+
+  /// < The command or the event is denied due to application policy (e.g. cannot rewind in recording).
+  static const int MC_RESULT_CODE_DENIED = 301;
+
+  /// < The command or the event is not supported.
+  static const int MC_RESULT_CODE_NOT_SUPPORTED = 302;
+
+  /// < The command or the event is out of supported range or the limit is reached.
+  static const int MC_RESULT_CODE_INVALID = 303;
+
+  /// < Timeout has occurred.
+  static const int MC_RESULT_CODE_TIMEOUT = 400;
+
+  /// < The application has failed.
+  static const int MC_RESULT_CODE_APP_FAILED = 401;
+
+  /// < The command or the event has failed because the application has no media.
+  static const int MC_RESULT_CODE_NO_MEDIA = 402;
+
+  /// < The command or the event has failed because there is no audio output device.
+  static const int MC_RESULT_CODE_NO_AUDIO_OUTPUT_DEVICE = 403;
+
+  /// < The command or the event has failed because there is no peer.
+  static const int MC_RESULT_CODE_NO_PEER = 404;
+
+  /// < The network has failed.
+  static const int MC_RESULT_CODE_NETWORK_FAILED = 500;
+
+  /// < The application needs to have an account to which it's logged in.
+  static const int MC_RESULT_CODE_NO_ACCOUNT = 600;
+
+  /// < The application could not log in.
+  static const int MC_RESULT_CODE_LOGIN_FAILED = 601;
+
+  /// < Unknown error.
+  static const int MC_RESULT_CODE_UNKNOWN = 2147483647;
+}
+
 /// @brief The structure type for the media controller playlist handle.
 /// @since_tizen 4.0
 typedef mc_playlist_h = ffi.Pointer<ffi.Void>;
@@ -6519,174 +7048,13 @@ typedef mc_playlist_cbFunction = ffi.Bool Function(
 typedef Dartmc_playlist_cbFunction = bool Function(
     mc_playlist_h playlist, ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the media meta info.
-/// @since_tizen 2.4
-///
-/// @see mc_server_set_metadata()
-/// @see mc_server_add_item_to_playlist()
-/// @see mc_metadata_get()
-abstract class mc_meta_e {
-  /// < Title
-  static const int MC_META_MEDIA_TITLE = 0;
-
-  /// < Artist
-  static const int MC_META_MEDIA_ARTIST = 1;
-
-  /// < Album
-  static const int MC_META_MEDIA_ALBUM = 2;
-
-  /// < Author
-  static const int MC_META_MEDIA_AUTHOR = 3;
-
-  /// < Genre
-  static const int MC_META_MEDIA_GENRE = 4;
-
-  /// < Duration
-  static const int MC_META_MEDIA_DURATION = 5;
-
-  /// < Date
-  static const int MC_META_MEDIA_DATE = 6;
-
-  /// < Copyright
-  static const int MC_META_MEDIA_COPYRIGHT = 7;
-
-  /// < Description
-  static const int MC_META_MEDIA_DESCRIPTION = 8;
-
-  /// < Track Number
-  static const int MC_META_MEDIA_TRACK_NUM = 9;
-
-  /// < Picture. Album Art
-  static const int MC_META_MEDIA_PICTURE = 10;
-
-  /// < Season (Since 5.5)
-  static const int MC_META_MEDIA_SEASON = 11;
-
-  /// < Episode (Since 5.5)
-  static const int MC_META_MEDIA_EPISODE = 12;
-
-  /// < Content resolution (Since 5.5)
-  static const int MC_META_MEDIA_RESOLUTION = 13;
-}
-
 /// @brief The structure type for the media controller ability handle.
 /// @since_tizen 5.0
 typedef mc_playback_ability_h = ffi.Pointer<ffi.Void>;
 
-/// @brief Enumeration for the media playback action.
-/// @details Media controller clients can control media controller server's playback by calling mc_client_send_playback_action_cmd() or mc_client_send_playlist_cmd(). \n
-/// Media controller servers have to set proper playback ability by using mc_server_set_playback_ability().
-/// @since_tizen 4.0
-///
-/// @see mc_server_set_playback_ability()
-/// @see mc_client_send_playback_action_cmd()
-/// @see mc_client_send_playlist_cmd()
-/// @see mc_playback_action_is_supported()
-/// @see mc_server_playback_action_cmd_received_cb()
-/// @see mc_server_playlist_cmd_received_cb()
-abstract class mc_playback_action_e {
-  /// < Play
-  static const int MC_PLAYBACK_ACTION_PLAY = 0;
-
-  /// < Pause
-  static const int MC_PLAYBACK_ACTION_PAUSE = 1;
-
-  /// < Stop
-  static const int MC_PLAYBACK_ACTION_STOP = 2;
-
-  /// < Next item
-  static const int MC_PLAYBACK_ACTION_NEXT = 3;
-
-  /// < Previous item
-  static const int MC_PLAYBACK_ACTION_PREV = 4;
-
-  /// < Fast forward
-  static const int MC_PLAYBACK_ACTION_FAST_FORWARD = 5;
-
-  /// < Rewind
-  static const int MC_PLAYBACK_ACTION_REWIND = 6;
-
-  /// < Play/Pause toggle
-  static const int MC_PLAYBACK_ACTION_TOGGLE_PLAY_PAUSE = 7;
-}
-
-/// @brief Enumeration for the support of the ability by the media controller server.
-/// @since_tizen 5.0
-///
-/// @remarks The media controller server should set the proper abilities. \n
-/// Only then can media controller clients send the appropriate control commands.
-///
-/// @see mc_server_set_playback_ability()
-/// @see mc_server_set_ability_support()
-/// @see mc_server_set_display_mode_ability()
-/// @see mc_server_set_display_rotation_ability()
-/// @see mc_client_get_server_ability_support()
-/// @see mc_ability_support_updated_cb()
-/// @see mc_playback_action_is_supported()
-abstract class mc_ability_support_e {
-  /// < Supported
-  static const int MC_ABILITY_SUPPORTED_YES = 0;
-
-  /// < Not supported
-  static const int MC_ABILITY_SUPPORTED_NO = 1;
-
-  /// < Not decided
-  static const int MC_ABILITY_SUPPORTED_UNDECIDED = 2;
-}
-
 /// @brief The structure type for the media controller search handle.
 /// @since_tizen 5.0
 typedef mc_search_h = ffi.Pointer<ffi.Void>;
-
-/// @brief Enumeration for the content type of the media content by the media controller server.
-/// @details Media controller clients can use this to know the playback status of the media controller server. \n
-/// And media controller clients can also use to search for the content provided by the media controller server.
-/// @since_tizen 5.0
-///
-/// @see mc_server_set_playback_content_type()
-/// @see mc_client_get_playback_content_type()
-/// @see mc_search_set_condition()
-abstract class mc_content_type_e {
-  /// < Image content type
-  static const int MC_CONTENT_TYPE_IMAGE = 0;
-
-  /// < Video content type
-  static const int MC_CONTENT_TYPE_VIDEO = 1;
-
-  /// < Music content type
-  static const int MC_CONTENT_TYPE_MUSIC = 2;
-
-  /// < Other content type
-  static const int MC_CONTENT_TYPE_OTHER = 3;
-
-  /// < Not decided
-  static const int MC_CONTENT_TYPE_UNDECIDED = 4;
-}
-
-/// @brief Enumeration for the search category.
-/// @details Media controller clients can use this to search for the content provided by the media controller server.
-/// @since_tizen 5.0
-///
-/// @see mc_search_set_condition()
-abstract class mc_search_category_e {
-  /// < No search category
-  static const int MC_SEARCH_NO_CATEGORY = 0;
-
-  /// < Search by content title
-  static const int MC_SEARCH_TITLE = 1;
-
-  /// < Search by content artist
-  static const int MC_SEARCH_ARTIST = 2;
-
-  /// < Search by content album
-  static const int MC_SEARCH_ALBUM = 3;
-
-  /// < Search by content genre
-  static const int MC_SEARCH_GENRE = 4;
-
-  /// < Search by Time Place Occasion
-  static const int MC_SEARCH_TPO = 5;
-}
 
 /// @brief Called for every search condition information in the obtained list of search.
 /// @details Iterates over a search list.
@@ -6751,22 +7119,6 @@ typedef Dartmc_server_state_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the media controller server state.
-/// @since_tizen 2.4
-///
-/// @see mc_client_get_latest_server_info()
-/// @see mc_server_state_updated_cb()
-abstract class mc_server_state_e {
-  /// < None state
-  static const int MC_SERVER_STATE_NONE = 0;
-
-  /// < Activate state
-  static const int MC_SERVER_STATE_ACTIVATE = 1;
-
-  /// < Deactivate state
-  static const int MC_SERVER_STATE_DEACTIVATE = 2;
-}
 
 /// @brief Called when the playback information of the media controller server is updated.
 /// @since_tizen 2.4
@@ -6853,22 +7205,6 @@ typedef Dartmc_shuffle_mode_updated_cbFunction = void Function(
     int mode,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the shuffle mode of the media controller server.
-/// @since_tizen 2.4
-///
-/// @see mc_server_update_shuffle_mode()
-/// @see mc_server_shuffle_mode_cmd_received_cb()
-/// @see mc_client_get_server_shuffle_mode()
-/// @see mc_client_send_shuffle_mode_cmd()
-/// @see mc_shuffle_mode_updated_cb()
-abstract class mc_shuffle_mode_e {
-  /// < Shuffle mode on
-  static const int MC_SHUFFLE_MODE_ON = 0;
-
-  /// < Shuffle mode off
-  static const int MC_SHUFFLE_MODE_OFF = 1;
-}
-
 /// @brief Called when the repeat mode of the media controller server is updated.
 /// @since_tizen 4.0
 ///
@@ -6893,25 +7229,6 @@ typedef Dartmc_repeat_mode_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int mode,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the repeat mode of the media controller server.
-/// @since_tizen 2.4
-///
-/// @see mc_server_update_repeat_mode()
-/// @see mc_server_repeat_mode_cmd_received_cb()
-/// @see mc_client_get_server_repeat_mode()
-/// @see mc_client_send_repeat_mode_cmd()
-/// @see mc_repeat_mode_updated_cb()
-abstract class mc_repeat_mode_e {
-  /// < Repeat mode on for all media
-  static const int MC_REPEAT_MODE_ON = 0;
-
-  /// < Repeat mode off
-  static const int MC_REPEAT_MODE_OFF = 1;
-
-  /// < Repeat mode on for one media (Since 4.0)
-  static const int MC_REPEAT_MODE_ONE_MEDIA = 2;
-}
 
 /// @brief Called when the playback ability support of the media controller server is updated.
 /// @since_tizen 5.0
@@ -6966,38 +7283,6 @@ typedef Dartmc_ability_support_updated_cbFunction = void Function(
     int ability,
     int support,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the ability of the media controller server.
-/// @since_tizen 5.5
-///
-/// @see mc_server_set_ability_support()
-/// @see mc_client_get_server_ability_support()
-/// @see mc_ability_support_updated_cb()
-abstract class mc_ability_e {
-  /// < Shuffle
-  static const int MC_ABILITY_SHUFFLE = 0;
-
-  /// < Repeat
-  static const int MC_ABILITY_REPEAT = 1;
-
-  /// < Playback Position
-  static const int MC_ABILITY_PLAYBACK_POSITION = 2;
-
-  /// < Playlist
-  static const int MC_ABILITY_PLAYLIST = 3;
-
-  /// < Custom command from a client
-  static const int MC_ABILITY_CLIENT_CUSTOM = 4;
-
-  /// < Search
-  static const int MC_ABILITY_SEARCH = 5;
-
-  /// < Subtitles display
-  static const int MC_ABILITY_SUBTITLES = 6;
-
-  /// < 360 content mode display
-  static const int MC_ABILITY_360_MODE = 7;
-}
 
 /// @brief Called when a media controller server's supported items for an ability is updated.
 /// @since_tizen 5.5
@@ -7092,22 +7377,6 @@ typedef Dartmc_playlist_updated_cbFunction = void Function(
     mc_playlist_h playlist,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the playlist update mode.
-/// @details Media controller clients can know the playlist change status of the media controller server by calling mc_client_set_playlist_updated_cb(). \n
-/// @since_tizen 4.0
-///
-/// @see mc_client_set_playlist_updated_cb()
-/// @see mc_playlist_updated_cb()
-/// @see mc_server_update_playlist_done()
-/// @see mc_server_delete_playlist()
-abstract class mc_playlist_update_mode_e {
-  /// < Create or Update playlist
-  static const int MC_PLAYLIST_UPDATED = 0;
-
-  /// < Remove playlist
-  static const int MC_PLAYLIST_REMOVED = 1;
-}
-
 /// @brief Called when the status of a media controller server's boolean attribute (subtitles or 360 mode) is updated.
 /// @since_tizen 5.5
 ///
@@ -7155,28 +7424,6 @@ typedef Dartmc_display_mode_updated_cbFunction = void Function(
     int mode,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the display mode of the media controller server.
-/// @since_tizen 5.5
-///
-/// @see mc_server_update_display_mode()
-/// @see mc_server_display_mode_cmd_received_cb()
-/// @see mc_client_get_server_display_mode()
-/// @see mc_client_send_display_mode_cmd()
-/// @see mc_display_mode_updated_cb()
-abstract class mc_display_mode_e {
-  /// < Letter box
-  static const int MC_DISPLAY_MODE_LETTER_BOX = 1;
-
-  /// < Origin size
-  static const int MC_DISPLAY_MODE_ORIGIN_SIZE = 2;
-
-  /// < Full-screen
-  static const int MC_DISPLAY_MODE_FULL_SCREEN = 4;
-
-  /// < Cropped full-screen
-  static const int MC_DISPLAY_MODE_CROPPED_FULL = 8;
-}
-
 /// @brief Called when a media controller server's display rotation is updated.
 /// @since_tizen 5.5
 ///
@@ -7199,28 +7446,6 @@ typedef Dartmc_display_rotation_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int rotation,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the display rotation of the media controller server.
-/// @since_tizen 5.5
-///
-/// @see mc_server_update_display_rotation()
-/// @see mc_server_display_rotation_cmd_received_cb()
-/// @see mc_client_get_server_display_rotation()
-/// @see mc_client_send_display_rotation_cmd()
-/// @see mc_display_rotation_updated_cb()
-abstract class mc_display_rotation_e {
-  /// < Display is not rotated
-  static const int MC_DISPLAY_ROTATION_NONE = 1;
-
-  /// < Display is rotated 90 degrees
-  static const int MC_DISPLAY_ROTATION_90 = 2;
-
-  /// < Display is rotated 180 degrees
-  static const int MC_DISPLAY_ROTATION_180 = 4;
-
-  /// < Display is rotated 270 degrees
-  static const int MC_DISPLAY_ROTATION_270 = 8;
-}
 
 /// @brief Called when receiving custom event from media controller servers.
 /// @since_tizen 4.0
@@ -7257,44 +7482,6 @@ typedef Dartmc_client_custom_event_received_cbFunction = void Function(
     ffi.Pointer<bundle.bundle> data,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the subscription type of the media controller client.
-/// @since_tizen 2.4
-///
-/// @see mc_client_subscribe()
-/// @see mc_client_unsubscribe()
-/// @see mc_client_foreach_server_subscribed()
-abstract class mc_subscription_type_e {
-  /// < Server state
-  static const int MC_SUBSCRIPTION_TYPE_SERVER_STATE = 0;
-
-  /// < Playback
-  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK = 1;
-
-  /// < Metadata
-  static const int MC_SUBSCRIPTION_TYPE_METADATA = 2;
-
-  /// < Shuffle mode
-  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_MODE = 3;
-
-  /// < Repeat mode
-  static const int MC_SUBSCRIPTION_TYPE_REPEAT_MODE = 4;
-
-  /// < Playlist (Since 4.0)
-  static const int MC_SUBSCRIPTION_TYPE_PLAYLIST = 5;
-
-  /// < Playback ability (Since 5.0)
-  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK_ABILITY = 6;
-
-  /// < Ability support (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT = 9;
-
-  /// < Display mode ability (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_MODE_ABILITY = 10;
-
-  /// < Display rotation ability (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_ROTATION_ABILITY = 11;
-}
-
 /// @brief Called when requesting the list of subscribed servers.
 /// @since_tizen 2.4
 ///
@@ -7317,113 +7504,6 @@ typedef mc_subscribed_server_cbFunction = ffi.Bool Function(
     ffi.Pointer<ffi.Char> server_name, ffi.Pointer<ffi.Void> user_data);
 typedef Dartmc_subscribed_server_cbFunction = bool Function(
     ffi.Pointer<ffi.Char> server_name, ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the media playback state of the media controller server.
-/// @since_tizen 2.4
-///
-/// @see mc_server_set_playback_state()
-/// @see mc_client_get_playback_state()
-abstract class mc_playback_states_e {
-  /// < None
-  static const int MC_PLAYBACK_STATE_NONE = 0;
-
-  /// < Playing
-  static const int MC_PLAYBACK_STATE_PLAYING = 1;
-
-  /// < Paused
-  static const int MC_PLAYBACK_STATE_PAUSED = 2;
-
-  /// < Stopped
-  static const int MC_PLAYBACK_STATE_STOPPED = 3;
-
-  /// < Moving to the next item (Since 4.0)
-  static const int MC_PLAYBACK_STATE_MOVING_TO_NEXT = 8;
-
-  /// < Moving to the previous item (Since 4.0)
-  static const int MC_PLAYBACK_STATE_MOVING_TO_PREVIOUS = 9;
-
-  /// < Fast forwarding (Since 4.0)
-  static const int MC_PLAYBACK_STATE_FAST_FORWARDING = 10;
-
-  /// < Rewinding (Since 4.0)
-  static const int MC_PLAYBACK_STATE_REWINDING = 11;
-
-  /// < Connecting (Since 6.0)
-  static const int MC_PLAYBACK_STATE_CONNECTING = 12;
-
-  /// < Buffering (Since 6.0)
-  static const int MC_PLAYBACK_STATE_BUFFERING = 13;
-
-  /// < Error (Since 6.0)
-  static const int MC_PLAYBACK_STATE_ERROR = 14;
-}
-
-/// @brief Enumeration for the content age rating of the media content by the media controller server.
-/// @since_tizen 5.0
-///
-/// @see mc_server_set_content_age_rating()
-/// @see mc_client_get_age_rating()
-abstract class mc_content_age_rating_e {
-  /// < Suitable for all ages
-  static const int MC_CONTENT_RATING_ALL = 0;
-
-  /// < Suitable for ages 1 and up
-  static const int MC_CONTENT_RATING_1_PLUS = 1;
-
-  /// < Suitable for ages 2 and up
-  static const int MC_CONTENT_RATING_2_PLUS = 2;
-
-  /// < Suitable for ages 3 and up
-  static const int MC_CONTENT_RATING_3_PLUS = 3;
-
-  /// < Suitable for ages 4 and up
-  static const int MC_CONTENT_RATING_4_PLUS = 4;
-
-  /// < Suitable for ages 5 and up
-  static const int MC_CONTENT_RATING_5_PLUS = 5;
-
-  /// < Suitable for ages 6 and up
-  static const int MC_CONTENT_RATING_6_PLUS = 6;
-
-  /// < Suitable for ages 7 and up
-  static const int MC_CONTENT_RATING_7_PLUS = 7;
-
-  /// < Suitable for ages 8 and up
-  static const int MC_CONTENT_RATING_8_PLUS = 8;
-
-  /// < Suitable for ages 9 and up
-  static const int MC_CONTENT_RATING_9_PLUS = 9;
-
-  /// < Suitable for ages 10 and up
-  static const int MC_CONTENT_RATING_10_PLUS = 10;
-
-  /// < Suitable for ages 11 and up
-  static const int MC_CONTENT_RATING_11_PLUS = 11;
-
-  /// < Suitable for ages 12 and up
-  static const int MC_CONTENT_RATING_12_PLUS = 12;
-
-  /// < Suitable for ages 13 and up
-  static const int MC_CONTENT_RATING_13_PLUS = 13;
-
-  /// < Suitable for ages 14 and up
-  static const int MC_CONTENT_RATING_14_PLUS = 14;
-
-  /// < Suitable for ages 15 and up
-  static const int MC_CONTENT_RATING_15_PLUS = 15;
-
-  /// < Suitable for ages 16 and up
-  static const int MC_CONTENT_RATING_16_PLUS = 16;
-
-  /// < Suitable for ages 17 and up
-  static const int MC_CONTENT_RATING_17_PLUS = 17;
-
-  /// < Suitable for ages 18 and up
-  static const int MC_CONTENT_RATING_18_PLUS = 18;
-
-  /// < Suitable for ages 19 and up
-  static const int MC_CONTENT_RATING_19_PLUS = 19;
-}
 
 /// @brief Called when requesting the list of created servers.
 /// @since_tizen 2.4
@@ -7825,3 +7905,5 @@ typedef Dartmc_server_search_cmd_received_cbFunction = void Function(
     ffi.Pointer<ffi.Char> request_id,
     mc_search_h search,
     ffi.Pointer<ffi.Void> user_data);
+
+const int MEDIA_CONTROLLER_ERROR_CLASS = -50462720;

--- a/lib/src/bindings/10.0/generated_bindings_capi_media_metadata_editor.dart
+++ b/lib/src/bindings/10.0/generated_bindings_capi_media_metadata_editor.dart
@@ -378,9 +378,34 @@ class Tizen100CapiMediaMetadataEditor {
 
 /// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
 /// @deprecated Deprecated since 9.0.
-/// @brief The handle of media metadata.
+/// @brief The enumerations of media metadata error.
 /// @since_tizen 2.4
-typedef metadata_editor_h = ffi.Pointer<ffi.Void>;
+abstract class metadata_editor_error_e {
+  /// < Successful
+  static const int METADATA_EDITOR_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int METADATA_EDITOR_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int METADATA_EDITOR_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < File not exist
+  static const int METADATA_EDITOR_ERROR_FILE_EXISTS = -17;
+
+  /// < Permission denied
+  static const int METADATA_EDITOR_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Unsupported type
+  static const int METADATA_EDITOR_ERROR_NOT_SUPPORTED = -1073741822;
+
+  /// < Invalid internal operation
+  static const int METADATA_EDITOR_ERROR_OPERATION_FAILED = -27000831;
+
+  /// < Update not possible (Since 6.0)
+  static const int METADATA_EDITOR_ERROR_METADATA_UPDATE_NOT_POSSIBLE =
+      -27000830;
+}
 
 /// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
 /// @deprecated Deprecated since 9.0.
@@ -426,3 +451,11 @@ abstract class metadata_editor_attr_e {
   /// < Unsynchronized lyric
   static const int METADATA_EDITOR_ATTR_UNSYNCLYRICS = 12;
 }
+
+/// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
+/// @deprecated Deprecated since 9.0.
+/// @brief The handle of media metadata.
+/// @since_tizen 2.4
+typedef metadata_editor_h = ffi.Pointer<ffi.Void>;
+
+const int METADATA_EDITOR_ERROR_CLASS = -27000832;

--- a/lib/src/bindings/10.0/generated_bindings_capi_media_metadata_extractor.dart
+++ b/lib/src/bindings/10.0/generated_bindings_capi_media_metadata_extractor.dart
@@ -386,11 +386,27 @@ class Tizen100CapiMediaMetadataExtractor {
 }
 
 /// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
-/// @brief The metadata extractor handle.
+/// @brief Enumeration for metadata extractor error.
 /// @since_tizen 2.3
-typedef metadata_extractor_h = ffi.Pointer<metadata_extractor_s>;
+abstract class metadata_extractor_error_e {
+  /// < Successful
+  static const int METADATA_EXTRACTOR_ERROR_NONE = 0;
 
-final class metadata_extractor_s extends ffi.Opaque {}
+  /// < Invalid parameter
+  static const int METADATA_EXTRACTOR_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int METADATA_EXTRACTOR_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < File does not exist
+  static const int METADATA_EXTRACTOR_ERROR_FILE_EXISTS = -17;
+
+  /// < Permission denied
+  static const int METADATA_EXTRACTOR_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Invalid internal operation
+  static const int METADATA_EXTRACTOR_ERROR_OPERATION_FAILED = -26411007;
+}
 
 /// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
 /// @brief Enumeration for attribute.
@@ -504,3 +520,12 @@ abstract class metadata_extractor_attr_e {
   /// < Stitched type. (0:None, 1:Non-stitched, 2:stitched) (Since 9.0)
   static const int METADATA_360_STITCHED = 35;
 }
+
+final class metadata_extractor_s extends ffi.Opaque {}
+
+/// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
+/// @brief The metadata extractor handle.
+/// @since_tizen 2.3
+typedef metadata_extractor_h = ffi.Pointer<metadata_extractor_s>;
+
+const int METADATA_EXTRACTOR_ERROR_CLASS = -26411008;

--- a/lib/src/bindings/10.0/generated_bindings_capi_media_screen_mirroring.dart
+++ b/lib/src/bindings/10.0/generated_bindings_capi_media_screen_mirroring.dart
@@ -1059,30 +1059,6 @@ class Tizen100CapiMediaScreenMirroring {
           int Function(scmirroring_sink_h, ffi.Pointer<ffi.Int32>)>();
 }
 
-/// @brief	The handle to the screen mirroring sink.
-/// @since_tizen 2.4
-typedef scmirroring_sink_h = ffi.Pointer<ffi.Void>;
-
-/// @brief Called when state of screen mirroring sink handle is changed.
-/// @since_tizen 2.4
-///
-/// @details This callback is called for state and error of screen mirroring sink will be delivered together.
-/// Error can be handled by return value of CAPIs. so there is no need to handle it here.
-///
-/// @param[in] error     The error code
-/// @param[in] state     The screen mirroring sink state
-/// @param[in] user_data The user data passed from the scmirroring_sink_set_state_cb() function
-///
-/// @pre scmirroring_sink_create()
-///
-/// @see scmirroring_sink_create()
-typedef scmirroring_sink_state_cb
-    = ffi.Pointer<ffi.NativeFunction<scmirroring_sink_state_cbFunction>>;
-typedef scmirroring_sink_state_cbFunction = ffi.Void Function(
-    ffi.Int32 error, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
-typedef Dartscmirroring_sink_state_cbFunction = void Function(
-    int error, int state, ffi.Pointer<ffi.Void> user_data);
-
 /// @brief Enumeration to provide screen mirroring error information.
 /// @since_tizen 2.4
 abstract class scmirroring_error_e {
@@ -1135,6 +1111,41 @@ abstract class scmirroring_sink_state_e {
   /// < Screen mirroring is disconnected
   static const int SCMIRRORING_SINK_STATE_DISCONNECTED = 6;
   static const int SCMIRRORING_SINK_STATE_MAX = 7;
+}
+
+/// @brief Enumeration for screen mirroring resolution.
+/// @since_tizen 2.4
+abstract class scmirroring_resolution_e {
+  static const int SCMIRRORING_RESOLUTION_UNKNOWN = 0;
+
+  /// < W-1920, H-1080, 30 fps
+  static const int SCMIRRORING_RESOLUTION_1920x1080_P30 = 1;
+
+  /// < W-1280, H-720, 30 fps
+  static const int SCMIRRORING_RESOLUTION_1280x720_P30 = 2;
+
+  /// < W-960, H-540, 30 fps
+  static const int SCMIRRORING_RESOLUTION_960x540_P30 = 4;
+
+  /// < W-864, H-480, 30 fps
+  static const int SCMIRRORING_RESOLUTION_864x480_P30 = 8;
+
+  /// < W-720, H-480, 30 fps
+  static const int SCMIRRORING_RESOLUTION_720x480_P60 = 16;
+
+  /// < W-640, H-480, 60 fps
+  static const int SCMIRRORING_RESOLUTION_640x480_P60 = 32;
+
+  /// < W-640, H-360, 30 fps
+  static const int SCMIRRORING_RESOLUTION_640x360_P30 = 64;
+  static const int SCMIRRORING_RESOLUTION_MAX = 128;
+}
+
+/// @brief Ability to send to multisink.
+/// @since_tizen 3.0
+abstract class scmirroring_multisink_e {
+  static const int SCMIRRORING_MULTISINK_DISABLE = 0;
+  static const int SCMIRRORING_MULTISINK_ENABLE = 1;
 }
 
 /// @brief Enumeration for screen mirroring display surface type.
@@ -1199,16 +1210,6 @@ abstract class scmirroring_device_type_e {
   static const int SCMIRRORING_DEVICE_TYPE_MOBILE = 2;
 }
 
-/// @brief Enumeration for screen mirroring video codec.
-/// @since_tizen 2.4
-abstract class scmirroring_video_codec_e {
-  /// < Screen mirroring is not negotiated yet
-  static const int SCMIRRORING_VIDEO_CODEC_NONE = 0;
-
-  /// < H.264 codec for video
-  static const int SCMIRRORING_VIDEO_CODEC_H264 = 1;
-}
-
 /// @brief Enumeration for screen mirroring audio codec.
 /// @since_tizen 2.4
 abstract class scmirroring_audio_codec_e {
@@ -1224,3 +1225,57 @@ abstract class scmirroring_audio_codec_e {
   /// < LPCM codec for audio
   static const int SCMIRRORING_AUDIO_CODEC_LPCM = 3;
 }
+
+/// @brief Enumeration for screen mirroring video codec.
+/// @since_tizen 2.4
+abstract class scmirroring_video_codec_e {
+  /// < Screen mirroring is not negotiated yet
+  static const int SCMIRRORING_VIDEO_CODEC_NONE = 0;
+
+  /// < H.264 codec for video
+  static const int SCMIRRORING_VIDEO_CODEC_H264 = 1;
+}
+
+/// @brief Enumeration for screen mirroring direct streaming mode.
+/// @since_tizen 3.0
+abstract class scmirroring_direct_streaming_e {
+  /// < Disable screen mirroring direct streaming mode
+  static const int SCMIRRORING_DIRECT_STREAMING_DISABLED = 0;
+
+  /// < Enable direct streaming for files
+  static const int SCMIRRORING_DIRECT_STREAMING_ENABLED = 1;
+}
+
+/// @brief Enumeration for screen mirroring AV streaming transport.
+/// @since_tizen 3.0
+abstract class scmirroring_av_transport_e {
+  /// < UDP transport for AV streaming data
+  static const int SCMIRRORING_AV_TRANSPORT_UDP = 0;
+
+  /// < TCP transport for AV streaming data
+  static const int SCMIRRORING_AV_TRANSPORT_TCP = 1;
+}
+
+/// @brief	The handle to the screen mirroring sink.
+/// @since_tizen 2.4
+typedef scmirroring_sink_h = ffi.Pointer<ffi.Void>;
+
+/// @brief Called when state of screen mirroring sink handle is changed.
+/// @since_tizen 2.4
+///
+/// @details This callback is called for state and error of screen mirroring sink will be delivered together.
+/// Error can be handled by return value of CAPIs. so there is no need to handle it here.
+///
+/// @param[in] error     The error code
+/// @param[in] state     The screen mirroring sink state
+/// @param[in] user_data The user data passed from the scmirroring_sink_set_state_cb() function
+///
+/// @pre scmirroring_sink_create()
+///
+/// @see scmirroring_sink_create()
+typedef scmirroring_sink_state_cb
+    = ffi.Pointer<ffi.NativeFunction<scmirroring_sink_state_cbFunction>>;
+typedef scmirroring_sink_state_cbFunction = ffi.Void Function(
+    ffi.Int32 error, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
+typedef Dartscmirroring_sink_state_cbFunction = void Function(
+    int error, int state, ffi.Pointer<ffi.Void> user_data);

--- a/lib/src/bindings/10.0/generated_bindings_capi_media_sound_pool.dart
+++ b/lib/src/bindings/10.0/generated_bindings_capi_media_sound_pool.dart
@@ -886,10 +886,54 @@ class Tizen100CapiMediaSoundPool {
 }
 
 /// @deprecated Deprecated since 10.0
-/// @brief Sound pool handle type.
+/// @brief Enumeration for Tizen Sound Pool error.
 ///
 /// @since_tizen 4.0
-typedef sound_pool_h = ffi.Pointer<ffi.Void>;
+abstract class sound_pool_error_e {
+  static const int SOUND_POOL_ERROR_NONE = 0;
+  static const int SOUND_POOL_ERROR_KEY_NOT_AVAILABLE = -126;
+  static const int SOUND_POOL_ERROR_OUT_OF_MEMORY = -12;
+  static const int SOUND_POOL_ERROR_INVALID_PARAMETER = -22;
+  static const int SOUND_POOL_ERROR_INVALID_OPERATION = -38;
+  static const int SOUND_POOL_ERROR_NOT_PERMITTED = -1;
+  static const int SOUND_POOL_ERROR_NO_SUCH_FILE = -2;
+}
+
+/// @deprecated Deprecated since 10.0
+/// @brief Enumeration of sound pool stream state.
+///
+/// @since_tizen 4.0
+abstract class sound_pool_stream_state_e {
+  /// < Stream state isn't determined
+  static const int SOUND_POOL_STREAM_STATE_NONE = 0;
+
+  /// < Stream state is playing
+  static const int SOUND_POOL_STREAM_STATE_PLAYING = 1;
+
+  /// < Stream state is paused
+  static const int SOUND_POOL_STREAM_STATE_PAUSED = 2;
+
+  /// < Stream state is stopped
+  static const int SOUND_POOL_STREAM_STATE_STOPPED = 3;
+
+  /// < Stream state is finished
+  static const int SOUND_POOL_STREAM_STATE_FINISHED = 4;
+
+  /// < Stream state is suspended
+  static const int SOUND_POOL_STREAM_STATE_SUSPENDED = 5;
+}
+
+/// @deprecated Deprecated since 10.0
+/// @brief Enumeration of sound pool stream priority policy.
+///
+/// @since_tizen 4.0
+abstract class sound_pool_stream_priority_policy_e {
+  /// < Stream priority policy is mute
+  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_MUTE = 0;
+
+  /// < Stream priority policy is suspended
+  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_SUSPENDED = 1;
+}
 
 /// @deprecated Deprecated since 10.0
 /// @brief Enumeration of sound pool state.
@@ -902,6 +946,12 @@ abstract class sound_pool_state_e {
   /// < Sound pool inactive state: streams can't be played
   static const int SOUND_POOL_STATE_INACTIVE = 1;
 }
+
+/// @deprecated Deprecated since 10.0
+/// @brief Sound pool handle type.
+///
+/// @since_tizen 4.0
+typedef sound_pool_h = ffi.Pointer<ffi.Void>;
 
 /// @deprecated Deprecated since 10.0
 /// @brief Called when the sound pool state is changed.
@@ -933,18 +983,6 @@ typedef Dartsound_pool_state_changed_cbFunction = void Function(
     int prev_state,
     int cur_state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @deprecated Deprecated since 10.0
-/// @brief Enumeration of sound pool stream priority policy.
-///
-/// @since_tizen 4.0
-abstract class sound_pool_stream_priority_policy_e {
-  /// < Stream priority policy is mute
-  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_MUTE = 0;
-
-  /// < Stream priority policy is suspended
-  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_SUSPENDED = 1;
-}
 
 /// @deprecated Deprecated since 10.0
 /// @brief Called when the sound pool stream state is changed.
@@ -979,27 +1017,3 @@ typedef Dartsound_pool_stream_state_changed_cbFunction = void Function(
     int prev_state,
     int cur_state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @deprecated Deprecated since 10.0
-/// @brief Enumeration of sound pool stream state.
-///
-/// @since_tizen 4.0
-abstract class sound_pool_stream_state_e {
-  /// < Stream state isn't determined
-  static const int SOUND_POOL_STREAM_STATE_NONE = 0;
-
-  /// < Stream state is playing
-  static const int SOUND_POOL_STREAM_STATE_PLAYING = 1;
-
-  /// < Stream state is paused
-  static const int SOUND_POOL_STREAM_STATE_PAUSED = 2;
-
-  /// < Stream state is stopped
-  static const int SOUND_POOL_STREAM_STATE_STOPPED = 3;
-
-  /// < Stream state is finished
-  static const int SOUND_POOL_STREAM_STATE_FINISHED = 4;
-
-  /// < Stream state is suspended
-  static const int SOUND_POOL_STREAM_STATE_SUSPENDED = 5;
-}

--- a/lib/src/bindings/10.0/generated_bindings_capi_media_thumbnail_util.dart
+++ b/lib/src/bindings/10.0/generated_bindings_capi_media_thumbnail_util.dart
@@ -156,3 +156,31 @@ class Tizen100CapiMediaThumbnailUtil {
               ffi.Pointer<ffi.UnsignedInt>,
               ffi.Pointer<ffi.UnsignedInt>)>();
 }
+
+/// @ingroup CAPI_MEDIA_THUMBNAIL_UTIL_MODULE
+/// @brief Enumeration for a thumbnail util error.
+/// @since_tizen 2.4
+abstract class thumbnail_util_error_e {
+  /// < Successful
+  static const int THUMBNAIL_UTIL_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int THUMBNAIL_UTIL_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int THUMBNAIL_UTIL_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Invalid Operation
+  static const int THUMBNAIL_UTIL_ERROR_INVALID_OPERATION = -38;
+
+  /// < No space left on device
+  static const int THUMBNAIL_UTIL_ERROR_FILE_NO_SPACE_ON_DEVICE = -28;
+
+  /// < Permission denied
+  static const int THUMBNAIL_UTIL_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Unsupported Content (Since 4.0)
+  static const int THUMBNAIL_UTIL_ERROR_UNSUPPORTED_CONTENT = -49872895;
+}
+
+const int THUMBNAIL_UTIL_ERROR_CLASS = -49872896;

--- a/lib/src/bindings/10.0/generated_bindings_capi_network_bluetooth.dart
+++ b/lib/src/bindings/10.0/generated_bindings_capi_network_bluetooth.dart
@@ -10759,6 +10759,187 @@ class Tizen100CapiNetworkBluetooth {
                   ffi.Pointer<bt_adapter_le_device_scan_result_info_s>>)>();
 }
 
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of PBAP fields.
+/// @since_tizen 3.0
+abstract class bt_pbap_field_e {
+  /// < All field
+  static const int BT_PBAP_FIELD_ALL = -1;
+
+  /// < vCard Version
+  static const int BT_PBAP_FIELD_VERSION = 1;
+
+  /// < Formatted Name
+  static const int BT_PBAP_FIELD_FN = 2;
+
+  /// < Structured Presentation of Name
+  static const int BT_PBAP_FIELD_N = 4;
+
+  /// < Associated Image or Photo
+  static const int BT_PBAP_FIELD_PHOTO = 8;
+
+  /// < Birthday
+  static const int BT_PBAP_FIELD_BDAY = 16;
+
+  /// < Delivery Address
+  static const int BT_PBAP_FIELD_ADR = 32;
+
+  /// < Delivery
+  static const int BT_PBAP_FIELD_LABEL = 64;
+
+  /// < Telephone Number
+  static const int BT_PBAP_FIELD_TEL = 128;
+
+  /// < Electronic Mail Address
+  static const int BT_PBAP_FIELD_EMAIL = 256;
+
+  /// < Electronic Mail
+  static const int BT_PBAP_FIELD_MAILER = 512;
+
+  /// < Time Zone
+  static const int BT_PBAP_FIELD_TZ = 1024;
+
+  /// < Geographic Position
+  static const int BT_PBAP_FIELD_GEO = 2048;
+
+  /// < Job
+  static const int BT_PBAP_FIELD_TITLE = 4096;
+
+  /// < Role within the Organization
+  static const int BT_PBAP_FIELD_ROLE = 8192;
+
+  /// < Organization Logo
+  static const int BT_PBAP_FIELD_LOGO = 16384;
+
+  /// < vCard of Person Representing
+  static const int BT_PBAP_FIELD_AGENT = 32768;
+
+  /// < Name of Organization
+  static const int BT_PBAP_FIELD_ORG = 65536;
+
+  /// < Comments
+  static const int BT_PBAP_FIELD_NOTE = 131072;
+
+  /// < Revision
+  static const int BT_PBAP_FIELD_REV = 262144;
+
+  /// < Pronunciation of Name
+  static const int BT_PBAP_FIELD_SOUND = 524288;
+
+  /// < Uniform Resource Locator
+  static const int BT_PBAP_FIELD_URL = 1048576;
+
+  /// < Unique ID
+  static const int BT_PBAP_FIELD_UID = 2097152;
+
+  /// < Public Encryption Key
+  static const int BT_PBAP_FIELD_KEY = 4194304;
+
+  /// < Nickname
+  static const int BT_PBAP_FIELD_NICKNAME = 8388608;
+
+  /// < Categories
+  static const int BT_PBAP_FIELD_CATEGORIES = 16777216;
+
+  /// < Product ID
+  static const int BT_PBAP_FIELD_PROID = 33554432;
+
+  /// < Class information
+  static const int BT_PBAP_FIELD_CLASS = 67108864;
+
+  /// < String used for sorting operations
+  static const int BT_PBAP_FIELD_SORT_STRING = 134217728;
+
+  /// < Time stamp
+  static const int BT_PBAP_FIELD_X_IRMC_CALL_DATETIME = 268435456;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_MODULE
+/// @brief Enumerations of Bluetooth error codes.
+/// @since_tizen 2.3
+abstract class bt_error_e {
+  /// < Successful
+  static const int BT_ERROR_NONE = 0;
+
+  /// < Operation cancelled
+  static const int BT_ERROR_CANCELLED = -125;
+
+  /// < Invalid parameter
+  static const int BT_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int BT_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Device or resource busy
+  static const int BT_ERROR_RESOURCE_BUSY = -16;
+
+  /// < Timeout error
+  static const int BT_ERROR_TIMED_OUT = -1073741823;
+
+  /// < Operation now in progress
+  static const int BT_ERROR_NOW_IN_PROGRESS = -115;
+
+  /// < BT is Not Supported
+  static const int BT_ERROR_NOT_SUPPORTED = -1073741822;
+
+  /// < Permission denied
+  static const int BT_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Quota exceeded
+  static const int BT_ERROR_QUOTA_EXCEEDED = -122;
+
+  /// < No data available
+  static const int BT_ERROR_NO_DATA = -61;
+
+  /// < Device policy restriction (Since 3.0)
+  static const int BT_ERROR_DEVICE_POLICY_RESTRICTION = -1073741820;
+
+  /// < Local adapter not initialized
+  static const int BT_ERROR_NOT_INITIALIZED = -29359871;
+
+  /// < Local adapter not enabled
+  static const int BT_ERROR_NOT_ENABLED = -29359870;
+
+  /// < Operation already done
+  static const int BT_ERROR_ALREADY_DONE = -29359869;
+
+  /// < Operation failed
+  static const int BT_ERROR_OPERATION_FAILED = -29359868;
+
+  /// < Operation not in progress
+  static const int BT_ERROR_NOT_IN_PROGRESS = -29359867;
+
+  /// < Remote device not bonded
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_BONDED = -29359866;
+
+  /// < Authentication rejected
+  static const int BT_ERROR_AUTH_REJECTED = -29359865;
+
+  /// < Authentication failed
+  static const int BT_ERROR_AUTH_FAILED = -29359864;
+
+  /// < Remote device not found
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_FOUND = -29359863;
+
+  /// < Service search failed
+  static const int BT_ERROR_SERVICE_SEARCH_FAILED = -29359862;
+
+  /// < Remote device is not connected
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_CONNECTED = -29359861;
+
+  /// < Resource temporarily unavailable
+  static const int BT_ERROR_AGAIN = -29359860;
+
+  /// < Service Not Found
+  static const int BT_ERROR_SERVICE_NOT_FOUND = -29359859;
+
+  /// < Authorization rejected (Since 5.0)
+  static const int BT_ERROR_AUTHORIZATION_REJECTED = -29359858;
+
+  /// < Max of connection exceeded (Since 8.0)
+  static const int BT_ERROR_MAX_CONNECTION = -29359857;
+}
+
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
 /// @brief  Enumerations of the Bluetooth adapter state.
 /// @since_tizen 2.3
@@ -10783,6 +10964,201 @@ abstract class bt_adapter_visibility_mode_e {
   /// < Discoverable mode with time limit. After specific period,
   /// it is changed to #BT_ADAPTER_VISIBILITY_MODE_NON_DISCOVERABLE.
   static const int BT_ADAPTER_VISIBILITY_MODE_LIMITED_DISCOVERABLE = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief Enumerations of the discovery state of Bluetooth device.
+/// @since_tizen 2.3
+abstract class bt_adapter_device_discovery_state_e {
+  /// < Device discovery is started
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_STARTED = 0;
+
+  /// < Device discovery is finished
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_FINISHED = 1;
+
+  /// < The remote Bluetooth device is found
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_FOUND = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising state.
+/// @since_tizen 2.3
+abstract class bt_adapter_le_advertising_state_e {
+  /// < Bluetooth advertising is stopped
+  static const int BT_ADAPTER_LE_ADVERTISING_STOPPED = 0;
+
+  /// < Bluetooth advertising is started
+  static const int BT_ADAPTER_LE_ADVERTISING_STARTED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising mode.
+/// @since_tizen 2.3.1
+abstract class bt_adapter_le_advertising_mode_e {
+  /// < Balanced advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_BALANCED = 0;
+
+  /// < Low latency advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_LATENCY = 1;
+
+  /// < Low energy advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_ENERGY = 2;
+
+  /// < Custom mode to set advertising parameters
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_CUSTOM = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising filter policy.
+/// @since_tizen 2.3
+abstract class bt_adapter_le_advertising_filter_policy_e {
+  /// < White list is not in use
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_DEFAULT = 0;
+
+  /// < Allow the scan
+  /// request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_SCAN_WL = 1;
+
+  /// < Allow the connection
+  /// request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_CONN_WL = 2;
+
+  /// < Allow the
+  /// scan and connection request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_SCAN_CONN_WL = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief Enumerations of the Bluetooth LE advertising flags.
+/// @since_tizen 8.0
+abstract class bt_adapter_le_advertising_flags_e {
+  /// < LE Limited Discoverable Mode
+  static const int BT_ADAPTER_LE_ADVERTISING_FLAGS_LIM_DISC = 1;
+
+  /// < LE General Discoverable Mode
+  static const int BT_ADAPTER_LE_ADVERTISING_FLAGS_GEN_DISC = 2;
+
+  /// < BR/EDR Not Supported
+  static const int BT_ADAPTER_LE_ADVERTISING_FLAGS_BREDR_UNSUP = 4;
+
+  /// < Simultaneous LE and BR/EDR to Same Device Capable (Controller)
+  static const int BT_ADAPTER_LE_ADVERTISING_FLAGS_CONTROLLER = 8;
+
+  /// < Simultaneous LE and BR/EDR to Same Device Capable (Host)
+  static const int BT_ADAPTER_LE_ADVERTISING_FLAGS_SIM_HOST = 16;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth LE packet type.
+/// @since_tizen 2.3
+abstract class bt_adapter_le_packet_type_e {
+  /// < Advertising packet
+  static const int BT_ADAPTER_LE_PACKET_ADVERTISING = 0;
+
+  /// < Scan response packet
+  static const int BT_ADAPTER_LE_PACKET_SCAN_RESPONSE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth le scan mode.
+/// @since_tizen 3.0
+abstract class bt_adapter_le_scan_mode_e {
+  /// < Balanced mode of power consumption and connection latency
+  static const int BT_ADAPTER_LE_SCAN_MODE_BALANCED = 0;
+
+  /// < Low connection latency but high power consumption
+  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_LATENCY = 1;
+
+  /// < Low power consumption but high connection latency
+  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_ENERGY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device disconnect reason.
+/// @since_tizen 2.3
+abstract class bt_device_disconnect_reason_e {
+  /// < Disconnected by unknown reason
+  static const int BT_DEVICE_DISCONNECT_REASON_UNKNOWN = 0;
+
+  /// < Disconnected by timeout
+  static const int BT_DEVICE_DISCONNECT_REASON_TIMEOUT = 1;
+
+  /// < Disconnected by local host
+  static const int BT_DEVICE_DISCONNECT_REASON_LOCAL_HOST = 2;
+
+  /// < Disconnected by remote
+  static const int BT_DEVICE_DISCONNECT_REASON_REMOTE = 3;
+
+  /// < Disconnected by MIC failure (Since 9.0)
+  static const int BT_DEVICE_DISCONNECT_REASON_MIC_FAILURE = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of connection link type.
+/// @since_tizen 2.3
+abstract class bt_device_connection_link_type_e {
+  /// < BR/EDR link
+  static const int BT_DEVICE_CONNECTION_LINK_BREDR = 0;
+
+  /// < LE link
+  static const int BT_DEVICE_CONNECTION_LINK_LE = 1;
+
+  /// < The connection type default
+  static const int BT_DEVICE_CONNECTION_LINK_DEFAULT = 255;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device authorization state.
+/// @since_tizen 2.3
+abstract class bt_device_authorization_e {
+  /// < The remote Bluetooth device is authorized
+  static const int BT_DEVICE_AUTHORIZED = 0;
+
+  /// < The remote Bluetooth device is unauthorized
+  static const int BT_DEVICE_UNAUTHORIZED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of Bluetooth profile.
+/// @since_tizen 2.3
+abstract class bt_profile_e {
+  /// < RFCOMM Profile
+  static const int BT_PROFILE_RFCOMM = 1;
+
+  /// < Advanced Audio Distribution Profile Source role
+  static const int BT_PROFILE_A2DP = 2;
+
+  /// < Headset Profile
+  static const int BT_PROFILE_HSP = 4;
+
+  /// < Human Interface Device Profile
+  static const int BT_PROFILE_HID = 8;
+
+  /// < Network Access Point Profile
+  static const int BT_PROFILE_NAP = 16;
+
+  /// < Audio Gateway Profile
+  static const int BT_PROFILE_AG = 32;
+
+  /// < Generic Attribute Profile
+  static const int BT_PROFILE_GATT = 64;
+
+  /// < NAP server Profile
+  static const int BT_PROFILE_NAP_SERVER = 128;
+
+  /// < Advanced Audio Distribution Profile Sink role
+  static const int BT_PROFILE_A2DP_SINK = 256;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device address type.
+/// @since_tizen 2.3
+abstract class bt_device_address_type_e {
+  /// < Public address
+  static const int BT_DEVICE_PUBLIC_ADDRESS = 0;
+
+  /// < Random address
+  static const int BT_DEVICE_RANDOM_ADDRESS = 1;
 }
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
@@ -10868,88 +11244,36 @@ abstract class bt_service_class_t {
   static const int BT_SC_MAX = 16777216;
 }
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief  Called when you get bonded devices repeatedly.
-/// @since_tizen 2.3
-///
-/// @param[in] device_info The bonded device information
-/// @param[in] user_data The user data passed from the foreach function
-/// @return @c true to continue with the next iteration of the loop,
-/// \n @c false to break out of the loop.
-/// @pre bt_adapter_foreach_bonded_device() will invoke this function.
-///
-/// @see bt_adapter_foreach_bonded_device()
-typedef bt_adapter_bonded_device_cb
-    = ffi.Pointer<ffi.NativeFunction<bt_adapter_bonded_device_cbFunction>>;
-typedef bt_adapter_bonded_device_cbFunction = ffi.Bool Function(
-    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
-typedef Dartbt_adapter_bonded_device_cbFunction = bool Function(
-    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Device information structure used for identifying pear device.
+/// @brief  Enumerations of major service class.
 /// @since_tizen 2.3
-///
-/// @see #bt_class_s
-/// @see bt_device_bond_created_cb()
-final class bt_device_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
+abstract class bt_major_service_class_e {
+  /// < Limited discoverable mode
+  static const int BT_MAJOR_SERVICE_CLASS_LIMITED_DISCOVERABLE_MODE = 8192;
 
-  /// < The name of remote device
-  external ffi.Pointer<ffi.Char> remote_name;
+  /// < Positioning class
+  static const int BT_MAJOR_SERVICE_CLASS_POSITIONING = 65536;
 
-  /// < The Bluetooth classes
-  external bt_class_s bt_class;
+  /// < Networking class
+  static const int BT_MAJOR_SERVICE_CLASS_NETWORKING = 131072;
 
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+  /// < Rendering class
+  static const int BT_MAJOR_SERVICE_CLASS_RENDERING = 262144;
 
-  /// < The number of services
-  @ffi.Int()
-  external int service_count;
+  /// < Capturing class
+  static const int BT_MAJOR_SERVICE_CLASS_CAPTURING = 524288;
 
-  /// < The bonding state
-  @ffi.Bool()
-  external bool is_bonded;
+  /// < Object transferring class
+  static const int BT_MAJOR_SERVICE_CLASS_OBJECT_TRANSFER = 1048576;
 
-  /// < The connection state
-  @ffi.Bool()
-  external bool is_connected;
+  /// < Audio class
+  static const int BT_MAJOR_SERVICE_CLASS_AUDIO = 2097152;
 
-  /// < The authorization state
-  @ffi.Bool()
-  external bool is_authorized;
+  /// < Telephony class
+  static const int BT_MAJOR_SERVICE_CLASS_TELEPHONY = 4194304;
 
-  /// < manufacturer specific data length
-  @ffi.Int()
-  external int manufacturer_data_len;
-
-  /// < manufacturer specific data
-  external ffi.Pointer<ffi.Char> manufacturer_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Class structure of device and service.
-/// @since_tizen 2.3
-///
-/// @see #bt_device_info_s
-/// @see #bt_adapter_device_discovery_info_s
-/// @see bt_device_bond_created_cb()
-/// @see bt_adapter_device_discovery_state_changed_cb()
-final class bt_class_s extends ffi.Struct {
-  /// < Major device class.
-  @ffi.Int32()
-  external int major_device_class;
-
-  /// < Minor device class.
-  @ffi.Int32()
-  external int minor_device_class;
-
-  /// < Major service class mask.
-  /// This value can be a combination of #bt_major_service_class_e like #BT_MAJOR_SERVICE_CLASS_RENDERING | #BT_MAJOR_SERVICE_CLASS_AUDIO
-  @ffi.Int()
-  external int major_service_class_mask;
+  /// < Information class
+  static const int BT_MAJOR_SERVICE_CLASS_INFORMATION = 8388608;
 }
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
@@ -11250,6 +11574,1026 @@ abstract class bt_minor_device_class_e {
   static const int BT_MINOR_DEVICE_CLASS_HEALTH_ANKLE_PROSTHESIS = 52;
 }
 
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief  Enumerations of gap appearance type.
+/// @since_tizen 2.3
+abstract class bt_appearance_type_e {
+  /// < Unknown appearance type
+  static const int BT_APPEARANCE_TYPE_UNKNOWN = 0;
+
+  /// < Generic Phone type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_PHONE = 64;
+
+  /// < Generic Computer type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_COMPUTER = 128;
+
+  /// < Generic Watch type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_WATCH = 192;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief  Enumerations of the Bluetooth device's LE connection mode.
+/// @since_tizen 3.0
+abstract class bt_device_le_connection_mode_e {
+  /// < Balanced mode of power consumption and connection latency
+  static const int BT_DEVICE_LE_CONNECTION_MODE_BALANCED = 0;
+
+  /// < Low connection latency but high power consumption
+  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_LATENCY = 1;
+
+  /// < Low power consumption but high connection latency
+  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_ENERGY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief  Enumerations of connected Bluetooth device event role.
+/// @since_tizen 2.3
+abstract class bt_socket_role_e {
+  /// < Unknown role
+  static const int BT_SOCKET_UNKNOWN = 0;
+
+  /// < Server role
+  static const int BT_SOCKET_SERVER = 1;
+
+  /// < Client role
+  static const int BT_SOCKET_CLIENT = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief  Enumerations of Bluetooth socket connection state.
+/// @since_tizen 2.3
+abstract class bt_socket_connection_state_e {
+  /// < RFCOMM is connected
+  static const int BT_SOCKET_CONNECTED = 0;
+
+  /// < RFCOMM is disconnected
+  static const int BT_SOCKET_DISCONNECTED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
+/// @brief  Enumerations for the types of profiles related with audio.
+/// @since_tizen 2.3
+abstract class bt_audio_profile_type_e {
+  /// < All supported profiles related with audio (Both Host and Device role)
+  static const int BT_AUDIO_PROFILE_TYPE_ALL = 0;
+
+  /// < local device AG and remote device HF Client (Host role, ex: mobile)
+  static const int BT_AUDIO_PROFILE_TYPE_HSP_HFP = 1;
+
+  /// < A2DP Source Connection, remote device is A2DP Sink (Host role, ex: mobile)
+  static const int BT_AUDIO_PROFILE_TYPE_A2DP = 2;
+
+  /// < local device HF Client and remote device AG (Device role, ex: headset)
+  static const int BT_AUDIO_PROFILE_TYPE_AG = 3;
+
+  /// < A2DP Sink Connection, remote device is A2DP Source (Device role, ex: headset)
+  static const int BT_AUDIO_PROFILE_TYPE_A2DP_SINK = 4;
+}
+
+/// @internal
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_AG_MODULE
+/// @brief  Enumerations for the call handling event.
+/// @since_tizen 2.3
+abstract class bt_ag_call_handling_event_e {
+  /// < Request to answer an incoming call
+  static const int BT_AG_CALL_HANDLING_EVENT_ANSWER = 0;
+
+  /// < Request to release a call
+  static const int BT_AG_CALL_HANDLING_EVENT_RELEASE = 1;
+
+  /// < Request to reject an incoming call
+  static const int BT_AG_CALL_HANDLING_EVENT_REJECT = 2;
+}
+
+/// @internal
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_AG_MODULE
+/// @brief  Enumerations for the multi call handling event.
+/// @since_tizen 2.3
+abstract class bt_ag_multi_call_handling_event_e {
+  /// < Request to release held calls
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_RELEASE_HELD_CALLS = 0;
+
+  /// < Request to release active calls
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_RELEASE_ACTIVE_CALLS = 1;
+
+  /// < Request to put active calls into hold state and activate another (held or waiting) call
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_ACTIVATE_HELD_CALL = 2;
+
+  /// < Request to add a held call to the conversation
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_MERGE_CALLS = 3;
+
+  /// < Request to let a user who has two calls to connect these two calls together and release its connections to both other parties
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_EXPLICIT_CALL_TRANSFER = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the equalizer state.
+/// @since_tizen 2.4
+abstract class bt_avrcp_equalizer_state_e {
+  /// < Equalizer Off
+  static const int BT_AVRCP_EQUALIZER_STATE_OFF = 1;
+
+  /// < Equalizer On
+  static const int BT_AVRCP_EQUALIZER_STATE_ON = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the repeat mode.
+/// @since_tizen 2.4
+abstract class bt_avrcp_repeat_mode_e {
+  /// < Repeat Off
+  static const int BT_AVRCP_REPEAT_MODE_OFF = 1;
+
+  /// < Single track repeat
+  static const int BT_AVRCP_REPEAT_MODE_SINGLE_TRACK = 2;
+
+  /// < All track repeat
+  static const int BT_AVRCP_REPEAT_MODE_ALL_TRACK = 3;
+
+  /// < Group repeat
+  static const int BT_AVRCP_REPEAT_MODE_GROUP = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the shuffle mode.
+/// @since_tizen 2.4
+abstract class bt_avrcp_shuffle_mode_e {
+  /// < Shuffle Off
+  static const int BT_AVRCP_SHUFFLE_MODE_OFF = 1;
+
+  /// < All tracks shuffle
+  static const int BT_AVRCP_SHUFFLE_MODE_ALL_TRACK = 2;
+
+  /// < Group shuffle
+  static const int BT_AVRCP_SHUFFLE_MODE_GROUP = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the scan mode.
+/// @since_tizen 2.4
+abstract class bt_avrcp_scan_mode_e {
+  /// < Scan Off
+  static const int BT_AVRCP_SCAN_MODE_OFF = 1;
+
+  /// < All tracks scan
+  static const int BT_AVRCP_SCAN_MODE_ALL_TRACK = 2;
+
+  /// < Group scan
+  static const int BT_AVRCP_SCAN_MODE_GROUP = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the player state.
+/// @since_tizen 3.0
+abstract class bt_avrcp_player_state_e {
+  /// < Stopped
+  static const int BT_AVRCP_PLAYER_STATE_STOPPED = 0;
+
+  /// < Playing
+  static const int BT_AVRCP_PLAYER_STATE_PLAYING = 1;
+
+  /// < Paused
+  static const int BT_AVRCP_PLAYER_STATE_PAUSED = 2;
+
+  /// < Seek Forward
+  static const int BT_AVRCP_PLAYER_STATE_FORWARD_SEEK = 3;
+
+  /// < Seek Rewind
+  static const int BT_AVRCP_PLAYER_STATE_REWIND_SEEK = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumeration for the player control commands.
+/// @since_tizen 3.0
+abstract class bt_avrcp_player_command_e {
+  /// < Play
+  static const int BT_AVRCP_CONTROL_PLAY = 1;
+
+  /// < Pause
+  static const int BT_AVRCP_CONTROL_PAUSE = 2;
+
+  /// < Stop
+  static const int BT_AVRCP_CONTROL_STOP = 3;
+
+  /// < Next Track
+  static const int BT_AVRCP_CONTROL_NEXT = 4;
+
+  /// < Previous track
+  static const int BT_AVRCP_CONTROL_PREVIOUS = 5;
+
+  /// < Fast Forward
+  static const int BT_AVRCP_CONTROL_FAST_FORWARD = 6;
+
+  /// < Rewind
+  static const int BT_AVRCP_CONTROL_REWIND = 7;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief Structure of Track metadata information.
+/// @since_tizen 3.0
+///
+/// @see #bt_class_s
+final class bt_avrcp_metadata_attributes_info_s extends ffi.Struct {
+  /// < Title
+  external ffi.Pointer<ffi.Char> title;
+
+  /// < Artist
+  external ffi.Pointer<ffi.Char> artist;
+
+  /// < Album name
+  external ffi.Pointer<ffi.Char> album;
+
+  /// < Album Genre
+  external ffi.Pointer<ffi.Char> genre;
+
+  /// < The total number of tracks
+  @ffi.UnsignedInt()
+  external int total_tracks;
+
+  /// < Track number
+  @ffi.UnsignedInt()
+  external int number;
+
+  /// < Duration
+  @ffi.UnsignedInt()
+  external int duration;
+}
+
+/// @deprecated Deprecated since 5.0.
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
+/// @brief  Enumerations for the data channel type.
+/// @since_tizen 2.3
+/// @remarks Deprecated, because of no usecase and supported devices.
+abstract class bt_hdp_channel_type_e {
+  /// < Reliable Data Channel
+  static const int BT_HDP_CHANNEL_TYPE_RELIABLE = 1;
+
+  /// < Streaming Data Channel
+  static const int BT_HDP_CHANNEL_TYPE_STREAMING = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the integer type for GATT handle's value.
+/// @since_tizen 2.3.1
+abstract class bt_data_type_int_e {
+  /// < 8 bit signed int type
+  static const int BT_DATA_TYPE_SINT8 = 0;
+
+  /// < 16 bit signed int type
+  static const int BT_DATA_TYPE_SINT16 = 1;
+
+  /// < 32 bit signed int type
+  static const int BT_DATA_TYPE_SINT32 = 2;
+
+  /// < 8 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT8 = 3;
+
+  /// < 16 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT16 = 4;
+
+  /// < 32 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT32 = 5;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the float type for GATT handle's value.
+/// @since_tizen 2.3.1
+abstract class bt_data_type_float_e {
+  /// < 32 bit float type
+  static const int BT_DATA_TYPE_FLOAT = 0;
+
+  /// < 16 bit float type
+  static const int BT_DATA_TYPE_SFLOAT = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the write type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_write_type_e {
+  /// < Write without response type
+  static const int BT_GATT_WRITE_TYPE_WRITE_NO_RESPONSE = 0;
+
+  /// < Write type
+  static const int BT_GATT_WRITE_TYPE_WRITE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the GATT handle's type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_type_e {
+  /// < GATT service type
+  static const int BT_GATT_TYPE_SERVICE = 1;
+
+  /// < GATT characteristic type
+  static const int BT_GATT_TYPE_CHARACTERISTIC = 2;
+
+  /// < GATT descriptor type
+  static const int BT_GATT_TYPE_DESCRIPTOR = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the service type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_service_type_e {
+  /// < GATT primary service type
+  static const int BT_GATT_SERVICE_TYPE_PRIMARY = 1;
+
+  /// < GATT secondary service type
+  static const int BT_GATT_SERVICE_TYPE_SECONDARY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the characteristic's property.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_property_e {
+  /// < Broadcast property
+  static const int BT_GATT_PROPERTY_BROADCAST = 1;
+
+  /// < Read property
+  static const int BT_GATT_PROPERTY_READ = 2;
+
+  /// < Write without response property
+  static const int BT_GATT_PROPERTY_WRITE_WITHOUT_RESPONSE = 4;
+
+  /// < Write property
+  static const int BT_GATT_PROPERTY_WRITE = 8;
+
+  /// < Notify property
+  static const int BT_GATT_PROPERTY_NOTIFY = 16;
+
+  /// < Indicate property
+  static const int BT_GATT_PROPERTY_INDICATE = 32;
+
+  /// < Authenticated signed writes property
+  static const int BT_GATT_PROPERTY_AUTHENTICATED_SIGNED_WRITES = 64;
+
+  /// < Extended properties
+  static const int BT_GATT_PROPERTY_EXTENDED_PROPERTIES = 128;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
+/// @brief  Enumerations of gatt server's service changing mode.
+/// @since_tizen 3.0
+abstract class bt_gatt_client_service_change_type_e {
+  /// < Service added
+  static const int BT_GATT_CLIENT_SERVICE_ADDED = 0;
+
+  /// < Service removed
+  static const int BT_GATT_CLIENT_SERVICE_REMOVED = 1;
+
+  /// < Resync is required (Since 6.5)
+  static const int BT_GATT_CLIENT_SERVICE_RESYNC = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the attribute's permission.
+/// @since_tizen 3.0
+abstract class bt_gatt_permission_e {
+  /// < Readable permission
+  static const int BT_GATT_PERMISSION_READ = 1;
+
+  /// < Writable permission
+  static const int BT_GATT_PERMISSION_WRITE = 2;
+
+  /// < Readable permission required encryption
+  static const int BT_GATT_PERMISSION_ENCRYPT_READ = 4;
+
+  /// < Writable permission required encryption
+  static const int BT_GATT_PERMISSION_ENCRYPT_WRITE = 8;
+
+  /// < Readable permission required encryption and authentication
+  static const int BT_GATT_PERMISSION_ENCRYPT_AUTHENTICATED_READ = 16;
+
+  /// < Writable permission required encryption and authentication
+  static const int BT_GATT_PERMISSION_ENCRYPT_AUTHENTICATED_WRITE = 32;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
+/// @brief  Enumerations of the remote device request types for attributes.
+/// @since_tizen 3.0
+abstract class bt_gatt_att_request_type_e {
+  /// < Read Requested
+  static const int BT_GATT_REQUEST_TYPE_READ = 0;
+
+  /// < Write Requested
+  static const int BT_GATT_REQUEST_TYPE_WRITE = 1;
+}
+
+/// @internal
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PAN_NAP_MODULE
+/// @brief  Enumerations for the types of PAN (Personal Area Networking) service.
+/// @since_tizen 2.3
+abstract class bt_panu_service_type_e {
+  /// < Network Access Point
+  static const int BT_PANU_SERVICE_TYPE_NAP = 0;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of address book location for PBAP.
+/// @since_tizen 3.0
+abstract class bt_pbap_address_book_source_e {
+  /// < Request for Addressbook from remote device
+  static const int BT_PBAP_SOURCE_DEVICE = 0;
+
+  /// < Request for address book from SIM
+  static const int BT_PBAP_SOURCE_SIM = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of folder type.
+/// @since_tizen 3.0
+abstract class bt_pbap_folder_type_e {
+  /// < Request for address book
+  static const int BT_PBAP_FOLDER_PHONE_BOOK = 0;
+
+  /// < Request for incoming calls
+  static const int BT_PBAP_FOLDER_INCOMING = 1;
+
+  /// < Request for outgoing calls
+  static const int BT_PBAP_FOLDER_OUTGOING = 2;
+
+  /// < Request for missed calls
+  static const int BT_PBAP_FOLDER_MISSED = 3;
+
+  /// < Request for combined calls
+  static const int BT_PBAP_FOLDER_COMBINED = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of phone book search fields.
+/// @since_tizen 3.0
+abstract class bt_pbap_search_field_e {
+  /// < Request for search by name (default)
+  static const int BT_PBAP_SEARCH_NAME = 0;
+
+  /// < Request for search by phone number
+  static const int BT_PBAP_SEARCH_NUMBER = 1;
+
+  /// < Request for search by sound
+  static const int BT_PBAP_SEARCH_SOUND = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of vCard Formats.
+/// @since_tizen 3.0
+abstract class bt_pbap_vcard_format_e {
+  /// < vCard format 2.1 (default)
+  static const int BT_PBAP_VCARD_FORMAT_VCARD21 = 0;
+
+  /// < vCard format 3.0
+  static const int BT_PBAP_VCARD_FORMAT_VCARD30 = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of sorting orders.
+/// @since_tizen 3.0
+abstract class bt_pbap_sort_order_e {
+  /// < Filter order indexed (default)
+  static const int BT_PBAP_ORDER_INDEXED = 0;
+
+  /// < Filter order alphanumeric
+  static const int BT_PBAP_ORDER_ALPHANUMERIC = 1;
+
+  /// < Filter order phonetic
+  static const int BT_PBAP_ORDER_PHONETIC = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Class structure of device and service.
+/// @since_tizen 2.3
+///
+/// @see #bt_device_info_s
+/// @see #bt_adapter_device_discovery_info_s
+/// @see bt_device_bond_created_cb()
+/// @see bt_adapter_device_discovery_state_changed_cb()
+final class bt_class_s extends ffi.Struct {
+  /// < Major device class.
+  @ffi.Int32()
+  external int major_device_class;
+
+  /// < Minor device class.
+  @ffi.Int32()
+  external int minor_device_class;
+
+  /// < Major service class mask.
+  /// This value can be a combination of #bt_major_service_class_e like #BT_MAJOR_SERVICE_CLASS_RENDERING | #BT_MAJOR_SERVICE_CLASS_AUDIO
+  @ffi.Int()
+  external int major_service_class_mask;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief Structure of device discovery information.
+/// @since_tizen 2.3
+///
+/// @see #bt_class_s
+/// @see bt_adapter_device_discovery_state_changed_cb()
+final class bt_adapter_device_discovery_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The name of remote device
+  external ffi.Pointer<ffi.Char> remote_name;
+
+  /// < The Bluetooth classes
+  external bt_class_s bt_class;
+
+  /// < The strength indicator of received signal
+  @ffi.Int()
+  external int rssi;
+
+  /// < The bonding state
+  @ffi.Bool()
+  external bool is_bonded;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services
+  @ffi.Int()
+  external int service_count;
+
+  /// < The Bluetooth appearance
+  @ffi.Int32()
+  external int appearance;
+
+  /// < manufacturer specific data length
+  @ffi.Int()
+  external int manufacturer_data_len;
+
+  /// < manufacturer specific data
+  external ffi.Pointer<ffi.Char> manufacturer_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief Structure of le scan result information.
+/// @since_tizen 2.3.1
+///
+/// @see bt_adapter_le_start_scan()
+final class bt_adapter_le_device_scan_result_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The address type of remote device
+  @ffi.Int32()
+  external int address_type;
+
+  /// < The strength indicator of received signal
+  @ffi.Int()
+  external int rssi;
+
+  /// < advertising indication data length
+  @ffi.Int()
+  external int adv_data_len;
+
+  /// < advertising indication data
+  external ffi.Pointer<ffi.Char> adv_data;
+
+  /// < scan response data length
+  @ffi.Int()
+  external int scan_data_len;
+
+  /// < scan response data
+  external ffi.Pointer<ffi.Char> scan_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief The structure for LE iBeacon scan result information.
+/// @since_tizen 4.0
+///
+/// @see bt_adapter_le_start_scan()
+final class bt_adapter_le_ibeacon_scan_result_info_s extends ffi.Struct {
+  /// < Company ID
+  @ffi.Int()
+  external int company_id;
+
+  /// < iBeacon type
+  @ffi.Int()
+  external int ibeacon_type;
+
+  /// < UUID
+  external ffi.Pointer<ffi.Char> uuid;
+
+  /// < Major ID
+  @ffi.Int()
+  external int major_id;
+
+  /// < Minor ID
+  @ffi.Int()
+  external int minor_id;
+
+  /// < Measured power
+  @ffi.Int()
+  external int measured_power;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief LE service data structure.
+/// @since_tizen 2.3.1
+///
+/// @see bt_adapter_le_get_scan_result_service_data()
+final class bt_adapter_le_service_data_s extends ffi.Struct {
+  /// < 16 bit UUID of the service data
+  external ffi.Pointer<ffi.Char> service_uuid;
+
+  /// < Service data
+  external ffi.Pointer<ffi.Char> service_data;
+
+  /// < Service data length
+  @ffi.Int()
+  external int service_data_len;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Device information structure used for identifying pear device.
+/// @since_tizen 2.3
+///
+/// @see #bt_class_s
+/// @see bt_device_bond_created_cb()
+final class bt_device_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The name of remote device
+  external ffi.Pointer<ffi.Char> remote_name;
+
+  /// < The Bluetooth classes
+  external bt_class_s bt_class;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services
+  @ffi.Int()
+  external int service_count;
+
+  /// < The bonding state
+  @ffi.Bool()
+  external bool is_bonded;
+
+  /// < The connection state
+  @ffi.Bool()
+  external bool is_connected;
+
+  /// < The authorization state
+  @ffi.Bool()
+  external bool is_authorized;
+
+  /// < manufacturer specific data length
+  @ffi.Int()
+  external int manufacturer_data_len;
+
+  /// < manufacturer specific data
+  external ffi.Pointer<ffi.Char> manufacturer_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Service Discovery Protocol (SDP) data structure.
+///
+/// @details This protocol is used for discovering available services or pear device,
+/// and finding one to connect with.
+///
+/// @since_tizen 2.3
+/// @see bt_device_service_searched_cb()
+final class bt_device_sdp_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services.
+  @ffi.Int()
+  external int service_count;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Device connection information structure.
+/// @since_tizen 2.3
+///
+/// @see bt_device_connection_state_changed_cb()
+final class bt_device_connection_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < Link type
+  @ffi.Int32()
+  external int link;
+
+  /// < Disconnection reason
+  @ffi.Int32()
+  external int disconn_reason;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief Rfcomm connection data used for exchanging data between Bluetooth devices.
+/// @since_tizen 2.3
+///
+/// @see bt_socket_connection_state_changed_cb()
+final class bt_socket_connection_s extends ffi.Struct {
+  /// < The file descriptor of connected socket
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The file descriptor of the server socket or -1 for client connection
+  @ffi.Int()
+  external int server_fd;
+
+  /// < The local device role in this connection
+  @ffi.Int32()
+  external int local_role;
+
+  /// < The remote device address
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The service UUId
+  external ffi.Pointer<ffi.Char> service_uuid;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief Structure of RFCOMM received data.
+/// @since_tizen 2.3
+///
+/// @remarks User can use standard linux functions for reading/writing \n
+/// data from/to sockets.
+///
+/// @see bt_socket_data_received_cb()
+final class bt_socket_received_data_s extends ffi.Struct {
+  /// < The socket fd
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The length of the received data
+  @ffi.Int()
+  external int data_size;
+
+  /// < The received data
+  external ffi.Pointer<ffi.Char> data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
+/// @brief Attribute protocol MTU change information structure.
+/// @since_tizen 4.0
+///
+/// @see bt_gatt_client_att_mtu_changed_cb()
+final class bt_gatt_client_att_mtu_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < MTU value
+  @ffi.UnsignedInt()
+  external int mtu;
+
+  /// < Request status
+  @ffi.UnsignedInt()
+  external int status;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID mouse's button.
+/// @since_tizen 3.0
+abstract class bt_hid_mouse_button_e {
+  /// <The mouse's none value
+  static const int BT_HID_MOUSE_BUTTON_NONE = 0;
+
+  /// <The mouse's left button value
+  static const int BT_HID_MOUSE_BUTTON_LEFT = 1;
+
+  /// <The mouse's right button value
+  static const int BT_HID_MOUSE_BUTTON_RIGHT = 2;
+
+  /// <The mouse's middle button value
+  static const int BT_HID_MOUSE_BUTTON_MIDDLE = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing the HID mouse event information.
+/// @since_tizen 3.0
+///
+/// @see bt_hid_device_send_mouse_event()
+final class bt_hid_mouse_data_s extends ffi.Struct {
+  /// < The button values, we can combine key's values when we pressed multiple mouse buttons
+  @ffi.Int()
+  external int buttons;
+
+  /// < The location's x value, -128 ~127
+  @ffi.Int()
+  external int axis_x;
+
+  /// < The location's y value, -128 ~127
+  @ffi.Int()
+  external int axis_y;
+
+  /// < The padding value, -128 ~127
+  @ffi.Int()
+  external int padding;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing the HID keyboard event information.
+/// @details If you want to know more detail values, refer to http://www.usb.org/developers/hidpage/ and see "HID Usage Tables"
+/// @since_tizen 3.0
+///
+/// @see bt_hid_device_send_key_event()
+final class bt_hid_key_data_s extends ffi.Struct {
+  /// < The modifier keys : such as shift, alt
+  @ffi.UnsignedChar()
+  external int modifier;
+
+  /// < The key value - currently pressed keys : Max 8 at once
+  @ffi.Array.multi([8])
+  external ffi.Array<ffi.UnsignedChar> key;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID header type.
+/// @since_tizen 3.0
+abstract class bt_hid_header_type_e {
+  /// < The Bluetooth HID header type: Handshake
+  static const int BT_HID_HEADER_HANDSHAKE = 0;
+
+  /// < The Bluetooth HID header type: HID control
+  static const int BT_HID_HEADER_HID_CONTROL = 1;
+
+  /// < The Bluetooth HID header type: Get report
+  static const int BT_HID_HEADER_GET_REPORT = 2;
+
+  /// < The Bluetooth HID header type: Set report
+  static const int BT_HID_HEADER_SET_REPORT = 3;
+
+  /// < The Bluetooth HID header type: Get protocol
+  static const int BT_HID_HEADER_GET_PROTOCOL = 4;
+
+  /// < The Bluetooth HID header type: Set protocol
+  static const int BT_HID_HEADER_SET_PROTOCOL = 5;
+
+  /// < The Bluetooth HID header type: Data
+  static const int BT_HID_HEADER_DATA = 6;
+
+  /// < The Bluetooth HID header type: Unknown
+  static const int BT_HID_HEADER_UNKNOWN = 7;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID parameter type.
+/// @since_tizen 3.0
+abstract class bt_hid_param_type_e {
+  /// < Parameter type: Input
+  static const int BT_HID_PARAM_DATA_RTYPE_INPUT = 0;
+
+  /// < Parameter type: Output
+  static const int BT_HID_PARAM_DATA_RTYPE_OUTPUT = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID handshake type.
+/// @since_tizen 3.0
+abstract class bt_hid_handshake_type_e {
+  /// < Handshake error code none
+  static const int BT_HID_HANDSHAKE_SUCCESSFUL = 0;
+
+  /// < Handshake error code Not Ready
+  static const int BT_HID_HANDSHAKE_NOT_READY = 1;
+
+  /// < Handshake error code send invalid report id
+  static const int BT_HID_HANDSHAKE_ERR_INVALID_REPORT_ID = 2;
+
+  /// < Handshake error code request unsupported request
+  static const int BT_HID_HANDSHAKE_ERR_UNSUPPORTED_REQUEST = 3;
+
+  /// < Handshake error code received invalid parameter
+  static const int BT_HID_HANDSHAKE_ERR_INVALID_PARAMETER = 4;
+
+  /// < unknown error
+  static const int BT_HID_HANDSHAKE_ERR_UNKNOWN = 14;
+
+  /// < Fatal error
+  static const int BT_HID_HANDSHAKE_ERR_FATAL = 15;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing data received from the HID Host.
+/// @since_tizen 3.0
+final class bt_hid_device_received_data_s extends ffi.Struct {
+  /// < The remote device's address
+  external ffi.Pointer<ffi.Char> address;
+
+  /// < The header type
+  @ffi.Int32()
+  external int header_type;
+
+  /// < The parameter type
+  @ffi.Int32()
+  external int param_type;
+
+  /// < The length of the received data
+  @ffi.Int()
+  external int data_size;
+
+  /// < The received data
+  external ffi.Pointer<ffi.Char> data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief The structure type containing vCard information.
+/// @since_tizen 3.0
+///
+/// @see bt_pbap_client_pull_vcard()
+final class bt_pbap_vcard_info_s extends ffi.Struct {
+  /// < The vcard index, used as a parameter for bt_pbap_client_pull_vcard()
+  @ffi.Int()
+  external int index;
+
+  /// < The contact name of the vCard
+  external ffi.Pointer<ffi.Char> contact_name;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief Enumeration for the scan filter type.
+/// @since_tizen 4.0
+/// @see bt_adapter_le_scan_filter_set_type()
+abstract class bt_adapter_le_scan_filter_type_e {
+  /// < iBeacon filter type
+  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_IBEACON = 0;
+
+  /// < Proximity UUID filter type
+  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_PROXIMITY_UUID = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief L2CAP CoC connection data used for exchanging data between Bluetooth devices.
+/// @since_tizen 7.0
+///
+/// @see bt_socket_l2cap_channel_connection_state_changed_cb()
+final class bt_socket_l2cap_le_connection_s extends ffi.Struct {
+  /// < The file descriptor of connected socket
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The file descriptor of the server socket or -1 for client connection
+  @ffi.Int()
+  external int server_fd;
+
+  /// < The local device role in this connection
+  @ffi.Int32()
+  external int local_role;
+
+  /// < The remote device address
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The psm of the connected socket
+  @ffi.Int()
+  external int psm;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_ADV_EXT_MODULE
+/// @brief Enumerations of the Bluetooth LE scan role.
+/// @since_tizen 8.0
+abstract class bt_adapter_le_scan_role_e {
+  /// < Scan all
+  static const int BT_ADAPTER_LE_SCAN_ALL = 0;
+
+  /// < Legacy scan only
+  static const int BT_ADAPTER_LE_SCAN_LEGACY_ONLY = 1;
+
+  /// < Extended scan only
+  static const int BT_ADAPTER_LE_SCAN_EXTENDED_ONLY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_ADV_EXT_MODULE
+/// @brief Enumerations of the Bluetooth LE phy.
+/// @since_tizen 8.0
+abstract class bt_adapter_le_phy_e {
+  /// < All phy
+  static const int BT_LE_ALL_PHY = 0;
+
+  /// < 1M phy
+  static const int BT_LE_1M_PHY = 1;
+
+  /// < 2M phy
+  static const int BT_LE_2M_PHY = 2;
+
+  /// < Coded phy
+  static const int BT_LE_CODED_PHY = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief  Called when you get bonded devices repeatedly.
+/// @since_tizen 2.3
+///
+/// @param[in] device_info The bonded device information
+/// @param[in] user_data The user data passed from the foreach function
+/// @return @c true to continue with the next iteration of the loop,
+/// \n @c false to break out of the loop.
+/// @pre bt_adapter_foreach_bonded_device() will invoke this function.
+///
+/// @see bt_adapter_foreach_bonded_device()
+typedef bt_adapter_bonded_device_cb
+    = ffi.Pointer<ffi.NativeFunction<bt_adapter_bonded_device_cbFunction>>;
+typedef bt_adapter_bonded_device_cbFunction = ffi.Bool Function(
+    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
+typedef Dartbt_adapter_bonded_device_cbFunction = bool Function(
+    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
+
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
 /// @brief  Called when the Bluetooth adapter state changes.
 /// @since_tizen 2.3
@@ -11357,80 +12701,6 @@ typedef Dartbt_adapter_device_discovery_state_changed_cbFunction
         ffi.Pointer<bt_adapter_device_discovery_info_s> discovery_info,
         ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief Enumerations of the discovery state of Bluetooth device.
-/// @since_tizen 2.3
-abstract class bt_adapter_device_discovery_state_e {
-  /// < Device discovery is started
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_STARTED = 0;
-
-  /// < Device discovery is finished
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_FINISHED = 1;
-
-  /// < The remote Bluetooth device is found
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_FOUND = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief Structure of device discovery information.
-/// @since_tizen 2.3
-///
-/// @see #bt_class_s
-/// @see bt_adapter_device_discovery_state_changed_cb()
-final class bt_adapter_device_discovery_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The name of remote device
-  external ffi.Pointer<ffi.Char> remote_name;
-
-  /// < The Bluetooth classes
-  external bt_class_s bt_class;
-
-  /// < The strength indicator of received signal
-  @ffi.Int()
-  external int rssi;
-
-  /// < The bonding state
-  @ffi.Bool()
-  external bool is_bonded;
-
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
-
-  /// < The number of services
-  @ffi.Int()
-  external int service_count;
-
-  /// < The Bluetooth appearance
-  @ffi.Int32()
-  external int appearance;
-
-  /// < manufacturer specific data length
-  @ffi.Int()
-  external int manufacturer_data_len;
-
-  /// < manufacturer specific data
-  external ffi.Pointer<ffi.Char> manufacturer_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief  Enumerations of gap appearance type.
-/// @since_tizen 2.3
-abstract class bt_appearance_type_e {
-  /// < Unknown appearance type
-  static const int BT_APPEARANCE_TYPE_UNKNOWN = 0;
-
-  /// < Generic Phone type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_PHONE = 64;
-
-  /// < Generic Computer type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_COMPUTER = 128;
-
-  /// < Generic Watch type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_WATCH = 192;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief  Called when the LE advertisement has been found.
 /// @since_tizen 2.3.1
@@ -11450,107 +12720,6 @@ typedef Dartbt_adapter_le_scan_result_cbFunction = void Function(
     int result,
     ffi.Pointer<bt_adapter_le_device_scan_result_info_s> info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief Structure of le scan result information.
-/// @since_tizen 2.3.1
-///
-/// @see bt_adapter_le_start_scan()
-final class bt_adapter_le_device_scan_result_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The address type of remote device
-  @ffi.Int32()
-  external int address_type;
-
-  /// < The strength indicator of received signal
-  @ffi.Int()
-  external int rssi;
-
-  /// < advertising indication data length
-  @ffi.Int()
-  external int adv_data_len;
-
-  /// < advertising indication data
-  external ffi.Pointer<ffi.Char> adv_data;
-
-  /// < scan response data length
-  @ffi.Int()
-  external int scan_data_len;
-
-  /// < scan response data
-  external ffi.Pointer<ffi.Char> scan_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device address type.
-/// @since_tizen 2.3
-abstract class bt_device_address_type_e {
-  /// < Public address
-  static const int BT_DEVICE_PUBLIC_ADDRESS = 0;
-
-  /// < Random address
-  static const int BT_DEVICE_RANDOM_ADDRESS = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth LE packet type.
-/// @since_tizen 2.3
-abstract class bt_adapter_le_packet_type_e {
-  /// < Advertising packet
-  static const int BT_ADAPTER_LE_PACKET_ADVERTISING = 0;
-
-  /// < Scan response packet
-  static const int BT_ADAPTER_LE_PACKET_SCAN_RESPONSE = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief LE service data structure.
-/// @since_tizen 2.3.1
-///
-/// @see bt_adapter_le_get_scan_result_service_data()
-final class bt_adapter_le_service_data_s extends ffi.Struct {
-  /// < 16 bit UUID of the service data
-  external ffi.Pointer<ffi.Char> service_uuid;
-
-  /// < Service data
-  external ffi.Pointer<ffi.Char> service_data;
-
-  /// < Service data length
-  @ffi.Int()
-  external int service_data_len;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief The structure for LE iBeacon scan result information.
-/// @since_tizen 4.0
-///
-/// @see bt_adapter_le_start_scan()
-final class bt_adapter_le_ibeacon_scan_result_info_s extends ffi.Struct {
-  /// < Company ID
-  @ffi.Int()
-  external int company_id;
-
-  /// < iBeacon type
-  @ffi.Int()
-  external int ibeacon_type;
-
-  /// < UUID
-  external ffi.Pointer<ffi.Char> uuid;
-
-  /// < Major ID
-  @ffi.Int()
-  external int major_id;
-
-  /// < Minor ID
-  @ffi.Int()
-  external int minor_id;
-
-  /// < Measured power
-  @ffi.Int()
-  external int measured_power;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief The handle to control Bluetooth LE advertising.
@@ -11621,59 +12790,6 @@ typedef Dartbt_adapter_le_advertising_state_changed_cbFunction = void Function(
     int adv_state,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth advertising state.
-/// @since_tizen 2.3
-abstract class bt_adapter_le_advertising_state_e {
-  /// < Bluetooth advertising is stopped
-  static const int BT_ADAPTER_LE_ADVERTISING_STOPPED = 0;
-
-  /// < Bluetooth advertising is started
-  static const int BT_ADAPTER_LE_ADVERTISING_STARTED = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth advertising mode.
-/// @since_tizen 2.3.1
-abstract class bt_adapter_le_advertising_mode_e {
-  /// < Balanced advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_BALANCED = 0;
-
-  /// < Low latency advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_LATENCY = 1;
-
-  /// < Low energy advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_ENERGY = 2;
-
-  /// < Custom mode to set advertising parameters
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_CUSTOM = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth le scan mode.
-/// @since_tizen 3.0
-abstract class bt_adapter_le_scan_mode_e {
-  /// < Balanced mode of power consumption and connection latency
-  static const int BT_ADAPTER_LE_SCAN_MODE_BALANCED = 0;
-
-  /// < Low connection latency but high power consumption
-  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_LATENCY = 1;
-
-  /// < Low power consumption but high connection latency
-  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_ENERGY = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device authorization state.
-/// @since_tizen 2.3
-abstract class bt_device_authorization_e {
-  /// < The remote Bluetooth device is authorized
-  static const int BT_DEVICE_AUTHORIZED = 0;
-
-  /// < The remote Bluetooth device is unauthorized
-  static const int BT_DEVICE_UNAUTHORIZED = 1;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief  Called when you get connected profiles repeatedly.
 /// @since_tizen 2.3
@@ -11690,52 +12806,6 @@ typedef bt_device_connected_profileFunction = ffi.Bool Function(
     ffi.Int32 profile, ffi.Pointer<ffi.Void> user_data);
 typedef Dartbt_device_connected_profileFunction = bool Function(
     int profile, ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of Bluetooth profile.
-/// @since_tizen 2.3
-abstract class bt_profile_e {
-  /// < RFCOMM Profile
-  static const int BT_PROFILE_RFCOMM = 1;
-
-  /// < Advanced Audio Distribution Profile Source role
-  static const int BT_PROFILE_A2DP = 2;
-
-  /// < Headset Profile
-  static const int BT_PROFILE_HSP = 4;
-
-  /// < Human Interface Device Profile
-  static const int BT_PROFILE_HID = 8;
-
-  /// < Network Access Point Profile
-  static const int BT_PROFILE_NAP = 16;
-
-  /// < Audio Gateway Profile
-  static const int BT_PROFILE_AG = 32;
-
-  /// < Generic Attribute Profile
-  static const int BT_PROFILE_GATT = 64;
-
-  /// < NAP server Profile
-  static const int BT_PROFILE_NAP_SERVER = 128;
-
-  /// < Advanced Audio Distribution Profile Sink role
-  static const int BT_PROFILE_A2DP_SINK = 256;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief  Enumerations of the Bluetooth device's LE connection mode.
-/// @since_tizen 3.0
-abstract class bt_device_le_connection_mode_e {
-  /// < Balanced mode of power consumption and connection latency
-  static const int BT_DEVICE_LE_CONNECTION_MODE_BALANCED = 0;
-
-  /// < Low connection latency but high power consumption
-  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_LATENCY = 1;
-
-  /// < Low power consumption but high connection latency
-  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_ENERGY = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief Called when the process of creating bond finishes.
@@ -11833,26 +12903,6 @@ typedef Dartbt_device_service_searched_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Service Discovery Protocol (SDP) data structure.
-///
-/// @details This protocol is used for discovering available services or pear device,
-/// and finding one to connect with.
-///
-/// @since_tizen 2.3
-/// @see bt_device_service_searched_cb()
-final class bt_device_sdp_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
-
-  /// < The number of services.
-  @ffi.Int()
-  external int service_count;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief  Called when the connection state is changed.
 /// @since_tizen 2.3
 ///
@@ -11871,58 +12921,6 @@ typedef Dartbt_device_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<bt_device_connection_info_s> conn_info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Device connection information structure.
-/// @since_tizen 2.3
-///
-/// @see bt_device_connection_state_changed_cb()
-final class bt_device_connection_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < Link type
-  @ffi.Int32()
-  external int link;
-
-  /// < Disconnection reason
-  @ffi.Int32()
-  external int disconn_reason;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of connection link type.
-/// @since_tizen 2.3
-abstract class bt_device_connection_link_type_e {
-  /// < BR/EDR link
-  static const int BT_DEVICE_CONNECTION_LINK_BREDR = 0;
-
-  /// < LE link
-  static const int BT_DEVICE_CONNECTION_LINK_LE = 1;
-
-  /// < The connection type default
-  static const int BT_DEVICE_CONNECTION_LINK_DEFAULT = 255;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device disconnect reason.
-/// @since_tizen 2.3
-abstract class bt_device_disconnect_reason_e {
-  /// < Disconnected by unknown reason
-  static const int BT_DEVICE_DISCONNECT_REASON_UNKNOWN = 0;
-
-  /// < Disconnected by timeout
-  static const int BT_DEVICE_DISCONNECT_REASON_TIMEOUT = 1;
-
-  /// < Disconnected by local host
-  static const int BT_DEVICE_DISCONNECT_REASON_LOCAL_HOST = 2;
-
-  /// < Disconnected by remote
-  static const int BT_DEVICE_DISCONNECT_REASON_REMOTE = 3;
-
-  /// < Disconnected by MIC failure (Since 9.0)
-  static const int BT_DEVICE_DISCONNECT_REASON_MIC_FAILURE = 4;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief Called when you receive data.
@@ -11945,27 +12943,6 @@ typedef bt_socket_data_received_cbFunction = ffi.Void Function(
 typedef Dartbt_socket_data_received_cbFunction = void Function(
     ffi.Pointer<bt_socket_received_data_s> data,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief Structure of RFCOMM received data.
-/// @since_tizen 2.3
-///
-/// @remarks User can use standard linux functions for reading/writing \n
-/// data from/to sockets.
-///
-/// @see bt_socket_data_received_cb()
-final class bt_socket_received_data_s extends ffi.Struct {
-  /// < The socket fd
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The length of the received data
-  @ffi.Int()
-  external int data_size;
-
-  /// < The received data
-  external ffi.Pointer<ffi.Char> data;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief  Called when a RFCOMM connection is requested.
@@ -12013,56 +12990,6 @@ typedef Dartbt_socket_connection_state_changed_cbFunction = void Function(
     int connection_state,
     ffi.Pointer<bt_socket_connection_s> connection,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief  Enumerations of Bluetooth socket connection state.
-/// @since_tizen 2.3
-abstract class bt_socket_connection_state_e {
-  /// < RFCOMM is connected
-  static const int BT_SOCKET_CONNECTED = 0;
-
-  /// < RFCOMM is disconnected
-  static const int BT_SOCKET_DISCONNECTED = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief Rfcomm connection data used for exchanging data between Bluetooth devices.
-/// @since_tizen 2.3
-///
-/// @see bt_socket_connection_state_changed_cb()
-final class bt_socket_connection_s extends ffi.Struct {
-  /// < The file descriptor of connected socket
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The file descriptor of the server socket or -1 for client connection
-  @ffi.Int()
-  external int server_fd;
-
-  /// < The local device role in this connection
-  @ffi.Int32()
-  external int local_role;
-
-  /// < The remote device address
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The service UUId
-  external ffi.Pointer<ffi.Char> service_uuid;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief  Enumerations of connected Bluetooth device event role.
-/// @since_tizen 2.3
-abstract class bt_socket_role_e {
-  /// < Unknown role
-  static const int BT_SOCKET_UNKNOWN = 0;
-
-  /// < Server role
-  static const int BT_SOCKET_SERVER = 1;
-
-  /// < Client role
-  static const int BT_SOCKET_CLIENT = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_OPP_SERVER_MODULE
 /// @brief  Called when an OPP connection is requested.
@@ -12234,45 +13161,6 @@ typedef Dartbt_hid_device_connection_state_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing the HID mouse event information.
-/// @since_tizen 3.0
-///
-/// @see bt_hid_device_send_mouse_event()
-final class bt_hid_mouse_data_s extends ffi.Struct {
-  /// < The button values, we can combine key's values when we pressed multiple mouse buttons
-  @ffi.Int()
-  external int buttons;
-
-  /// < The location's x value, -128 ~127
-  @ffi.Int()
-  external int axis_x;
-
-  /// < The location's y value, -128 ~127
-  @ffi.Int()
-  external int axis_y;
-
-  /// < The padding value, -128 ~127
-  @ffi.Int()
-  external int padding;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing the HID keyboard event information.
-/// @details If you want to know more detail values, refer to http://www.usb.org/developers/hidpage/ and see "HID Usage Tables"
-/// @since_tizen 3.0
-///
-/// @see bt_hid_device_send_key_event()
-final class bt_hid_key_data_s extends ffi.Struct {
-  /// < The modifier keys : such as shift, alt
-  @ffi.UnsignedChar()
-  external int modifier;
-
-  /// < The key value - currently pressed keys : Max 8 at once
-  @ffi.Array.multi([8])
-  external ffi.Array<ffi.UnsignedChar> key;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
 /// @brief  Called when the HID Device receives data from the HID Host.
 /// @details The following error codes can be delivered: \n
 /// #BT_ERROR_NONE \n
@@ -12290,89 +13178,6 @@ typedef bt_hid_device_data_received_cbFunction = ffi.Void Function(
 typedef Dartbt_hid_device_data_received_cbFunction = void Function(
     ffi.Pointer<bt_hid_device_received_data_s> data,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing data received from the HID Host.
-/// @since_tizen 3.0
-final class bt_hid_device_received_data_s extends ffi.Struct {
-  /// < The remote device's address
-  external ffi.Pointer<ffi.Char> address;
-
-  /// < The header type
-  @ffi.Int32()
-  external int header_type;
-
-  /// < The parameter type
-  @ffi.Int32()
-  external int param_type;
-
-  /// < The length of the received data
-  @ffi.Int()
-  external int data_size;
-
-  /// < The received data
-  external ffi.Pointer<ffi.Char> data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief Enumerations of the Bluetooth HID header type.
-/// @since_tizen 3.0
-abstract class bt_hid_header_type_e {
-  /// < The Bluetooth HID header type: Handshake
-  static const int BT_HID_HEADER_HANDSHAKE = 0;
-
-  /// < The Bluetooth HID header type: HID control
-  static const int BT_HID_HEADER_HID_CONTROL = 1;
-
-  /// < The Bluetooth HID header type: Get report
-  static const int BT_HID_HEADER_GET_REPORT = 2;
-
-  /// < The Bluetooth HID header type: Set report
-  static const int BT_HID_HEADER_SET_REPORT = 3;
-
-  /// < The Bluetooth HID header type: Get protocol
-  static const int BT_HID_HEADER_GET_PROTOCOL = 4;
-
-  /// < The Bluetooth HID header type: Set protocol
-  static const int BT_HID_HEADER_SET_PROTOCOL = 5;
-
-  /// < The Bluetooth HID header type: Data
-  static const int BT_HID_HEADER_DATA = 6;
-
-  /// < The Bluetooth HID header type: Unknown
-  static const int BT_HID_HEADER_UNKNOWN = 7;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief Enumerations of the Bluetooth HID parameter type.
-/// @since_tizen 3.0
-abstract class bt_hid_param_type_e {
-  /// < Parameter type: Input
-  static const int BT_HID_PARAM_DATA_RTYPE_INPUT = 0;
-
-  /// < Parameter type: Output
-  static const int BT_HID_PARAM_DATA_RTYPE_OUTPUT = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
-/// @brief  Enumerations for the types of profiles related with audio.
-/// @since_tizen 2.3
-abstract class bt_audio_profile_type_e {
-  /// < All supported profiles related with audio (Both Host and Device role)
-  static const int BT_AUDIO_PROFILE_TYPE_ALL = 0;
-
-  /// < local device AG and remote device HF Client (Host role, ex: mobile)
-  static const int BT_AUDIO_PROFILE_TYPE_HSP_HFP = 1;
-
-  /// < A2DP Source Connection, remote device is A2DP Sink (Host role, ex: mobile)
-  static const int BT_AUDIO_PROFILE_TYPE_A2DP = 2;
-
-  /// < local device HF Client and remote device AG (Device role, ex: headset)
-  static const int BT_AUDIO_PROFILE_TYPE_AG = 3;
-
-  /// < A2DP Sink Connection, remote device is A2DP Source (Device role, ex: headset)
-  static const int BT_AUDIO_PROFILE_TYPE_A2DP_SINK = 4;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
 /// @brief  Called when the connection state is changed.
@@ -12421,82 +13226,6 @@ typedef Dartbt_avrcp_target_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<ffi.Char> remote_address,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the equalizer state.
-/// @since_tizen 2.4
-abstract class bt_avrcp_equalizer_state_e {
-  /// < Equalizer Off
-  static const int BT_AVRCP_EQUALIZER_STATE_OFF = 1;
-
-  /// < Equalizer On
-  static const int BT_AVRCP_EQUALIZER_STATE_ON = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the repeat mode.
-/// @since_tizen 2.4
-abstract class bt_avrcp_repeat_mode_e {
-  /// < Repeat Off
-  static const int BT_AVRCP_REPEAT_MODE_OFF = 1;
-
-  /// < Single track repeat
-  static const int BT_AVRCP_REPEAT_MODE_SINGLE_TRACK = 2;
-
-  /// < All track repeat
-  static const int BT_AVRCP_REPEAT_MODE_ALL_TRACK = 3;
-
-  /// < Group repeat
-  static const int BT_AVRCP_REPEAT_MODE_GROUP = 4;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the shuffle mode.
-/// @since_tizen 2.4
-abstract class bt_avrcp_shuffle_mode_e {
-  /// < Shuffle Off
-  static const int BT_AVRCP_SHUFFLE_MODE_OFF = 1;
-
-  /// < All tracks shuffle
-  static const int BT_AVRCP_SHUFFLE_MODE_ALL_TRACK = 2;
-
-  /// < Group shuffle
-  static const int BT_AVRCP_SHUFFLE_MODE_GROUP = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the scan mode.
-/// @since_tizen 2.4
-abstract class bt_avrcp_scan_mode_e {
-  /// < Scan Off
-  static const int BT_AVRCP_SCAN_MODE_OFF = 1;
-
-  /// < All tracks scan
-  static const int BT_AVRCP_SCAN_MODE_ALL_TRACK = 2;
-
-  /// < Group scan
-  static const int BT_AVRCP_SCAN_MODE_GROUP = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the player state.
-/// @since_tizen 3.0
-abstract class bt_avrcp_player_state_e {
-  /// < Stopped
-  static const int BT_AVRCP_PLAYER_STATE_STOPPED = 0;
-
-  /// < Playing
-  static const int BT_AVRCP_PLAYER_STATE_PLAYING = 1;
-
-  /// < Paused
-  static const int BT_AVRCP_PLAYER_STATE_PAUSED = 2;
-
-  /// < Seek Forward
-  static const int BT_AVRCP_PLAYER_STATE_FORWARD_SEEK = 3;
-
-  /// < Seek Rewind
-  static const int BT_AVRCP_PLAYER_STATE_REWIND_SEEK = 4;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
 /// @brief  Called when the equalizer state is changed by the remote control device.
@@ -12603,37 +13332,6 @@ typedef Dartbt_avrcp_track_info_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief Structure of Track metadata information.
-/// @since_tizen 3.0
-///
-/// @see #bt_class_s
-final class bt_avrcp_metadata_attributes_info_s extends ffi.Struct {
-  /// < Title
-  external ffi.Pointer<ffi.Char> title;
-
-  /// < Artist
-  external ffi.Pointer<ffi.Char> artist;
-
-  /// < Album name
-  external ffi.Pointer<ffi.Char> album;
-
-  /// < Album Genre
-  external ffi.Pointer<ffi.Char> genre;
-
-  /// < The total number of tracks
-  @ffi.UnsignedInt()
-  external int total_tracks;
-
-  /// < Track number
-  @ffi.UnsignedInt()
-  external int number;
-
-  /// < Duration
-  @ffi.UnsignedInt()
-  external int duration;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
 /// @brief  Called when the connection state is changed.
 /// @since_tizen 3.0
 /// @param[in] connected  The state to be changed. true means connected state, Otherwise, false.
@@ -12649,32 +13347,6 @@ typedef bt_avrcp_control_connection_state_changed_cbFunction
 typedef Dartbt_avrcp_control_connection_state_changed_cbFunction
     = void Function(bool connected, ffi.Pointer<ffi.Char> remote_address,
         ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumeration for the player control commands.
-/// @since_tizen 3.0
-abstract class bt_avrcp_player_command_e {
-  /// < Play
-  static const int BT_AVRCP_CONTROL_PLAY = 1;
-
-  /// < Pause
-  static const int BT_AVRCP_CONTROL_PAUSE = 2;
-
-  /// < Stop
-  static const int BT_AVRCP_CONTROL_STOP = 3;
-
-  /// < Next Track
-  static const int BT_AVRCP_CONTROL_NEXT = 4;
-
-  /// < Previous track
-  static const int BT_AVRCP_CONTROL_PREVIOUS = 5;
-
-  /// < Fast Forward
-  static const int BT_AVRCP_CONTROL_FAST_FORWARD = 6;
-
-  /// < Rewind
-  static const int BT_AVRCP_CONTROL_REWIND = 7;
-}
 
 /// @deprecated Deprecated since 5.0.
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
@@ -12706,19 +13378,6 @@ typedef Dartbt_hdp_connected_cbFunction = void Function(
     int type,
     int channel,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @deprecated Deprecated since 5.0.
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
-/// @brief  Enumerations for the data channel type.
-/// @since_tizen 2.3
-/// @remarks Deprecated, because of no usecase and supported devices.
-abstract class bt_hdp_channel_type_e {
-  /// < Reliable Data Channel
-  static const int BT_HDP_CHANNEL_TYPE_RELIABLE = 1;
-
-  /// < Streaming Data Channel
-  static const int BT_HDP_CHANNEL_TYPE_STREAMING = 2;
-}
 
 /// @deprecated Deprecated since 5.0.
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
@@ -12772,54 +13431,6 @@ typedef Dartbt_hdp_data_received_cbFunction = void Function(int channel,
 /// @since_tizen 2.3.1
 typedef bt_gatt_h = ffi.Pointer<ffi.Void>;
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the integer type for GATT handle's value.
-/// @since_tizen 2.3.1
-abstract class bt_data_type_int_e {
-  /// < 8 bit signed int type
-  static const int BT_DATA_TYPE_SINT8 = 0;
-
-  /// < 16 bit signed int type
-  static const int BT_DATA_TYPE_SINT16 = 1;
-
-  /// < 32 bit signed int type
-  static const int BT_DATA_TYPE_SINT32 = 2;
-
-  /// < 8 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT8 = 3;
-
-  /// < 16 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT16 = 4;
-
-  /// < 32 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT32 = 5;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the float type for GATT handle's value.
-/// @since_tizen 2.3.1
-abstract class bt_data_type_float_e {
-  /// < 32 bit float type
-  static const int BT_DATA_TYPE_FLOAT = 0;
-
-  /// < 16 bit float type
-  static const int BT_DATA_TYPE_SFLOAT = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the GATT handle's type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_type_e {
-  /// < GATT service type
-  static const int BT_GATT_TYPE_SERVICE = 1;
-
-  /// < GATT characteristic type
-  static const int BT_GATT_TYPE_CHARACTERISTIC = 2;
-
-  /// < GATT descriptor type
-  static const int BT_GATT_TYPE_DESCRIPTOR = 3;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief The handle of a GATT client which is associated with a remote device.
 /// @since_tizen 2.3.1
@@ -12844,17 +13455,6 @@ typedef bt_gatt_foreach_cbFunction = ffi.Bool Function(ffi.Int total,
     ffi.Int index, bt_gatt_h gatt_handle, ffi.Pointer<ffi.Void> user_data);
 typedef Dartbt_gatt_foreach_cbFunction = bool Function(int total, int index,
     bt_gatt_h gatt_handle, ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the write type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_write_type_e {
-  /// < Write without response type
-  static const int BT_GATT_WRITE_TYPE_WRITE_NO_RESPONSE = 0;
-
-  /// < Write type
-  static const int BT_GATT_WRITE_TYPE_WRITE = 1;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief  Called when the client request(e.g. read / write) has been completed.
@@ -12895,24 +13495,6 @@ typedef Dartbt_gatt_client_att_mtu_changed_cbFunction = void Function(
     bt_gatt_client_h client,
     ffi.Pointer<bt_gatt_client_att_mtu_info_s> mtu_info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
-/// @brief Attribute protocol MTU change information structure.
-/// @since_tizen 4.0
-///
-/// @see bt_gatt_client_att_mtu_changed_cb()
-final class bt_gatt_client_att_mtu_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < MTU value
-  @ffi.UnsignedInt()
-  external int mtu;
-
-  /// < Request status
-  @ffi.UnsignedInt()
-  external int status;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief  Called when a value of a watched characteristic's GATT handle has been changed.
@@ -12959,20 +13541,6 @@ typedef Dartbt_gatt_client_service_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Char> service_uuid,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
-/// @brief  Enumerations of gatt server's service changing mode.
-/// @since_tizen 3.0
-abstract class bt_gatt_client_service_change_type_e {
-  /// < Service added
-  static const int BT_GATT_CLIENT_SERVICE_ADDED = 0;
-
-  /// < Service removed
-  static const int BT_GATT_CLIENT_SERVICE_REMOVED = 1;
-
-  /// < Resync is required (Since 6.5)
-  static const int BT_GATT_CLIENT_SERVICE_RESYNC = 2;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
 /// @brief Called when the connection state is changed.
 ///
@@ -13001,17 +13569,6 @@ typedef Dartbt_gatt_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<ffi.Char> remote_address,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the service type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_service_type_e {
-  /// < GATT primary service type
-  static const int BT_GATT_SERVICE_TYPE_PRIMARY = 1;
-
-  /// < GATT secondary service type
-  static const int BT_GATT_SERVICE_TYPE_SECONDARY = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
 /// @brief The handle of a GATT server.
@@ -13128,17 +13685,6 @@ typedef Dartbt_gatt_server_write_value_requested_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
-/// @brief  Enumerations of the remote device request types for attributes.
-/// @since_tizen 3.0
-abstract class bt_gatt_att_request_type_e {
-  /// < Read Requested
-  static const int BT_GATT_REQUEST_TYPE_READ = 0;
-
-  /// < Write Requested
-  static const int BT_GATT_REQUEST_TYPE_WRITE = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
 /// @brief  Called when the sending notification / indication is done.
 /// @since_tizen 3.0
 ///
@@ -13206,37 +13752,6 @@ typedef Dartbt_pbap_connection_state_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of address book location for PBAP.
-/// @since_tizen 3.0
-abstract class bt_pbap_address_book_source_e {
-  /// < Request for Addressbook from remote device
-  static const int BT_PBAP_SOURCE_DEVICE = 0;
-
-  /// < Request for address book from SIM
-  static const int BT_PBAP_SOURCE_SIM = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of folder type.
-/// @since_tizen 3.0
-abstract class bt_pbap_folder_type_e {
-  /// < Request for address book
-  static const int BT_PBAP_FOLDER_PHONE_BOOK = 0;
-
-  /// < Request for incoming calls
-  static const int BT_PBAP_FOLDER_INCOMING = 1;
-
-  /// < Request for outgoing calls
-  static const int BT_PBAP_FOLDER_OUTGOING = 2;
-
-  /// < Request for missed calls
-  static const int BT_PBAP_FOLDER_MISSED = 3;
-
-  /// < Request for combined calls
-  static const int BT_PBAP_FOLDER_COMBINED = 4;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
 /// @brief  Called when PBAP Phonebook size calculation completes.
 /// @details The following error codes can be delivered: \n
 /// #BT_ERROR_NONE \n
@@ -13262,31 +13777,6 @@ typedef Dartbt_pbap_phone_book_size_cbFunction = void Function(
     ffi.Pointer<ffi.Char> remote_address,
     int size,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of vCard Formats.
-/// @since_tizen 3.0
-abstract class bt_pbap_vcard_format_e {
-  /// < vCard format 2.1 (default)
-  static const int BT_PBAP_VCARD_FORMAT_VCARD21 = 0;
-
-  /// < vCard format 3.0
-  static const int BT_PBAP_VCARD_FORMAT_VCARD30 = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of sorting orders.
-/// @since_tizen 3.0
-abstract class bt_pbap_sort_order_e {
-  /// < Filter order indexed (default)
-  static const int BT_PBAP_ORDER_INDEXED = 0;
-
-  /// < Filter order alphanumeric
-  static const int BT_PBAP_ORDER_ALPHANUMERIC = 1;
-
-  /// < Filter order phonetic
-  static const int BT_PBAP_ORDER_PHONETIC = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
 /// @brief  Called when PBAP Phonebook Pull completes.
@@ -13346,50 +13836,10 @@ typedef Dartbt_pbap_list_vcards_cbFunction = void Function(
     int count,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief The structure type containing vCard information.
-/// @since_tizen 3.0
-///
-/// @see bt_pbap_client_pull_vcard()
-final class bt_pbap_vcard_info_s extends ffi.Struct {
-  /// < The vcard index, used as a parameter for bt_pbap_client_pull_vcard()
-  @ffi.Int()
-  external int index;
-
-  /// < The contact name of the vCard
-  external ffi.Pointer<ffi.Char> contact_name;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of phone book search fields.
-/// @since_tizen 3.0
-abstract class bt_pbap_search_field_e {
-  /// < Request for search by name (default)
-  static const int BT_PBAP_SEARCH_NAME = 0;
-
-  /// < Request for search by phone number
-  static const int BT_PBAP_SEARCH_NUMBER = 1;
-
-  /// < Request for search by sound
-  static const int BT_PBAP_SEARCH_SOUND = 2;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief The handle of a Bluetooth LE scan filter.
 /// @since_tizen 4.0
 typedef bt_scan_filter_h = ffi.Pointer<ffi.Void>;
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief Enumeration for the scan filter type.
-/// @since_tizen 4.0
-/// @see bt_adapter_le_scan_filter_set_type()
-abstract class bt_adapter_le_scan_filter_type_e {
-  /// < iBeacon filter type
-  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_IBEACON = 0;
-
-  /// < Proximity UUID filter type
-  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_PROXIMITY_UUID = 1;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief  Called when the l2cap channel socket connection state changes.
@@ -13421,32 +13871,6 @@ typedef Dartbt_socket_l2cap_channel_connection_state_changed_cbFunction
         ffi.Pointer<bt_socket_l2cap_le_connection_s> connection,
         ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief L2CAP CoC connection data used for exchanging data between Bluetooth devices.
-/// @since_tizen 7.0
-///
-/// @see bt_socket_l2cap_channel_connection_state_changed_cb()
-final class bt_socket_l2cap_le_connection_s extends ffi.Struct {
-  /// < The file descriptor of connected socket
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The file descriptor of the server socket or -1 for client connection
-  @ffi.Int()
-  external int server_fd;
-
-  /// < The local device role in this connection
-  @ffi.Int32()
-  external int local_role;
-
-  /// < The remote device address
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The psm of the connected socket
-  @ffi.Int()
-  external int psm;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_ADV_EXT_MODULE
 /// @brief Called when the LE advertisement has been found.
 /// @since_tizen 8.0
@@ -13469,34 +13893,3 @@ typedef Dartbt_adapter_le_new_scan_result_cbFunction = void Function(
 /// @brief The handle of a new scan result.
 /// @since_tizen 8.0
 typedef bt_new_scan_result_h = ffi.Pointer<ffi.Void>;
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_ADV_EXT_MODULE
-/// @brief Enumerations of the Bluetooth LE scan role.
-/// @since_tizen 8.0
-abstract class bt_adapter_le_scan_role_e {
-  /// < Scan all
-  static const int BT_ADAPTER_LE_SCAN_ALL = 0;
-
-  /// < Legacy scan only
-  static const int BT_ADAPTER_LE_SCAN_LEGACY_ONLY = 1;
-
-  /// < Extended scan only
-  static const int BT_ADAPTER_LE_SCAN_EXTENDED_ONLY = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_ADV_EXT_MODULE
-/// @brief Enumerations of the Bluetooth LE phy.
-/// @since_tizen 8.0
-abstract class bt_adapter_le_phy_e {
-  /// < All phy
-  static const int BT_LE_ALL_PHY = 0;
-
-  /// < 1M phy
-  static const int BT_LE_1M_PHY = 1;
-
-  /// < 2M phy
-  static const int BT_LE_2M_PHY = 2;
-
-  /// < Coded phy
-  static const int BT_LE_CODED_PHY = 3;
-}

--- a/lib/src/bindings/10.0/generated_bindings_capi_system_info.dart
+++ b/lib/src/bindings/10.0/generated_bindings_capi_system_info.dart
@@ -377,6 +377,38 @@ class Tizen100CapiSystemInfo {
           int Function(ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Int32>)>();
 }
 
+/// @brief Enumeration for system information error codes.
+abstract class system_info_error_e {
+  /// < Successful
+  static const int SYSTEM_INFO_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int SYSTEM_INFO_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int SYSTEM_INFO_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < An input/output error occurred when reading value from system
+  static const int SYSTEM_INFO_ERROR_IO_ERROR = -5;
+
+  /// < No permission to use the API
+  static const int SYSTEM_INFO_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Not supported parameter (Since 3.0)
+  static const int SYSTEM_INFO_ERROR_NOT_SUPPORTED = -1073741822;
+}
+
+/// @internal
+/// @brief It is not decided if it should be opened to public.
+abstract class system_info_type_e {
+  static const int SYSTEM_INFO_TYPE_MIN = 0;
+  static const int SYSTEM_INFO_BOOL = 0;
+  static const int SYSTEM_INFO_INT = 1;
+  static const int SYSTEM_INFO_DOUBLE = 2;
+  static const int SYSTEM_INFO_STRING = 3;
+  static const int SYSTEM_INFO_TYPE_MAX = 4;
+}
+
 /// @internal
 /// @brief Enumeration for system information key.
 abstract class system_info_key_e {
@@ -424,15 +456,4 @@ abstract class system_info_key_e {
 
   /// < @internal Indicates whether the device supports tethering
   static const int SYSTEM_INFO_KEY_TETHERING_SUPPORTED = 14;
-}
-
-/// @internal
-/// @brief It is not decided if it should be opened to public.
-abstract class system_info_type_e {
-  static const int SYSTEM_INFO_TYPE_MIN = 0;
-  static const int SYSTEM_INFO_BOOL = 0;
-  static const int SYSTEM_INFO_INT = 1;
-  static const int SYSTEM_INFO_DOUBLE = 2;
-  static const int SYSTEM_INFO_STRING = 3;
-  static const int SYSTEM_INFO_TYPE_MAX = 4;
 }

--- a/lib/src/bindings/10.0/generated_bindings_mv_barcode_detector.dart
+++ b/lib/src/bindings/10.0/generated_bindings_mv_barcode_detector.dart
@@ -83,6 +83,123 @@ class Tizen100MvBarcodeDetector {
           ffi.Pointer<ffi.Void>)>();
 }
 
+/// @brief Enumeration for supported barcode types.
+/// @details QR codes (versions 1 to 40) and set of 1D barcodes are supported
+///
+/// @since_tizen 2.4
+/// @remarks #MV_BARCODE_UNDEFINED is deprecated. Use #MV_BARCODE_UNKNOWN instead
+abstract class mv_barcode_type_e {
+  /// < 2D barcode - Quick Response code
+  static const int MV_BARCODE_QR = 0;
+
+  /// < 1D barcode - Universal Product Code with 12-digit
+  static const int MV_BARCODE_UPC_A = 1;
+
+  /// < 1D barcode - Universal Product Code with 6-digit
+  static const int MV_BARCODE_UPC_E = 2;
+
+  /// < 1D barcode - International Article Number with 8-digit
+  static const int MV_BARCODE_EAN_8 = 3;
+
+  /// < 1D barcode - International Article Number with 13-digit
+  static const int MV_BARCODE_EAN_13 = 4;
+
+  /// < 1D barcode - Code 128
+  static const int MV_BARCODE_CODE128 = 5;
+
+  /// < 1D barcode - Code 39
+  static const int MV_BARCODE_CODE39 = 6;
+
+  /// < 1D barcode - Interleaved Two of Five
+  static const int MV_BARCODE_I2_5 = 7;
+
+  /// < @deprecated Undefined (Deprecated since 6.0)
+  static const int MV_BARCODE_UNDEFINED = 8;
+
+  /// < 1D barcode - International Article Number with 2-digit(add-on) (since 6.0)
+  static const int MV_BARCODE_EAN_2 = 9;
+
+  /// < 1D barcode - International Article Number with 5-digit(add-on) (since 6.0)
+  static const int MV_BARCODE_EAN_5 = 10;
+
+  /// < 1D barcode - Code 93 (since 6.0)
+  static const int MV_BARCODE_CODE93 = 11;
+
+  /// < 1D barcode - CODABAR (since 6.0)
+  static const int MV_BARCODE_CODABAR = 12;
+
+  /// < 1D barcode - GS1 DATABAR (since 6.0)
+  static const int MV_BARCODE_DATABAR = 13;
+
+  /// < 1D barcode - GS1 DATABAR EXPAND(since 6.0)
+  static const int MV_BARCODE_DATABAR_EXPAND = 14;
+
+  /// < Unknown (since 6.0)
+  static const int MV_BARCODE_UNKNOWN = 100;
+}
+
+/// @brief Enumeration for supported QR code error correction level.
+///
+/// @since_tizen 2.4
+/// @remarks This is unavailable for 1D barcodes
+abstract class mv_barcode_qr_ecc_e {
+  /// < Recovery up to  7% losses
+  static const int MV_BARCODE_QR_ECC_LOW = 0;
+
+  /// < Recovery up to 15% losses
+  static const int MV_BARCODE_QR_ECC_MEDIUM = 1;
+
+  /// < Recovery up to 25% losses
+  static const int MV_BARCODE_QR_ECC_QUARTILE = 2;
+
+  /// < Recovery up to 30% losses
+  static const int MV_BARCODE_QR_ECC_HIGH = 3;
+
+  /// < Unavailable
+  static const int MV_BARCODE_QR_ECC_UNAVAILABLE = 4;
+}
+
+/// @brief Enumeration for supported QR code encoding mode.
+///
+/// @since_tizen 2.4
+/// @remarks This is unavailable for 1D barcodes
+abstract class mv_barcode_qr_mode_e {
+  /// < Numeric digits
+  static const int MV_BARCODE_QR_MODE_NUMERIC = 0;
+
+  /// < Alphanumeric characters
+  static const int MV_BARCODE_QR_MODE_ALPHANUMERIC = 1;
+
+  /// < Raw 8-bit bytes
+  static const int MV_BARCODE_QR_MODE_BYTE = 2;
+
+  /// < UTF-8 character encoding
+  static const int MV_BARCODE_QR_MODE_UTF8 = 3;
+
+  /// < Unavailable
+  static const int MV_BARCODE_QR_MODE_UNAVAILABLE = 4;
+}
+
+/// @brief Enumeration for supported image formats for the barcode generating.
+///
+/// @since_tizen 2.4
+abstract class mv_barcode_image_format_e {
+  /// < Unavailable image format
+  static const int MV_BARCODE_IMAGE_FORMAT_UNAVAILABLE = -1;
+
+  /// < BMP image format
+  static const int MV_BARCODE_IMAGE_FORMAT_BMP = 0;
+
+  /// < JPEG image format
+  static const int MV_BARCODE_IMAGE_FORMAT_JPG = 1;
+
+  /// < PNG image format
+  static const int MV_BARCODE_IMAGE_FORMAT_PNG = 2;
+
+  /// < The number of supported image format
+  static const int MV_BARCODE_IMAGE_FORMAT_NUM = 3;
+}
+
 /// @brief Enumeration to target attribute
 ///
 /// @since_tizen 2.4
@@ -152,61 +269,6 @@ typedef Dartmv_barcode_detected_cbFunction = void Function(
     ffi.Pointer<ffi.Int32> types,
     int number_of_barcodes,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for supported barcode types.
-/// @details QR codes (versions 1 to 40) and set of 1D barcodes are supported
-///
-/// @since_tizen 2.4
-/// @remarks #MV_BARCODE_UNDEFINED is deprecated. Use #MV_BARCODE_UNKNOWN instead
-abstract class mv_barcode_type_e {
-  /// < 2D barcode - Quick Response code
-  static const int MV_BARCODE_QR = 0;
-
-  /// < 1D barcode - Universal Product Code with 12-digit
-  static const int MV_BARCODE_UPC_A = 1;
-
-  /// < 1D barcode - Universal Product Code with 6-digit
-  static const int MV_BARCODE_UPC_E = 2;
-
-  /// < 1D barcode - International Article Number with 8-digit
-  static const int MV_BARCODE_EAN_8 = 3;
-
-  /// < 1D barcode - International Article Number with 13-digit
-  static const int MV_BARCODE_EAN_13 = 4;
-
-  /// < 1D barcode - Code 128
-  static const int MV_BARCODE_CODE128 = 5;
-
-  /// < 1D barcode - Code 39
-  static const int MV_BARCODE_CODE39 = 6;
-
-  /// < 1D barcode - Interleaved Two of Five
-  static const int MV_BARCODE_I2_5 = 7;
-
-  /// < @deprecated Undefined (Deprecated since 6.0)
-  static const int MV_BARCODE_UNDEFINED = 8;
-
-  /// < 1D barcode - International Article Number with 2-digit(add-on) (since 6.0)
-  static const int MV_BARCODE_EAN_2 = 9;
-
-  /// < 1D barcode - International Article Number with 5-digit(add-on) (since 6.0)
-  static const int MV_BARCODE_EAN_5 = 10;
-
-  /// < 1D barcode - Code 93 (since 6.0)
-  static const int MV_BARCODE_CODE93 = 11;
-
-  /// < 1D barcode - CODABAR (since 6.0)
-  static const int MV_BARCODE_CODABAR = 12;
-
-  /// < 1D barcode - GS1 DATABAR (since 6.0)
-  static const int MV_BARCODE_DATABAR = 13;
-
-  /// < 1D barcode - GS1 DATABAR EXPAND(since 6.0)
-  static const int MV_BARCODE_DATABAR_EXPAND = 14;
-
-  /// < Unknown (since 6.0)
-  static const int MV_BARCODE_UNKNOWN = 100;
-}
 
 const String MV_BARCODE_DETECT_ATTR_TARGET = 'MV_BARCODE_DETECT_ATTR_TARGET';
 

--- a/lib/src/bindings/10.0/generated_bindings_mv_barcode_generator.dart
+++ b/lib/src/bindings/10.0/generated_bindings_mv_barcode_generator.dart
@@ -279,7 +279,7 @@ abstract class _mv_barcode_type_e {
 ///
 /// @since_tizen 2.4
 /// @remarks This is unavailable for 1D barcodes
-abstract class mv_barcode_qr_mode_e {
+abstract class _mv_barcode_qr_mode_e {
   /// < Numeric digits
   static const int MV_BARCODE_QR_MODE_NUMERIC = 0;
 
@@ -300,7 +300,7 @@ abstract class mv_barcode_qr_mode_e {
 ///
 /// @since_tizen 2.4
 /// @remarks This is unavailable for 1D barcodes
-abstract class mv_barcode_qr_ecc_e {
+abstract class _mv_barcode_qr_ecc_e {
   /// < Recovery up to  7% losses
   static const int MV_BARCODE_QR_ECC_LOW = 0;
 
@@ -320,7 +320,7 @@ abstract class mv_barcode_qr_ecc_e {
 /// @brief Enumeration for supported image formats for the barcode generating.
 ///
 /// @since_tizen 2.4
-abstract class mv_barcode_image_format_e {
+abstract class _mv_barcode_image_format_e {
   /// < Unavailable image format
   static const int MV_BARCODE_IMAGE_FORMAT_UNAVAILABLE = -1;
 

--- a/lib/src/bindings/10.0/generated_bindings_mv_face.dart
+++ b/lib/src/bindings/10.0/generated_bindings_mv_face.dart
@@ -1121,6 +1121,55 @@ class Tizen100MvFace {
 }
 
 /// @deprecated Deprecated since 9.0
+/// @brief Enumeration for eyes state type.
+///
+/// @since_tizen 3.0
+///
+/// @see mv_face_eye_condition_recognize()
+abstract class mv_face_eye_condition_e {
+  /// < Eyes are open
+  static const int MV_FACE_EYES_OPEN = 0;
+
+  /// < Eyes are closed
+  static const int MV_FACE_EYES_CLOSED = 1;
+
+  /// < The eyes condition wasn't determined
+  static const int MV_FACE_EYES_NOT_FOUND = 2;
+}
+
+/// @deprecated Deprecated since 9.0
+/// @brief Enumeration for expression types can be determined for faces.
+///
+/// @since_tizen 3.0
+///
+/// @see mv_face_facial_expression_recognize()
+abstract class mv_face_facial_expression_e {
+  /// < Unknown face expression
+  static const int MV_FACE_UNKNOWN = 0;
+
+  /// < Face expression is neutral
+  static const int MV_FACE_NEUTRAL = 1;
+
+  /// < Face expression is smiling
+  static const int MV_FACE_SMILE = 2;
+
+  /// < Face expression is sadness
+  static const int MV_FACE_SADNESS = 3;
+
+  /// < Face expression is surprise
+  static const int MV_FACE_SURPRISE = 4;
+
+  /// < Face expression is anger
+  static const int MV_FACE_ANGER = 5;
+
+  /// < Face expression is fear
+  static const int MV_FACE_FEAR = 6;
+
+  /// < Face expression is disgust
+  static const int MV_FACE_DISGUST = 7;
+}
+
+/// @deprecated Deprecated since 9.0
 /// @brief Called when faces are detected for the @a source.
 /// @details This type callback can be invoked each time when
 /// mv_face_detect() is called to process the results of face
@@ -1338,23 +1387,6 @@ typedef Dartmv_face_eye_condition_recognized_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @deprecated Deprecated since 9.0
-/// @brief Enumeration for eyes state type.
-///
-/// @since_tizen 3.0
-///
-/// @see mv_face_eye_condition_recognize()
-abstract class mv_face_eye_condition_e {
-  /// < Eyes are open
-  static const int MV_FACE_EYES_OPEN = 0;
-
-  /// < Eyes are closed
-  static const int MV_FACE_EYES_CLOSED = 1;
-
-  /// < The eyes condition wasn't determined
-  static const int MV_FACE_EYES_NOT_FOUND = 2;
-}
-
-/// @deprecated Deprecated since 9.0
 /// @brief Called when facial expression is recognized.
 /// @details This type callback can be invoked each time when
 /// mv_face_facial_expression_recognize() is called for @a face_location to
@@ -1390,38 +1422,6 @@ typedef Dartmv_face_facial_expression_recognized_cbFunction = void Function(
     mv_common.mv_rectangle_s face_location,
     int facial_expression,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @deprecated Deprecated since 9.0
-/// @brief Enumeration for expression types can be determined for faces.
-///
-/// @since_tizen 3.0
-///
-/// @see mv_face_facial_expression_recognize()
-abstract class mv_face_facial_expression_e {
-  /// < Unknown face expression
-  static const int MV_FACE_UNKNOWN = 0;
-
-  /// < Face expression is neutral
-  static const int MV_FACE_NEUTRAL = 1;
-
-  /// < Face expression is smiling
-  static const int MV_FACE_SMILE = 2;
-
-  /// < Face expression is sadness
-  static const int MV_FACE_SADNESS = 3;
-
-  /// < Face expression is surprise
-  static const int MV_FACE_SURPRISE = 4;
-
-  /// < Face expression is anger
-  static const int MV_FACE_ANGER = 5;
-
-  /// < Face expression is fear
-  static const int MV_FACE_FEAR = 6;
-
-  /// < Face expression is disgust
-  static const int MV_FACE_DISGUST = 7;
-}
 
 const String MV_FACE_DETECTION_MODEL_FILE_PATH =
     'MV_FACE_DETECTION_MODEL_FILE_PATH';

--- a/lib/src/bindings/10.0/generated_bindings_mv_inference.dart
+++ b/lib/src/bindings/10.0/generated_bindings_mv_inference.dart
@@ -840,6 +840,172 @@ class Tizen100MvInference {
 }
 
 /// @deprecated Deprecated since 9.0
+/// @brief Enumeration for inference backend.
+/// #MV_INFERENCE_BACKEND_OPENCV An open source computer vision and machine learning
+/// software library.
+/// (https://opencv.org/about/)
+/// #MV_INFERENCE_BACKEND_TFLITE Google-introduced open source inference engine for embedded systems,
+/// which runs Tensorflow Lite model.
+/// (https://www.tensorflow.org/lite/guide/get_started)
+/// #MV_INFERENCE_BACKEND_ARMNN ARM-introduced open source inference engine for CPUs, GPUs and NPUs, which
+/// enables efficient translation of existing neural network frameworks
+/// such as TensorFlow, TensorFlow Lite and Caffes, allowing them to
+/// run efficiently without modification on Embedded hardware.
+/// (https://developer.arm.com/ip-products/processors/machine-learning/arm-nn)
+/// #MV_INFERENCE_BACKEND_MLAPI Samsung-introduced open source ML single API framework of NNStreamer, which
+/// runs various NN models via tensor filters of NNStreamer. (Deprecated since 7.0)
+/// (https://github.com/nnstreamer/nnstreamer)
+/// #MV_INFERENCE_BACKEND_ONE Samsung-introduced open source inference engine called On-device Neural Engine, which
+/// performs inference of a given NN model on various devices such as CPU, GPU, DSP and NPU.
+/// (https://github.com/Samsung/ONE)
+///
+/// @since_tizen 5.5
+///
+/// @see mv_inference_prepare()
+abstract class mv_inference_backend_type_e {
+  /// < None
+  static const int MV_INFERENCE_BACKEND_NONE = -1;
+
+  /// < OpenCV
+  static const int MV_INFERENCE_BACKEND_OPENCV = 0;
+
+  /// < TensorFlow-Lite
+  static const int MV_INFERENCE_BACKEND_TFLITE = 1;
+
+  /// < @deprecated ARMNN (Since 6.0) (Deprecated since 8.0)
+  static const int MV_INFERENCE_BACKEND_ARMNN = 2;
+
+  /// < @deprecated ML Single API of NNStreamer (Deprecated since 7.0)
+  static const int MV_INFERENCE_BACKEND_MLAPI = 3;
+
+  /// < On-device Neural Engine (Since 6.0)
+  static const int MV_INFERENCE_BACKEND_ONE = 4;
+
+  /// < NNTrainer (Since 7.0)
+  static const int MV_INFERENCE_BACKEND_NNTRAINER = 5;
+
+  /// < SNPE Engine (Since 7.0)
+  static const int MV_INFERENCE_BACKEND_SNPE = 6;
+
+  /// < @deprecated Backend MAX (Deprecated since 7.0)
+  static const int MV_INFERENCE_BACKEND_MAX = 7;
+}
+
+/// @deprecated Deprecated since 9.0
+/// @brief Enumeration for inference target.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_target_device_e {
+  /// < None
+  static const int MV_INFERENCE_TARGET_DEVICE_NONE = 0;
+
+  /// < CPU
+  static const int MV_INFERENCE_TARGET_DEVICE_CPU = 1;
+
+  /// < GPU
+  static const int MV_INFERENCE_TARGET_DEVICE_GPU = 2;
+
+  /// < CUSTOM
+  static const int MV_INFERENCE_TARGET_DEVICE_CUSTOM = 4;
+
+  /// < Target MAX
+  static const int MV_INFERENCE_TARGET_DEVICE_MAX = 8;
+}
+
+/// @deprecated Deprecated since 9.0
+/// @brief Enumeration for input data type.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_data_type_e {
+  /// < Data type of a given pre-trained model is float.
+  static const int MV_INFERENCE_DATA_FLOAT32 = 0;
+
+  /// < Data type of a given pre-trained model is unsigned char.
+  static const int MV_INFERENCE_DATA_UINT8 = 1;
+
+  /// < Data type of a given pre-trained model is signed char. (Since 10.0)
+  static const int MV_INFERENCE_DATA_INT8 = 2;
+}
+
+/// @deprecated Deprecated since 9.0
+/// @brief Enumeration for human pose landmark.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_human_pose_landmark_e {
+  /// < Head of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_HEAD = 1;
+
+  /// < Neck of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_NECK = 2;
+
+  /// < Thorax of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_THORAX = 3;
+
+  /// < Right shoulder of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_SHOULDER = 4;
+
+  /// < Right elbow of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_ELBOW = 5;
+
+  /// < Right wrist of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_WRIST = 6;
+
+  /// < Left shoulder of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_SHOULDER = 7;
+
+  /// < Left elbow of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_ELBOW = 8;
+
+  /// < Left wrist of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_WRIST = 9;
+
+  /// < Pelvis of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_PELVIS = 10;
+
+  /// < Right hip of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_HIP = 11;
+
+  /// < Right knee of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_KNEE = 12;
+
+  /// < Right ankle of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_ANKLE = 13;
+
+  /// < Left hip of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_HIP = 14;
+
+  /// < Left knee of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_KNEE = 15;
+
+  /// < Left ankle of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_ANKLE = 16;
+}
+
+/// @deprecated Deprecated since 9.0
+/// @brief Enumeration for human body parts.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_human_body_part_e {
+  /// < HEAD, NECK, and THORAX
+  static const int MV_INFERENCE_HUMAN_BODY_PART_HEAD = 1;
+
+  /// < RIGHT SHOULDER, ELBOW, and WRIST
+  static const int MV_INFERENCE_HUMAN_BODY_PART_ARM_RIGHT = 2;
+
+  /// < LEFT SHOULDER, ELBOW, and WRIST
+  static const int MV_INFERENCE_HUMAN_BODY_PART_ARM_LEFT = 4;
+
+  /// < THORAX, PELVIS, RIGHT HIP, and LEFT HIP
+  static const int MV_INFERENCE_HUMAN_BODY_PART_BODY = 8;
+
+  /// < RIGHT HIP, KNEE, and ANKLE
+  static const int MV_INFERENCE_HUMAN_BODY_PART_LEG_RIGHT = 16;
+
+  /// < LEFT HIP, KNEE, and ANKLE
+  static const int MV_INFERENCE_HUMAN_BODY_PART_LEG_LEFT = 32;
+}
+
+/// @deprecated Deprecated since 9.0
 /// @brief The inference handle.
 /// @details Contains information about location of
 /// detected landmarks for one or more poses.

--- a/lib/src/bindings/10.0/generated_bindings_mv_landmark_detection.dart
+++ b/lib/src/bindings/10.0/generated_bindings_mv_landmark_detection.dart
@@ -331,9 +331,320 @@ class Tizen100MvLandmarkDetection {
       _mv_facial_landmark_get_positionPtr.asFunction<
           int Function(mv_facial_landmark_h, int, ffi.Pointer<ffi.UnsignedInt>,
               ffi.Pointer<ffi.UnsignedInt>)>();
+
+  /// @brief Creates pose landmark object handle.
+  /// @details Use this function to create an pose landmark object handle.
+  /// After creation the handle has to be prepared with
+  /// mv_pose_landmark_prepare() function to prepare
+  /// a pose landmark object.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[out] handle    The handle to the pose landmark object to be created
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_INTERNAL Internal Error
+  ///
+  /// @post Release @a handle by using
+  /// mv_pose_landmark_destroy() function when it is not needed
+  /// anymore
+  ///
+  /// @code
+  /// #include <mv_pose_landmark.h>
+  /// ...
+  /// mv_pose_landmark_h handle = NULL;
+  /// mv_pose_landmark_create(&handle);
+  /// ...
+  /// mv_pose_landmark_destroy(handle);
+  /// @endcode
+  ///
+  /// @see mv_pose_landmark_destroy()
+  int mv_pose_landmark_create(
+    ffi.Pointer<mv_pose_landmark_h> handle,
+  ) {
+    return _mv_pose_landmark_create(
+      handle,
+    );
+  }
+
+  late final _mv_pose_landmark_createPtr = _lookup<
+          ffi
+          .NativeFunction<ffi.Int Function(ffi.Pointer<mv_pose_landmark_h>)>>(
+      'mv_pose_landmark_create');
+  late final _mv_pose_landmark_create = _mv_pose_landmark_createPtr
+      .asFunction<int Function(ffi.Pointer<mv_pose_landmark_h>)>();
+
+  /// @brief Destroys pose landmark handle and releases all its resources.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle    The handle to the pose landmark object to be destroyed.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  ///
+  /// @pre Create an pose landmark handle by using mv_pose_landmark_create()
+  ///
+  /// @see mv_pose_landmark_create()
+  int mv_pose_landmark_destroy(
+    mv_pose_landmark_h handle,
+  ) {
+    return _mv_pose_landmark_destroy(
+      handle,
+    );
+  }
+
+  late final _mv_pose_landmark_destroyPtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(mv_pose_landmark_h)>>(
+          'mv_pose_landmark_destroy');
+  late final _mv_pose_landmark_destroy = _mv_pose_landmark_destroyPtr
+      .asFunction<int Function(mv_pose_landmark_h)>();
+
+  /// @brief Configures the backend to the inference handle.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle         The handle to the inference
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_OUT_OF_MEMORY Out of memory
+  int mv_pose_landmark_configure(
+    mv_pose_landmark_h handle,
+  ) {
+    return _mv_pose_landmark_configure(
+      handle,
+    );
+  }
+
+  late final _mv_pose_landmark_configurePtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(mv_pose_landmark_h)>>(
+          'mv_pose_landmark_configure');
+  late final _mv_pose_landmark_configure = _mv_pose_landmark_configurePtr
+      .asFunction<int Function(mv_pose_landmark_h)>();
+
+  /// @brief Prepares inference.
+  /// @details Use this function to prepare inference based on
+  /// the configured network.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle         The handle to the inference
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_INVALID_DATA Invalid model data
+  /// @retval #MEDIA_VISION_ERROR_OUT_OF_MEMORY Out of memory
+  int mv_pose_landmark_prepare(
+    mv_pose_landmark_h handle,
+  ) {
+    return _mv_pose_landmark_prepare(
+      handle,
+    );
+  }
+
+  late final _mv_pose_landmark_preparePtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(mv_pose_landmark_h)>>(
+          'mv_pose_landmark_prepare');
+  late final _mv_pose_landmark_prepare = _mv_pose_landmark_preparePtr
+      .asFunction<int Function(mv_pose_landmark_h)>();
+
+  /// @brief Inferences with a given facial on the @a source.
+  /// @details Use this function to inference with a given source.
+  ///
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle         The handle to the pose landmark object.
+  /// @param[in] source         The handle to the source of the media.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED_FORMAT Source colorspace
+  /// isn't supported
+  /// @retval #MEDIA_VISION_ERROR_OUT_OF_MEMORY Out of memory
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an pose landmark handle by calling mv_pose_landmark_create()
+  /// @pre Prepare an inference by calling mv_pose_landmark_configure()
+  /// @pre Prepare an pose landmark by calling mv_pose_landmark_prepare()
+  ///
+  /// @par Inference Example
+  /// @snippet pose_landmark_sync.c PLD sync
+  int mv_pose_landmark_inference(
+    mv_pose_landmark_h handle,
+    mv_common.mv_source_h source,
+  ) {
+    return _mv_pose_landmark_inference(
+      handle,
+      source,
+    );
+  }
+
+  late final _mv_pose_landmark_inferencePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(mv_pose_landmark_h,
+              mv_common.mv_source_h)>>('mv_pose_landmark_inference');
+  late final _mv_pose_landmark_inference = _mv_pose_landmark_inferencePtr
+      .asFunction<int Function(mv_pose_landmark_h, mv_common.mv_source_h)>();
+
+  /// @brief Performs asynchronously the pose landmark inference on the @a source.
+  ///
+  /// @since_tizen 9.0
+  /// @remarks This function operates asynchronously, so it returns immediately upon invocation.
+  /// The inference results are inserted into the outgoing queue within the framework
+  /// in the order of processing, and the results can be obtained through mv_pose_landmark_get_result_count()
+  /// and mv_pose_landmark_get_position().
+  ///
+  /// @param[in] handle         The handle to the inference
+  /// @param[in] source         The handle to the source of the media
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED_FORMAT Source colorspace
+  /// isn't supported
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an inference handle by calling mv_pose_landmark_create()
+  /// @pre Prepare an inference by calling mv_pose_landmark_configure()
+  /// @pre Prepare an inference by calling mv_pose_landmark_prepare()
+  ///
+  /// @par Async Inference Example
+  /// @snippet pose_landmark_async.c PLD async
+  int mv_pose_landmark_inference_async(
+    mv_pose_landmark_h handle,
+    mv_common.mv_source_h source,
+  ) {
+    return _mv_pose_landmark_inference_async(
+      handle,
+      source,
+    );
+  }
+
+  late final _mv_pose_landmark_inference_asyncPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(mv_pose_landmark_h,
+              mv_common.mv_source_h)>>('mv_pose_landmark_inference_async');
+  late final _mv_pose_landmark_inference_async =
+      _mv_pose_landmark_inference_asyncPtr.asFunction<
+          int Function(mv_pose_landmark_h, mv_common.mv_source_h)>();
+
+  /// @brief Gets the result count to objects.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle         The handle to the inference
+  /// @param[out] frame_number  A frame number inferenced.
+  /// @param[out] result_cnt    A number of results.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an inference handle by calling mv_pose_landmark_create()
+  /// @pre Prepare an inference by calling mv_pose_landmark_configure()
+  /// @pre Prepare an inference by calling mv_pose_landmark_prepare()
+  /// @pre Request an inference by calling mv_pose_landmark_inference()
+  int mv_pose_landmark_get_result_count(
+    mv_pose_landmark_h handle,
+    ffi.Pointer<ffi.UnsignedLong> frame_number,
+    ffi.Pointer<ffi.UnsignedInt> result_cnt,
+  ) {
+    return _mv_pose_landmark_get_result_count(
+      handle,
+      frame_number,
+      result_cnt,
+    );
+  }
+
+  late final _mv_pose_landmark_get_result_countPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Int Function(
+                  mv_pose_landmark_h,
+                  ffi.Pointer<ffi.UnsignedLong>,
+                  ffi.Pointer<ffi.UnsignedInt>)>>(
+      'mv_pose_landmark_get_result_count');
+  late final _mv_pose_landmark_get_result_count =
+      _mv_pose_landmark_get_result_countPtr.asFunction<
+          int Function(mv_pose_landmark_h, ffi.Pointer<ffi.UnsignedLong>,
+              ffi.Pointer<ffi.UnsignedInt>)>();
+
+  /// @brief Gets the pose landmark position values to a given index.
+  ///
+  /// @since_tizen 9.0
+  /// @remarks pos_x and pos_y arrays are allocated internally by the framework and will remain valid
+  /// until the handle is released.
+  /// Please do not deallocate them directly, and if you want to use them after the handle is released,
+  /// please copy them to user memory and use the copy.
+  ///
+  /// This function operates differently depending on the inference request method.
+  /// - After mv_facial_landmark_inference() calls, this function returns facial landmark positions immediately.
+  /// - After mv_facial_landmark_inference_async() calls, this function can be blocked until the asynchronous inference request is completed
+  /// or the timeout occurs if no result within 3 seconds.
+  ///
+  /// Additionally, after calling the mv_facial_landmark_inference_async function, the function operates
+  /// in asynchronous mode until the handle is released.
+  ///
+  /// @param[in] handle               The handle to the inference
+  /// @param[in] index                A result index.
+  /// @param[out] pos_x               An array containing x-coordinate values.
+  /// @param[out] pos_y               An array containing y-coordinate values.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an inference handle by calling mv_pose_landmark_create()
+  /// @pre Prepare an inference by calling mv_pose_landmark_configure()
+  /// @pre Prepare an inference by calling mv_pose_landmark_prepare()
+  /// @pre Prepare an inference by calling mv_pose_landmark_inference()
+  /// @pre Get result count by calling mv_pose_landmark_get_result_count()
+  int mv_pose_landmark_get_position(
+    mv_pose_landmark_h handle,
+    int index,
+    ffi.Pointer<ffi.UnsignedInt> pos_x,
+    ffi.Pointer<ffi.UnsignedInt> pos_y,
+  ) {
+    return _mv_pose_landmark_get_position(
+      handle,
+      index,
+      pos_x,
+      pos_y,
+    );
+  }
+
+  late final _mv_pose_landmark_get_positionPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(
+              mv_pose_landmark_h,
+              ffi.UnsignedInt,
+              ffi.Pointer<ffi.UnsignedInt>,
+              ffi.Pointer<ffi.UnsignedInt>)>>('mv_pose_landmark_get_position');
+  late final _mv_pose_landmark_get_position =
+      _mv_pose_landmark_get_positionPtr.asFunction<
+          int Function(mv_pose_landmark_h, int, ffi.Pointer<ffi.UnsignedInt>,
+              ffi.Pointer<ffi.UnsignedInt>)>();
 }
 
 /// @brief The facial landmark object handle.
 ///
 /// @since_tizen 9.0
 typedef mv_facial_landmark_h = ffi.Pointer<ffi.Void>;
+
+/// @brief The pose landmark object handle.
+///
+/// @since_tizen 9.0
+typedef mv_pose_landmark_h = ffi.Pointer<ffi.Void>;

--- a/lib/src/bindings/10.0/generated_bindings_mv_object_detection.dart
+++ b/lib/src/bindings/10.0/generated_bindings_mv_object_detection.dart
@@ -25,6 +25,321 @@ class Tizen100MvObjectDetection {
           lookup)
       : _lookup = lookup;
 
+  /// @brief Creates a inference handle for face detection object.
+  /// @details Use this function to create a inference handle. After the creation
+  /// the face detection task has to be prepared with
+  /// mv_face_detection_prepare() function to prepare a network
+  /// for the inference.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @remarks The @a handle should be released using mv_face_detection_destroy().
+  ///
+  /// @param[out] handle    The handle to the inference to be created.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_INTERNAL Internal Error
+  ///
+  /// @code
+  /// #include <mv_face_detection.h>
+  /// ...
+  /// mv_face_detection_h handle = NULL;
+  /// mv_face_detection_create(&handle);
+  /// ...
+  /// mv_face_detection_destroy(handle);
+  /// @endcode
+  ///
+  /// @see mv_face_detection_destroy()
+  /// @see mv_face_detection_prepare()
+  int mv_face_detection_create(
+    ffi.Pointer<mv_face_detection_h> handle,
+  ) {
+    return _mv_face_detection_create(
+      handle,
+    );
+  }
+
+  late final _mv_face_detection_createPtr = _lookup<
+          ffi
+          .NativeFunction<ffi.Int Function(ffi.Pointer<mv_face_detection_h>)>>(
+      'mv_face_detection_create');
+  late final _mv_face_detection_create = _mv_face_detection_createPtr
+      .asFunction<int Function(ffi.Pointer<mv_face_detection_h>)>();
+
+  /// @brief Destroys inference handle and releases all its resources.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle    The handle to the inference to be destroyed.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  ///
+  /// @pre Create inference handle by using mv_face_detection_create()
+  ///
+  /// @see mv_face_detection_create()
+  int mv_face_detection_destroy(
+    mv_face_detection_h handle,
+  ) {
+    return _mv_face_detection_destroy(
+      handle,
+    );
+  }
+
+  late final _mv_face_detection_destroyPtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(mv_face_detection_h)>>(
+          'mv_face_detection_destroy');
+  late final _mv_face_detection_destroy = _mv_face_detection_destroyPtr
+      .asFunction<int Function(mv_face_detection_h)>();
+
+  /// @brief Configures the backend for the face detection inference.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle         The handle to the inference
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_INVALID_OPERATION Invalid operation
+  /// @retval #MEDIA_VISION_ERROR_OUT_OF_MEMORY Out of memory
+  ///
+  /// @pre Create an inference handle by calling mv_face_detection_create()
+  int mv_face_detection_configure(
+    mv_face_detection_h handle,
+  ) {
+    return _mv_face_detection_configure(
+      handle,
+    );
+  }
+
+  late final _mv_face_detection_configurePtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(mv_face_detection_h)>>(
+          'mv_face_detection_configure');
+  late final _mv_face_detection_configure = _mv_face_detection_configurePtr
+      .asFunction<int Function(mv_face_detection_h)>();
+
+  /// @brief Prepares the face detection inference.
+  /// @details Use this function to prepare the face detection inference based on
+  /// the configured network.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle         The handle to the inference.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_INVALID_DATA Invalid model data
+  /// @retval #MEDIA_VISION_ERROR_OUT_OF_MEMORY Out of memory
+  /// @retval #MEDIA_VISION_ERROR_INVALID_OPERATION Invalid operation
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED_FORMAT Not supported format
+  ///
+  /// @pre Prepare an inference by calling mv_face_detection_configure()
+  int mv_face_detection_prepare(
+    mv_face_detection_h handle,
+  ) {
+    return _mv_face_detection_prepare(
+      handle,
+    );
+  }
+
+  late final _mv_face_detection_preparePtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(mv_face_detection_h)>>(
+          'mv_face_detection_prepare');
+  late final _mv_face_detection_prepare = _mv_face_detection_preparePtr
+      .asFunction<int Function(mv_face_detection_h)>();
+
+  /// @brief Performs the face detection inference on the @a source.
+  ///
+  /// @since_tizen 9.0
+  /// @remarks This function is synchronous and may take considerable time to run.
+  ///
+  /// @param[in] handle          The handle to the inference
+  /// @param[in] source         The handle to the source of the media
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED_FORMAT Source colorspace
+  /// isn't supported
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an inference handle by calling mv_face_detection_create()
+  /// @pre Prepare an inference by calling mv_face_detection_configure()
+  /// @pre Prepare an inference by calling mv_face_detection_prepare()
+  ///
+  /// @par Inference Example
+  /// @snippet face_detection_sync.c FD sync
+  int mv_face_detection_inference(
+    mv_face_detection_h handle,
+    mv_common.mv_source_h source,
+  ) {
+    return _mv_face_detection_inference(
+      handle,
+      source,
+    );
+  }
+
+  late final _mv_face_detection_inferencePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(mv_face_detection_h,
+              mv_common.mv_source_h)>>('mv_face_detection_inference');
+  late final _mv_face_detection_inference = _mv_face_detection_inferencePtr
+      .asFunction<int Function(mv_face_detection_h, mv_common.mv_source_h)>();
+
+  /// @brief Performs asynchronously the face detection inference on the @a source.
+  ///
+  /// @since_tizen 9.0
+  /// @remarks This function operates asynchronously, so it returns immediately upon invocation.
+  /// The inference results are inserted into the outgoing queue within the framework
+  /// in the order of processing, and the results can be obtained through mv_face_detection_get_result_count()
+  /// and mv_face_detection_get_bound_box().
+  ///
+  /// @param[in] handle         The handle to the inference
+  /// @param[in] source         The handle to the source of the media
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED_FORMAT Source colorspace
+  /// isn't supported
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an inference handle by calling mv_face_detection_create()
+  /// @pre Prepare an inference by calling mv_face_detection_configure()
+  /// @pre Prepare an inference by calling mv_face_detection_prepare()
+  ///
+  /// @par Async Inference Example
+  /// @snippet face_detection_async.c FD async
+  int mv_face_detection_inference_async(
+    mv_face_detection_h handle,
+    mv_common.mv_source_h source,
+  ) {
+    return _mv_face_detection_inference_async(
+      handle,
+      source,
+    );
+  }
+
+  late final _mv_face_detection_inference_asyncPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(mv_face_detection_h,
+              mv_common.mv_source_h)>>('mv_face_detection_inference_async');
+  late final _mv_face_detection_inference_async =
+      _mv_face_detection_inference_asyncPtr.asFunction<
+          int Function(mv_face_detection_h, mv_common.mv_source_h)>();
+
+  /// @brief Gets the face detection inference result on the @a handle.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle          The handle to the inference
+  /// @param[out] frame_number   A frame number inferenced.
+  /// @param[out] result_cnt     A number of results.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an inference handle by calling mv_face_detection_create()
+  /// @pre Prepare an inference by calling mv_face_detection_configure()
+  /// @pre Prepare an inference by calling mv_face_detection_prepare()
+  /// @pre Request an inference by calling mv_face_detection_inference()
+  int mv_face_detection_get_result_count(
+    mv_face_detection_h handle,
+    ffi.Pointer<ffi.UnsignedLong> frame_number,
+    ffi.Pointer<ffi.UnsignedInt> result_cnt,
+  ) {
+    return _mv_face_detection_get_result_count(
+      handle,
+      frame_number,
+      result_cnt,
+    );
+  }
+
+  late final _mv_face_detection_get_result_countPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Int Function(
+                  mv_face_detection_h,
+                  ffi.Pointer<ffi.UnsignedLong>,
+                  ffi.Pointer<ffi.UnsignedInt>)>>(
+      'mv_face_detection_get_result_count');
+  late final _mv_face_detection_get_result_count =
+      _mv_face_detection_get_result_countPtr.asFunction<
+          int Function(mv_face_detection_h, ffi.Pointer<ffi.UnsignedLong>,
+              ffi.Pointer<ffi.UnsignedInt>)>();
+
+  /// @brief Gets a bound box to detected face region.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle              The handle to the inference
+  /// @param[in] index               A result index.
+  /// @param[out] left               An left position of bound box.
+  /// @param[out] top                An top position of bound box.
+  /// @param[out] right              An right position of bound box.
+  /// @param[out] bottom             An bottom position of bound box.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an inference handle by calling mv_face_detection_create()
+  /// @pre Prepare an inference by calling mv_face_detection_configure()
+  /// @pre Prepare an inference by calling mv_face_detection_prepare()
+  /// @pre Request an inference by calling mv_face_detection_inference()
+  /// @pre Get result count by calling mv_face_detection_get_result_count()
+  int mv_face_detection_get_bound_box(
+    mv_face_detection_h handle,
+    int index,
+    ffi.Pointer<ffi.Int> left,
+    ffi.Pointer<ffi.Int> top,
+    ffi.Pointer<ffi.Int> right,
+    ffi.Pointer<ffi.Int> bottom,
+  ) {
+    return _mv_face_detection_get_bound_box(
+      handle,
+      index,
+      left,
+      top,
+      right,
+      bottom,
+    );
+  }
+
+  late final _mv_face_detection_get_bound_boxPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(
+              mv_face_detection_h,
+              ffi.UnsignedInt,
+              ffi.Pointer<ffi.Int>,
+              ffi.Pointer<ffi.Int>,
+              ffi.Pointer<ffi.Int>,
+              ffi.Pointer<ffi.Int>)>>('mv_face_detection_get_bound_box');
+  late final _mv_face_detection_get_bound_box =
+      _mv_face_detection_get_bound_boxPtr.asFunction<
+          int Function(
+              mv_face_detection_h,
+              int,
+              ffi.Pointer<ffi.Int>,
+              ffi.Pointer<ffi.Int>,
+              ffi.Pointer<ffi.Int>,
+              ffi.Pointer<ffi.Int>)>();
+
   /// @brief Creates a inference handle for object detection object.
   /// @details Use this function to create a inference handle. After the creation
   /// the object detection 3d task has to be prepared with
@@ -335,6 +650,11 @@ class Tizen100MvObjectDetection {
               ffi.Pointer<ffi.Int>,
               ffi.Pointer<ffi.Int>)>();
 }
+
+/// @brief The face detection object handle.
+///
+/// @since_tizen 9.0
+typedef mv_face_detection_h = ffi.Pointer<ffi.Void>;
 
 /// @brief The object detection object handle.
 ///

--- a/lib/src/bindings/10.0/generated_bindings_tbm.dart
+++ b/lib/src/bindings/10.0/generated_bindings_tbm.dart
@@ -449,6 +449,8 @@ class Tizen100Tbm {
       _tbm_surface_get_formatPtr.asFunction<int Function(tbm_surface_h)>();
 }
 
+final class _tbm_surface extends ffi.Opaque {}
+
 /// @brief Enumeration for tbm_surface error type.
 /// @since_tizen 2.3
 abstract class tbm_surface_error_e {
@@ -544,11 +546,127 @@ typedef tbm_surface_plane_s = _tbm_surface_plane;
 /// @since_tizen 2.3
 typedef tbm_surface_h = ffi.Pointer<_tbm_surface>;
 
-final class _tbm_surface extends ffi.Opaque {}
-
 /// @brief Definition for the TBM surface information struct.
 /// @since_tizen 2.3
 typedef tbm_surface_info_s = _tbm_surface_info;
+
+const int TBM_FORMAT_C8 = 538982467;
+
+const int TBM_FORMAT_RGB332 = 943867730;
+
+const int TBM_FORMAT_BGR233 = 944916290;
+
+const int TBM_FORMAT_XRGB4444 = 842093144;
+
+const int TBM_FORMAT_XBGR4444 = 842089048;
+
+const int TBM_FORMAT_RGBX4444 = 842094674;
+
+const int TBM_FORMAT_BGRX4444 = 842094658;
+
+const int TBM_FORMAT_ARGB4444 = 842093121;
+
+const int TBM_FORMAT_ABGR4444 = 842089025;
+
+const int TBM_FORMAT_RGBA4444 = 842088786;
+
+const int TBM_FORMAT_BGRA4444 = 842088770;
+
+const int TBM_FORMAT_XRGB1555 = 892424792;
+
+const int TBM_FORMAT_XBGR1555 = 892420696;
+
+const int TBM_FORMAT_RGBX5551 = 892426322;
+
+const int TBM_FORMAT_BGRX5551 = 892426306;
+
+const int TBM_FORMAT_ARGB1555 = 892424769;
+
+const int TBM_FORMAT_ABGR1555 = 892420673;
+
+const int TBM_FORMAT_RGBA5551 = 892420434;
+
+const int TBM_FORMAT_BGRA5551 = 892420418;
+
+const int TBM_FORMAT_RGB565 = 909199186;
+
+const int TBM_FORMAT_BGR565 = 909199170;
+
+const int TBM_FORMAT_RGB888 = 875710290;
+
+const int TBM_FORMAT_BGR888 = 875710274;
+
+const int TBM_FORMAT_XRGB8888 = 875713112;
+
+const int TBM_FORMAT_XBGR8888 = 875709016;
+
+const int TBM_FORMAT_RGBX8888 = 875714642;
+
+const int TBM_FORMAT_BGRX8888 = 875714626;
+
+const int TBM_FORMAT_ARGB8888 = 875713089;
+
+const int TBM_FORMAT_ABGR8888 = 875708993;
+
+const int TBM_FORMAT_RGBA8888 = 875708754;
+
+const int TBM_FORMAT_BGRA8888 = 875708738;
+
+const int TBM_FORMAT_XRGB2101010 = 808669784;
+
+const int TBM_FORMAT_XBGR2101010 = 808665688;
+
+const int TBM_FORMAT_RGBX1010102 = 808671314;
+
+const int TBM_FORMAT_BGRX1010102 = 808671298;
+
+const int TBM_FORMAT_ARGB2101010 = 808669761;
+
+const int TBM_FORMAT_ABGR2101010 = 808665665;
+
+const int TBM_FORMAT_RGBA1010102 = 808665426;
+
+const int TBM_FORMAT_BGRA1010102 = 808665410;
+
+const int TBM_FORMAT_YUYV = 1448695129;
+
+const int TBM_FORMAT_YVYU = 1431918169;
+
+const int TBM_FORMAT_UYVY = 1498831189;
+
+const int TBM_FORMAT_VYUY = 1498765654;
+
+const int TBM_FORMAT_AYUV = 1448433985;
+
+const int TBM_FORMAT_NV12 = 842094158;
+
+const int TBM_FORMAT_NV21 = 825382478;
+
+const int TBM_FORMAT_NV16 = 909203022;
+
+const int TBM_FORMAT_NV61 = 825644622;
+
+const int TBM_FORMAT_YUV410 = 961959257;
+
+const int TBM_FORMAT_YVU410 = 961893977;
+
+const int TBM_FORMAT_YUV411 = 825316697;
+
+const int TBM_FORMAT_YVU411 = 825316953;
+
+const int TBM_FORMAT_YUV420 = 842093913;
+
+const int TBM_FORMAT_YVU420 = 842094169;
+
+const int TBM_FORMAT_YUV422 = 909202777;
+
+const int TBM_FORMAT_YVU422 = 909203033;
+
+const int TBM_FORMAT_YUV444 = 875713881;
+
+const int TBM_FORMAT_YVU444 = 875714137;
+
+const int TBM_FORMAT_NV12MT = 842091860;
 
 const int TBM_SURF_PLANE_MAX = 4;
 

--- a/lib/src/bindings/6.0/generated_bindings_capi_base_common.dart
+++ b/lib/src/bindings/6.0/generated_bindings_capi_base_common.dart
@@ -386,6 +386,8 @@ abstract class tizen_error_e {
   static const int TIZEN_ERROR_END_OF_COLLECTION = -1073741819;
 }
 
+const int NULL = 0;
+
 const int TIZEN_ERROR_MAX_PLATFORM_ERROR = 0;
 
 const int TIZEN_ERROR_MIN_PLATFORM_ERROR = -1073741824;

--- a/lib/src/bindings/6.0/generated_bindings_capi_geofence_manager.dart
+++ b/lib/src/bindings/6.0/generated_bindings_capi_geofence_manager.dart
@@ -1223,71 +1223,6 @@ class Tizen60CapiGeofenceManager {
       .asFunction<int Function(geofence_status_h, ffi.Pointer<ffi.Int>)>();
 }
 
-/// @brief The geofence manager handle.
-/// @since_tizen 2.4
-typedef geofence_manager_h = ffi.Pointer<geofence_manager_s>;
-
-final class geofence_manager_s extends ffi.Opaque {}
-
-/// @brief The geofence handle.
-/// @since_tizen 2.4
-typedef geofence_h = ffi.Pointer<geofence_s>;
-
-final class geofence_s extends ffi.Opaque {}
-
-/// @brief Called when a device enters or exits the given geofence.
-/// @since_tizen 2.4
-/// @param[in] geofence_id The specified geofence ID
-/// @param[in] state The geofence state
-/// @param[in] user_data The user data passed from callback registration function
-/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_state_changed_cb().
-/// @see geofence_state_e
-/// @see geofence_manager_start()
-/// @see geofence_manager_set_geofence_state_changed_cb()
-typedef geofence_state_changed_cb
-    = ffi.Pointer<ffi.NativeFunction<geofence_state_changed_cbFunction>>;
-typedef geofence_state_changed_cbFunction = ffi.Void Function(
-    ffi.Int geofence_id, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
-typedef Dartgeofence_state_changed_cbFunction = void Function(
-    int geofence_id, int state, ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the state of geofence manager.
-/// @since_tizen 2.4
-abstract class geofence_state_e {
-  /// < Uncertain state of geofence
-  static const int GEOFENCE_STATE_UNCERTAIN = 0;
-
-  /// < Geofence In state
-  static const int GEOFENCE_STATE_IN = 1;
-
-  /// < Geofence Out state
-  static const int GEOFENCE_STATE_OUT = 2;
-}
-
-/// @brief Called when the some event occurs in geofence and place such as add, update, etc..
-/// @details The events of public geofence is also received if there are public geofences.
-/// @since_tizen 2.4
-/// @remarks The value of place_id or geofence_id is -1 when the place ID or geofence ID is not assigned.
-/// @param[in] place_id The place ID
-/// @param[in] geofence_id The specified geofence ID
-/// @param[in] error The error code for the particular action
-/// @param[in] manage The result code for the particular place and geofence management
-/// @param[in] user_data The user data passed from callback registration function
-/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_event_cb()
-/// @see geofence_manage_e
-/// @see geofence_manager_start()
-/// @see geofence_manager_set_geofence_event_cb()
-typedef geofence_event_cb
-    = ffi.Pointer<ffi.NativeFunction<geofence_event_cbFunction>>;
-typedef geofence_event_cbFunction = ffi.Void Function(
-    ffi.Int place_id,
-    ffi.Int geofence_id,
-    ffi.Int32 error,
-    ffi.Int32 manage,
-    ffi.Pointer<ffi.Void> user_data);
-typedef Dartgeofence_event_cbFunction = void Function(int place_id,
-    int geofence_id, int error, int manage, ffi.Pointer<ffi.Void> user_data);
-
 /// @brief Enumeration for Geofence manager of error code.
 /// @since_tizen 2.4
 abstract class geofence_manager_error_e {
@@ -1334,57 +1269,18 @@ abstract class geofence_manager_error_e {
   static const int GEOFENCE_MANAGER_ERROR_GEOFENCE_ACCESS_DENIED = -46202871;
 }
 
-/// @brief Enumeration for geofence management events.
+/// @brief Enumeration for the state of geofence manager.
 /// @since_tizen 2.4
-abstract class geofence_manage_e {
-  /// < Geofence is added
-  static const int GEOFENCE_MANAGE_FENCE_ADDED = 0;
+abstract class geofence_state_e {
+  /// < Uncertain state of geofence
+  static const int GEOFENCE_STATE_UNCERTAIN = 0;
 
-  /// < Geofence is removed
-  static const int GEOFENCE_MANAGE_FENCE_REMOVED = 1;
+  /// < Geofence In state
+  static const int GEOFENCE_STATE_IN = 1;
 
-  /// < Geofencing is started
-  static const int GEOFENCE_MANAGE_FENCE_STARTED = 2;
-
-  /// < Geofencing is stopped
-  static const int GEOFENCE_MANAGE_FENCE_STOPPED = 3;
-
-  /// < Place is added
-  static const int GEOFENCE_MANAGE_PLACE_ADDED = 16;
-
-  /// < Place is removed
-  static const int GEOFENCE_MANAGE_PLACE_REMOVED = 17;
-
-  /// < Place is updated
-  static const int GEOFENCE_MANAGE_PLACE_UPDATED = 18;
-
-  /// < Setting for geofencing is enabled
-  static const int GEOFENCE_MANAGE_SETTING_ENABLED = 32;
-
-  /// < Setting for geofencing is disabled
-  static const int GEOFENCE_MANAGE_SETTING_DISABLED = 33;
+  /// < Geofence Out state
+  static const int GEOFENCE_STATE_OUT = 2;
 }
-
-/// @brief Called when a proximity state of device is changed.
-/// @since_tizen 3.0
-/// @param[in] geofence_id The specified geofence ID
-/// @param[in] state The proximity state
-/// @param[in] provider The proximity provider
-/// @param[in] user_data The user data passed from callback registration function
-/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_proximity_state_changed_cb().
-/// @see geofence_proximity_state_e
-/// @see geofence_proximity_provider_e
-/// @see geofence_manager_start()
-/// @see geofence_manager_set_geofence_proximity_state_changed_cb()
-typedef geofence_proximity_state_changed_cb = ffi
-    .Pointer<ffi.NativeFunction<geofence_proximity_state_changed_cbFunction>>;
-typedef geofence_proximity_state_changed_cbFunction = ffi.Void Function(
-    ffi.Int geofence_id,
-    ffi.Int32 state,
-    ffi.Int32 provider,
-    ffi.Pointer<ffi.Void> user_data);
-typedef Dartgeofence_proximity_state_changed_cbFunction = void Function(
-    int geofence_id, int state, int provider, ffi.Pointer<ffi.Void> user_data);
 
 /// @brief Enumeration for the state of proximity.
 /// @since_tizen 3.0
@@ -1420,6 +1316,125 @@ abstract class geofence_proximity_provider_e {
   /// < Proximity is specified by Sensor
   static const int GEOFENCE_PROXIMITY_PROVIDER_SENSOR = 4;
 }
+
+/// @brief Enumeration for geofence type.
+/// @since_tizen 2.4
+abstract class geofence_type_e {
+  /// < Geofence is specified by geospatial coordinate
+  static const int GEOFENCE_TYPE_GEOPOINT = 1;
+
+  /// < Geofence is specified by Wi-Fi access point
+  static const int GEOFENCE_TYPE_WIFI = 2;
+
+  /// < Geofence is specified by Bluetooth device
+  static const int GEOFENCE_TYPE_BT = 3;
+}
+
+/// @brief Enumeration for geofence management events.
+/// @since_tizen 2.4
+abstract class geofence_manage_e {
+  /// < Geofence is added
+  static const int GEOFENCE_MANAGE_FENCE_ADDED = 0;
+
+  /// < Geofence is removed
+  static const int GEOFENCE_MANAGE_FENCE_REMOVED = 1;
+
+  /// < Geofencing is started
+  static const int GEOFENCE_MANAGE_FENCE_STARTED = 2;
+
+  /// < Geofencing is stopped
+  static const int GEOFENCE_MANAGE_FENCE_STOPPED = 3;
+
+  /// < Place is added
+  static const int GEOFENCE_MANAGE_PLACE_ADDED = 16;
+
+  /// < Place is removed
+  static const int GEOFENCE_MANAGE_PLACE_REMOVED = 17;
+
+  /// < Place is updated
+  static const int GEOFENCE_MANAGE_PLACE_UPDATED = 18;
+
+  /// < Setting for geofencing is enabled
+  static const int GEOFENCE_MANAGE_SETTING_ENABLED = 32;
+
+  /// < Setting for geofencing is disabled
+  static const int GEOFENCE_MANAGE_SETTING_DISABLED = 33;
+}
+
+final class geofence_manager_s extends ffi.Opaque {}
+
+final class geofence_s extends ffi.Opaque {}
+
+final class geofence_status_s extends ffi.Opaque {}
+
+/// @brief The geofence manager handle.
+/// @since_tizen 2.4
+typedef geofence_manager_h = ffi.Pointer<geofence_manager_s>;
+
+/// @brief The geofence handle.
+/// @since_tizen 2.4
+typedef geofence_h = ffi.Pointer<geofence_s>;
+
+/// @brief Called when a device enters or exits the given geofence.
+/// @since_tizen 2.4
+/// @param[in] geofence_id The specified geofence ID
+/// @param[in] state The geofence state
+/// @param[in] user_data The user data passed from callback registration function
+/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_state_changed_cb().
+/// @see geofence_state_e
+/// @see geofence_manager_start()
+/// @see geofence_manager_set_geofence_state_changed_cb()
+typedef geofence_state_changed_cb
+    = ffi.Pointer<ffi.NativeFunction<geofence_state_changed_cbFunction>>;
+typedef geofence_state_changed_cbFunction = ffi.Void Function(
+    ffi.Int geofence_id, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
+typedef Dartgeofence_state_changed_cbFunction = void Function(
+    int geofence_id, int state, ffi.Pointer<ffi.Void> user_data);
+
+/// @brief Called when the some event occurs in geofence and place such as add, update, etc..
+/// @details The events of public geofence is also received if there are public geofences.
+/// @since_tizen 2.4
+/// @remarks The value of place_id or geofence_id is -1 when the place ID or geofence ID is not assigned.
+/// @param[in] place_id The place ID
+/// @param[in] geofence_id The specified geofence ID
+/// @param[in] error The error code for the particular action
+/// @param[in] manage The result code for the particular place and geofence management
+/// @param[in] user_data The user data passed from callback registration function
+/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_event_cb()
+/// @see geofence_manage_e
+/// @see geofence_manager_start()
+/// @see geofence_manager_set_geofence_event_cb()
+typedef geofence_event_cb
+    = ffi.Pointer<ffi.NativeFunction<geofence_event_cbFunction>>;
+typedef geofence_event_cbFunction = ffi.Void Function(
+    ffi.Int place_id,
+    ffi.Int geofence_id,
+    ffi.Int32 error,
+    ffi.Int32 manage,
+    ffi.Pointer<ffi.Void> user_data);
+typedef Dartgeofence_event_cbFunction = void Function(int place_id,
+    int geofence_id, int error, int manage, ffi.Pointer<ffi.Void> user_data);
+
+/// @brief Called when a proximity state of device is changed.
+/// @since_tizen 3.0
+/// @param[in] geofence_id The specified geofence ID
+/// @param[in] state The proximity state
+/// @param[in] provider The proximity provider
+/// @param[in] user_data The user data passed from callback registration function
+/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_proximity_state_changed_cb().
+/// @see geofence_proximity_state_e
+/// @see geofence_proximity_provider_e
+/// @see geofence_manager_start()
+/// @see geofence_manager_set_geofence_proximity_state_changed_cb()
+typedef geofence_proximity_state_changed_cb = ffi
+    .Pointer<ffi.NativeFunction<geofence_proximity_state_changed_cbFunction>>;
+typedef geofence_proximity_state_changed_cbFunction = ffi.Void Function(
+    ffi.Int geofence_id,
+    ffi.Int32 state,
+    ffi.Int32 provider,
+    ffi.Pointer<ffi.Void> user_data);
+typedef Dartgeofence_proximity_state_changed_cbFunction = void Function(
+    int geofence_id, int state, int provider, ffi.Pointer<ffi.Void> user_data);
 
 /// @brief Called when the fence list is requested.
 /// @since_tizen 2.4
@@ -1476,21 +1491,6 @@ typedef Dartgeofence_manager_place_cbFunction = bool Function(
     int place_cnt,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for geofence type.
-/// @since_tizen 2.4
-abstract class geofence_type_e {
-  /// < Geofence is specified by geospatial coordinate
-  static const int GEOFENCE_TYPE_GEOPOINT = 1;
-
-  /// < Geofence is specified by Wi-Fi access point
-  static const int GEOFENCE_TYPE_WIFI = 2;
-
-  /// < Geofence is specified by Bluetooth device
-  static const int GEOFENCE_TYPE_BT = 3;
-}
-
 /// @brief The geofence status handle.
 /// @since_tizen 2.4
 typedef geofence_status_h = ffi.Pointer<geofence_status_s>;
-
-final class geofence_status_s extends ffi.Opaque {}

--- a/lib/src/bindings/6.0/generated_bindings_capi_media_controller.dart
+++ b/lib/src/bindings/6.0/generated_bindings_capi_media_controller.dart
@@ -6781,6 +6781,461 @@ class Tizen60CapiMediaController {
       .asFunction<int Function(mc_server_h, ffi.Pointer<ffi.Char>)>();
 }
 
+/// @brief Enumeration for the media controller error.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_error_e {
+  /// < Successful
+  static const int MEDIA_CONTROLLER_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int MEDIA_CONTROLLER_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int MEDIA_CONTROLLER_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Invalid Operation
+  static const int MEDIA_CONTROLLER_ERROR_INVALID_OPERATION = -38;
+
+  /// < No space left on device
+  static const int MEDIA_CONTROLLER_ERROR_FILE_NO_SPACE_ON_DEVICE = -28;
+
+  /// < Permission denied
+  static const int MEDIA_CONTROLLER_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Limited by server application (since 5.5)
+  static const int MEDIA_CONTROLLER_ERROR_ABILITY_LIMITED_BY_SERVER_APP =
+      -50462719;
+}
+
+/// @brief Enumeration for the media controller server state.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_server_state_e {
+  /// < None state
+  static const int MC_SERVER_STATE_NONE = 0;
+
+  /// < Activate state
+  static const int MC_SERVER_STATE_ACTIVATE = 1;
+
+  /// < Deactivate state
+  static const int MC_SERVER_STATE_DEACTIVATE = 2;
+}
+
+/// @brief Enumeration for the media meta info.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_meta_e {
+  /// < Title
+  static const int MC_META_MEDIA_TITLE = 0;
+
+  /// < Artist
+  static const int MC_META_MEDIA_ARTIST = 1;
+
+  /// < Album
+  static const int MC_META_MEDIA_ALBUM = 2;
+
+  /// < Author
+  static const int MC_META_MEDIA_AUTHOR = 3;
+
+  /// < Genre
+  static const int MC_META_MEDIA_GENRE = 4;
+
+  /// < Duration
+  static const int MC_META_MEDIA_DURATION = 5;
+
+  /// < Date
+  static const int MC_META_MEDIA_DATE = 6;
+
+  /// < Copyright
+  static const int MC_META_MEDIA_COPYRIGHT = 7;
+
+  /// < Description
+  static const int MC_META_MEDIA_DESCRIPTION = 8;
+
+  /// < Track Number
+  static const int MC_META_MEDIA_TRACK_NUM = 9;
+
+  /// < Picture. Album Art
+  static const int MC_META_MEDIA_PICTURE = 10;
+
+  /// < Season (Since 5.5)
+  static const int MC_META_MEDIA_SEASON = 11;
+
+  /// < Episode (Since 5.5)
+  static const int MC_META_MEDIA_EPISODE = 12;
+
+  /// < Content resolution (Since 5.5)
+  static const int MC_META_MEDIA_RESOLUTION = 13;
+}
+
+/// @brief Enumeration for the media playback state.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_playback_states_e {
+  /// < None
+  static const int MC_PLAYBACK_STATE_NONE = 0;
+
+  /// < Playing
+  static const int MC_PLAYBACK_STATE_PLAYING = 1;
+
+  /// < Paused
+  static const int MC_PLAYBACK_STATE_PAUSED = 2;
+
+  /// < Stopped
+  static const int MC_PLAYBACK_STATE_STOPPED = 3;
+
+  /// < Moving to the next item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_MOVING_TO_NEXT = 8;
+
+  /// < Moving to the previous item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_MOVING_TO_PREVIOUS = 9;
+
+  /// < Fast forwarding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_FAST_FORWARDING = 10;
+
+  /// < Rewinding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_REWINDING = 11;
+
+  /// < Connecting (Since 6.0)
+  static const int MC_PLAYBACK_STATE_CONNECTING = 12;
+
+  /// < Buffering (Since 6.0)
+  static const int MC_PLAYBACK_STATE_BUFFERING = 13;
+
+  /// < Error (Since 6.0)
+  static const int MC_PLAYBACK_STATE_ERROR = 14;
+}
+
+/// @brief Enumeration for the media playback action.
+/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
+abstract class mc_playback_action_e {
+  /// < Play
+  static const int MC_PLAYBACK_ACTION_PLAY = 0;
+
+  /// < Pause
+  static const int MC_PLAYBACK_ACTION_PAUSE = 1;
+
+  /// < Stop
+  static const int MC_PLAYBACK_ACTION_STOP = 2;
+
+  /// < Next item
+  static const int MC_PLAYBACK_ACTION_NEXT = 3;
+
+  /// < Previous item
+  static const int MC_PLAYBACK_ACTION_PREV = 4;
+
+  /// < Fast forward
+  static const int MC_PLAYBACK_ACTION_FAST_FORWARD = 5;
+
+  /// < Rewind
+  static const int MC_PLAYBACK_ACTION_REWIND = 6;
+
+  /// < Play/Pause toggle
+  static const int MC_PLAYBACK_ACTION_TOGGLE_PLAY_PAUSE = 7;
+}
+
+/// @brief Enumeration for the shuffle mode.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_shuffle_mode_e {
+  /// < Shuffle mode on
+  static const int MC_SHUFFLE_MODE_ON = 0;
+
+  /// < Shuffle mode off
+  static const int MC_SHUFFLE_MODE_OFF = 1;
+}
+
+/// @brief Enumeration for the repeat mode.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_repeat_mode_e {
+  /// < Repeat mode on for all media
+  static const int MC_REPEAT_MODE_ON = 0;
+
+  /// < Repeat mode off
+  static const int MC_REPEAT_MODE_OFF = 1;
+
+  /// < Repeat mode on for one media (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_REPEAT_MODE_ONE_MEDIA = 2;
+}
+
+/// @brief Enumeration for the subscription type.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_subscription_type_e {
+  /// < Server state
+  static const int MC_SUBSCRIPTION_TYPE_SERVER_STATE = 0;
+
+  /// < Playback
+  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK = 1;
+
+  /// < Metadata
+  static const int MC_SUBSCRIPTION_TYPE_METADATA = 2;
+
+  /// < Shuffle mode
+  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_MODE = 3;
+
+  /// < Repeat mode
+  static const int MC_SUBSCRIPTION_TYPE_REPEAT_MODE = 4;
+
+  /// < Playlist (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_SUBSCRIPTION_TYPE_PLAYLIST = 5;
+
+  /// < Playback ability (Since 5.0)
+  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK_ABILITY = 6;
+
+  /// < Shuffle ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
+  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_ABILITY = 7;
+
+  /// < Repeat ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
+  static const int MC_SUBSCRIPTION_TYPE_REPEAT_ABILITY = 8;
+
+  /// < Ability support (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT = 9;
+
+  /// < Display mode ability (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_MODE_ABILITY = 10;
+
+  /// < Display rotation ability (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_ROTATION_ABILITY = 11;
+}
+
+/// @brief Enumeration for the playlist update mode.
+/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
+abstract class mc_playlist_update_mode_e {
+  /// < Create or Update playlist
+  static const int MC_PLAYLIST_UPDATED = 0;
+
+  /// < Remove playlist
+  static const int MC_PLAYLIST_REMOVED = 1;
+}
+
+/// @brief Enumeration for the content type of the content.
+/// @since_tizen 5.0
+abstract class mc_content_type_e {
+  /// < Image content type
+  static const int MC_CONTENT_TYPE_IMAGE = 0;
+
+  /// < Video content type
+  static const int MC_CONTENT_TYPE_VIDEO = 1;
+
+  /// < Music content type
+  static const int MC_CONTENT_TYPE_MUSIC = 2;
+
+  /// < Other content type
+  static const int MC_CONTENT_TYPE_OTHER = 3;
+
+  /// < Not decided
+  static const int MC_CONTENT_TYPE_UNDECIDED = 4;
+}
+
+/// @brief Enumeration for the content age rating of the content.
+/// @since_tizen 5.0
+abstract class mc_content_age_rating_e {
+  /// < Suitable for all ages
+  static const int MC_CONTENT_RATING_ALL = 0;
+
+  /// < Suitable for ages 1 and up
+  static const int MC_CONTENT_RATING_1_PLUS = 1;
+
+  /// < Suitable for ages 2 and up
+  static const int MC_CONTENT_RATING_2_PLUS = 2;
+
+  /// < Suitable for ages 3 and up
+  static const int MC_CONTENT_RATING_3_PLUS = 3;
+
+  /// < Suitable for ages 4 and up
+  static const int MC_CONTENT_RATING_4_PLUS = 4;
+
+  /// < Suitable for ages 5 and up
+  static const int MC_CONTENT_RATING_5_PLUS = 5;
+
+  /// < Suitable for ages 6 and up
+  static const int MC_CONTENT_RATING_6_PLUS = 6;
+
+  /// < Suitable for ages 7 and up
+  static const int MC_CONTENT_RATING_7_PLUS = 7;
+
+  /// < Suitable for ages 8 and up
+  static const int MC_CONTENT_RATING_8_PLUS = 8;
+
+  /// < Suitable for ages 9 and up
+  static const int MC_CONTENT_RATING_9_PLUS = 9;
+
+  /// < Suitable for ages 10 and up
+  static const int MC_CONTENT_RATING_10_PLUS = 10;
+
+  /// < Suitable for ages 11 and up
+  static const int MC_CONTENT_RATING_11_PLUS = 11;
+
+  /// < Suitable for ages 12 and up
+  static const int MC_CONTENT_RATING_12_PLUS = 12;
+
+  /// < Suitable for ages 13 and up
+  static const int MC_CONTENT_RATING_13_PLUS = 13;
+
+  /// < Suitable for ages 14 and up
+  static const int MC_CONTENT_RATING_14_PLUS = 14;
+
+  /// < Suitable for ages 15 and up
+  static const int MC_CONTENT_RATING_15_PLUS = 15;
+
+  /// < Suitable for ages 16 and up
+  static const int MC_CONTENT_RATING_16_PLUS = 16;
+
+  /// < Suitable for ages 17 and up
+  static const int MC_CONTENT_RATING_17_PLUS = 17;
+
+  /// < Suitable for ages 18 and up
+  static const int MC_CONTENT_RATING_18_PLUS = 18;
+
+  /// < Suitable for ages 19 and up
+  static const int MC_CONTENT_RATING_19_PLUS = 19;
+}
+
+/// @brief Enumeration for the support of the ability.
+/// @since_tizen 5.0
+abstract class mc_ability_support_e {
+  /// < Supported
+  static const int MC_ABILITY_SUPPORTED_YES = 0;
+
+  /// < Not supported
+  static const int MC_ABILITY_SUPPORTED_NO = 1;
+
+  /// < Not decided
+  static const int MC_ABILITY_SUPPORTED_UNDECIDED = 2;
+}
+
+/// @brief Enumeration for the ability.
+/// @since_tizen 5.5
+abstract class mc_ability_e {
+  /// < Shuffle
+  static const int MC_ABILITY_SHUFFLE = 0;
+
+  /// < Repeat
+  static const int MC_ABILITY_REPEAT = 1;
+
+  /// < Playback Position
+  static const int MC_ABILITY_PLAYBACK_POSITION = 2;
+
+  /// < Playlist
+  static const int MC_ABILITY_PLAYLIST = 3;
+
+  /// < Custom command from a client
+  static const int MC_ABILITY_CLIENT_CUSTOM = 4;
+
+  /// < Search
+  static const int MC_ABILITY_SEARCH = 5;
+
+  /// < Subtitles display
+  static const int MC_ABILITY_SUBTITLES = 6;
+
+  /// < 360 content mode display
+  static const int MC_ABILITY_360_MODE = 7;
+}
+
+/// @brief Enumeration for the search category.
+/// @since_tizen 5.0
+abstract class mc_search_category_e {
+  /// < No search category
+  static const int MC_SEARCH_NO_CATEGORY = 0;
+
+  /// < Search by content title
+  static const int MC_SEARCH_TITLE = 1;
+
+  /// < Search by content artist
+  static const int MC_SEARCH_ARTIST = 2;
+
+  /// < Search by content album
+  static const int MC_SEARCH_ALBUM = 3;
+
+  /// < Search by content genre
+  static const int MC_SEARCH_GENRE = 4;
+
+  /// < Search by Time Place Occasion
+  static const int MC_SEARCH_TPO = 5;
+}
+
+/// @brief Enumeration for the display mode.
+/// @since_tizen 5.5
+abstract class mc_display_mode_e {
+  /// < Letter box
+  static const int MC_DISPLAY_MODE_LETTER_BOX = 1;
+
+  /// < Origin size
+  static const int MC_DISPLAY_MODE_ORIGIN_SIZE = 2;
+
+  /// < Full-screen
+  static const int MC_DISPLAY_MODE_FULL_SCREEN = 4;
+
+  /// < Cropped full-screen
+  static const int MC_DISPLAY_MODE_CROPPED_FULL = 8;
+}
+
+/// @brief Enumeration for the display rotation.
+/// @since_tizen 5.5
+abstract class mc_display_rotation_e {
+  /// < Display is not rotated
+  static const int MC_DISPLAY_ROTATION_NONE = 1;
+
+  /// < Display is rotated 90 degrees
+  static const int MC_DISPLAY_ROTATION_90 = 2;
+
+  /// < Display is rotated 180 degrees
+  static const int MC_DISPLAY_ROTATION_180 = 4;
+
+  /// < Display is rotated 270 degrees
+  static const int MC_DISPLAY_ROTATION_270 = 8;
+}
+
+/// @brief The result codes of the reply for the command or the event.
+/// @since_tizen 6.0
+///
+/// @see mc_cmd_reply_received_cb()
+/// @see mc_client_send_event_reply()
+/// @see mc_server_event_reply_received_cb()
+/// @see mc_server_send_cmd_reply()
+abstract class mc_result_code_e {
+  /// < The command or the event has been successfully completed.
+  static const int MC_RESULT_CODE_SUCCESS = 0;
+
+  /// < The command or the event had already been completed.
+  static const int MC_RESULT_CODE_ALREADY_DONE = 200;
+
+  /// < The command or the event is aborted by some external event (e.g. aborted play command by incoming call).
+  static const int MC_RESULT_CODE_ABORTED = 300;
+
+  /// < The command or the event is denied due to application policy (e.g. cannot rewind in recording).
+  static const int MC_RESULT_CODE_DENIED = 301;
+
+  /// < The command or the event is not supported.
+  static const int MC_RESULT_CODE_NOT_SUPPORTED = 302;
+
+  /// < The command or the event is out of supported range or the limit is reached.
+  static const int MC_RESULT_CODE_INVALID = 303;
+
+  /// < Timeout has occurred.
+  static const int MC_RESULT_CODE_TIMEOUT = 400;
+
+  /// < The application has failed.
+  static const int MC_RESULT_CODE_APP_FAILED = 401;
+
+  /// < The command or the event has failed because the application has no media.
+  static const int MC_RESULT_CODE_NO_MEDIA = 402;
+
+  /// < The command or the event has failed because there is no audio output device.
+  static const int MC_RESULT_CODE_NO_AUDIO_OUTPUT_DEVICE = 403;
+
+  /// < The command or the event has failed because there is no peer.
+  static const int MC_RESULT_CODE_NO_PEER = 404;
+
+  /// < The network has failed.
+  static const int MC_RESULT_CODE_NETWORK_FAILED = 500;
+
+  /// < The application needs to have an account to which it's logged in.
+  static const int MC_RESULT_CODE_NO_ACCOUNT = 600;
+
+  /// < The application could not log in.
+  static const int MC_RESULT_CODE_LOGIN_FAILED = 601;
+
+  /// < Unknown error.
+  static const int MC_RESULT_CODE_UNKNOWN = 2147483647;
+}
+
 /// @brief The structure type for the media controller playlist handle.
 /// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
 typedef mc_playlist_h = ffi.Pointer<ffi.Void>;
@@ -6848,141 +7303,13 @@ typedef mc_playlist_cbFunction = ffi.Bool Function(
 typedef Dartmc_playlist_cbFunction = bool Function(
     mc_playlist_h playlist, ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the media meta info.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_meta_e {
-  /// < Title
-  static const int MC_META_MEDIA_TITLE = 0;
-
-  /// < Artist
-  static const int MC_META_MEDIA_ARTIST = 1;
-
-  /// < Album
-  static const int MC_META_MEDIA_ALBUM = 2;
-
-  /// < Author
-  static const int MC_META_MEDIA_AUTHOR = 3;
-
-  /// < Genre
-  static const int MC_META_MEDIA_GENRE = 4;
-
-  /// < Duration
-  static const int MC_META_MEDIA_DURATION = 5;
-
-  /// < Date
-  static const int MC_META_MEDIA_DATE = 6;
-
-  /// < Copyright
-  static const int MC_META_MEDIA_COPYRIGHT = 7;
-
-  /// < Description
-  static const int MC_META_MEDIA_DESCRIPTION = 8;
-
-  /// < Track Number
-  static const int MC_META_MEDIA_TRACK_NUM = 9;
-
-  /// < Picture. Album Art
-  static const int MC_META_MEDIA_PICTURE = 10;
-
-  /// < Season (Since 5.5)
-  static const int MC_META_MEDIA_SEASON = 11;
-
-  /// < Episode (Since 5.5)
-  static const int MC_META_MEDIA_EPISODE = 12;
-
-  /// < Content resolution (Since 5.5)
-  static const int MC_META_MEDIA_RESOLUTION = 13;
-}
-
 /// @brief The structure type for the media controller ability handle.
 /// @since_tizen 5.0
 typedef mc_playback_ability_h = ffi.Pointer<ffi.Void>;
 
-/// @brief Enumeration for the media playback action.
-/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
-abstract class mc_playback_action_e {
-  /// < Play
-  static const int MC_PLAYBACK_ACTION_PLAY = 0;
-
-  /// < Pause
-  static const int MC_PLAYBACK_ACTION_PAUSE = 1;
-
-  /// < Stop
-  static const int MC_PLAYBACK_ACTION_STOP = 2;
-
-  /// < Next item
-  static const int MC_PLAYBACK_ACTION_NEXT = 3;
-
-  /// < Previous item
-  static const int MC_PLAYBACK_ACTION_PREV = 4;
-
-  /// < Fast forward
-  static const int MC_PLAYBACK_ACTION_FAST_FORWARD = 5;
-
-  /// < Rewind
-  static const int MC_PLAYBACK_ACTION_REWIND = 6;
-
-  /// < Play/Pause toggle
-  static const int MC_PLAYBACK_ACTION_TOGGLE_PLAY_PAUSE = 7;
-}
-
-/// @brief Enumeration for the support of the ability.
-/// @since_tizen 5.0
-abstract class mc_ability_support_e {
-  /// < Supported
-  static const int MC_ABILITY_SUPPORTED_YES = 0;
-
-  /// < Not supported
-  static const int MC_ABILITY_SUPPORTED_NO = 1;
-
-  /// < Not decided
-  static const int MC_ABILITY_SUPPORTED_UNDECIDED = 2;
-}
-
 /// @brief The structure type for the media controller search handle.
 /// @since_tizen 5.0
 typedef mc_search_h = ffi.Pointer<ffi.Void>;
-
-/// @brief Enumeration for the content type of the content.
-/// @since_tizen 5.0
-abstract class mc_content_type_e {
-  /// < Image content type
-  static const int MC_CONTENT_TYPE_IMAGE = 0;
-
-  /// < Video content type
-  static const int MC_CONTENT_TYPE_VIDEO = 1;
-
-  /// < Music content type
-  static const int MC_CONTENT_TYPE_MUSIC = 2;
-
-  /// < Other content type
-  static const int MC_CONTENT_TYPE_OTHER = 3;
-
-  /// < Not decided
-  static const int MC_CONTENT_TYPE_UNDECIDED = 4;
-}
-
-/// @brief Enumeration for the search category.
-/// @since_tizen 5.0
-abstract class mc_search_category_e {
-  /// < No search category
-  static const int MC_SEARCH_NO_CATEGORY = 0;
-
-  /// < Search by content title
-  static const int MC_SEARCH_TITLE = 1;
-
-  /// < Search by content artist
-  static const int MC_SEARCH_ARTIST = 2;
-
-  /// < Search by content album
-  static const int MC_SEARCH_ALBUM = 3;
-
-  /// < Search by content genre
-  static const int MC_SEARCH_GENRE = 4;
-
-  /// < Search by Time Place Occasion
-  static const int MC_SEARCH_TPO = 5;
-}
 
 /// @brief Called for every search condition information in the obtained list of search.
 /// @details Iterates over a search list.
@@ -7047,19 +7374,6 @@ typedef Dartmc_server_state_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the media controller server state.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_server_state_e {
-  /// < None state
-  static const int MC_SERVER_STATE_NONE = 0;
-
-  /// < Activate state
-  static const int MC_SERVER_STATE_ACTIVATE = 1;
-
-  /// < Deactivate state
-  static const int MC_SERVER_STATE_DEACTIVATE = 2;
-}
 
 /// @brief Called when the playback information of the media controller server is updated.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
@@ -7146,16 +7460,6 @@ typedef Dartmc_shuffle_mode_updated_cbFunction = void Function(
     int mode,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the shuffle mode.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_shuffle_mode_e {
-  /// < Shuffle mode on
-  static const int MC_SHUFFLE_MODE_ON = 0;
-
-  /// < Shuffle mode off
-  static const int MC_SHUFFLE_MODE_OFF = 1;
-}
-
 /// @brief Called when the repeat mode of the media controller server is updated.
 /// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
 ///
@@ -7180,19 +7484,6 @@ typedef Dartmc_repeat_mode_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int mode,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the repeat mode.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_repeat_mode_e {
-  /// < Repeat mode on for all media
-  static const int MC_REPEAT_MODE_ON = 0;
-
-  /// < Repeat mode off
-  static const int MC_REPEAT_MODE_OFF = 1;
-
-  /// < Repeat mode on for one media (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_REPEAT_MODE_ONE_MEDIA = 2;
-}
 
 /// @brief Called when the playback ability support of the media controller server is updated.
 /// @since_tizen 5.0
@@ -7299,34 +7590,6 @@ typedef Dartmc_ability_support_updated_cbFunction = void Function(
     int support,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the ability.
-/// @since_tizen 5.5
-abstract class mc_ability_e {
-  /// < Shuffle
-  static const int MC_ABILITY_SHUFFLE = 0;
-
-  /// < Repeat
-  static const int MC_ABILITY_REPEAT = 1;
-
-  /// < Playback Position
-  static const int MC_ABILITY_PLAYBACK_POSITION = 2;
-
-  /// < Playlist
-  static const int MC_ABILITY_PLAYLIST = 3;
-
-  /// < Custom command from a client
-  static const int MC_ABILITY_CLIENT_CUSTOM = 4;
-
-  /// < Search
-  static const int MC_ABILITY_SEARCH = 5;
-
-  /// < Subtitles display
-  static const int MC_ABILITY_SUBTITLES = 6;
-
-  /// < 360 content mode display
-  static const int MC_ABILITY_360_MODE = 7;
-}
-
 /// @brief Called when a media controller server's supported items for an ability is updated.
 /// @since_tizen 5.5
 ///
@@ -7416,16 +7679,6 @@ typedef Dartmc_playlist_updated_cbFunction = void Function(
     mc_playlist_h playlist,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the playlist update mode.
-/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
-abstract class mc_playlist_update_mode_e {
-  /// < Create or Update playlist
-  static const int MC_PLAYLIST_UPDATED = 0;
-
-  /// < Remove playlist
-  static const int MC_PLAYLIST_REMOVED = 1;
-}
-
 /// @brief Called when the status of a media controller server's boolean attribute (subtitles or 360 mode) is updated.
 /// @since_tizen 5.5
 ///
@@ -7473,22 +7726,6 @@ typedef Dartmc_display_mode_updated_cbFunction = void Function(
     int mode,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the display mode.
-/// @since_tizen 5.5
-abstract class mc_display_mode_e {
-  /// < Letter box
-  static const int MC_DISPLAY_MODE_LETTER_BOX = 1;
-
-  /// < Origin size
-  static const int MC_DISPLAY_MODE_ORIGIN_SIZE = 2;
-
-  /// < Full-screen
-  static const int MC_DISPLAY_MODE_FULL_SCREEN = 4;
-
-  /// < Cropped full-screen
-  static const int MC_DISPLAY_MODE_CROPPED_FULL = 8;
-}
-
 /// @brief Called when a media controller server's display rotation is updated.
 /// @since_tizen 5.5
 ///
@@ -7511,22 +7748,6 @@ typedef Dartmc_display_rotation_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int rotation,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the display rotation.
-/// @since_tizen 5.5
-abstract class mc_display_rotation_e {
-  /// < Display is not rotated
-  static const int MC_DISPLAY_ROTATION_NONE = 1;
-
-  /// < Display is rotated 90 degrees
-  static const int MC_DISPLAY_ROTATION_90 = 2;
-
-  /// < Display is rotated 180 degrees
-  static const int MC_DISPLAY_ROTATION_180 = 4;
-
-  /// < Display is rotated 270 degrees
-  static const int MC_DISPLAY_ROTATION_270 = 8;
-}
 
 /// @brief Called when receiving custom event of media controller servers.
 /// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
@@ -7563,46 +7784,6 @@ typedef Dartmc_client_custom_event_received_cbFunction = void Function(
     ffi.Pointer<bundle.bundle> data,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the subscription type.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_subscription_type_e {
-  /// < Server state
-  static const int MC_SUBSCRIPTION_TYPE_SERVER_STATE = 0;
-
-  /// < Playback
-  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK = 1;
-
-  /// < Metadata
-  static const int MC_SUBSCRIPTION_TYPE_METADATA = 2;
-
-  /// < Shuffle mode
-  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_MODE = 3;
-
-  /// < Repeat mode
-  static const int MC_SUBSCRIPTION_TYPE_REPEAT_MODE = 4;
-
-  /// < Playlist (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_SUBSCRIPTION_TYPE_PLAYLIST = 5;
-
-  /// < Playback ability (Since 5.0)
-  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK_ABILITY = 6;
-
-  /// < Shuffle ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
-  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_ABILITY = 7;
-
-  /// < Repeat ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
-  static const int MC_SUBSCRIPTION_TYPE_REPEAT_ABILITY = 8;
-
-  /// < Ability support (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT = 9;
-
-  /// < Display mode ability (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_MODE_ABILITY = 10;
-
-  /// < Display rotation ability (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_ROTATION_ABILITY = 11;
-}
-
 /// @brief Called when requesting the list of subscribed servers.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
 ///
@@ -7625,107 +7806,6 @@ typedef mc_subscribed_server_cbFunction = ffi.Bool Function(
     ffi.Pointer<ffi.Char> server_name, ffi.Pointer<ffi.Void> user_data);
 typedef Dartmc_subscribed_server_cbFunction = bool Function(
     ffi.Pointer<ffi.Char> server_name, ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the media playback state.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_playback_states_e {
-  /// < None
-  static const int MC_PLAYBACK_STATE_NONE = 0;
-
-  /// < Playing
-  static const int MC_PLAYBACK_STATE_PLAYING = 1;
-
-  /// < Paused
-  static const int MC_PLAYBACK_STATE_PAUSED = 2;
-
-  /// < Stopped
-  static const int MC_PLAYBACK_STATE_STOPPED = 3;
-
-  /// < Moving to the next item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_MOVING_TO_NEXT = 8;
-
-  /// < Moving to the previous item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_MOVING_TO_PREVIOUS = 9;
-
-  /// < Fast forwarding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_FAST_FORWARDING = 10;
-
-  /// < Rewinding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_REWINDING = 11;
-
-  /// < Connecting (Since 6.0)
-  static const int MC_PLAYBACK_STATE_CONNECTING = 12;
-
-  /// < Buffering (Since 6.0)
-  static const int MC_PLAYBACK_STATE_BUFFERING = 13;
-
-  /// < Error (Since 6.0)
-  static const int MC_PLAYBACK_STATE_ERROR = 14;
-}
-
-/// @brief Enumeration for the content age rating of the content.
-/// @since_tizen 5.0
-abstract class mc_content_age_rating_e {
-  /// < Suitable for all ages
-  static const int MC_CONTENT_RATING_ALL = 0;
-
-  /// < Suitable for ages 1 and up
-  static const int MC_CONTENT_RATING_1_PLUS = 1;
-
-  /// < Suitable for ages 2 and up
-  static const int MC_CONTENT_RATING_2_PLUS = 2;
-
-  /// < Suitable for ages 3 and up
-  static const int MC_CONTENT_RATING_3_PLUS = 3;
-
-  /// < Suitable for ages 4 and up
-  static const int MC_CONTENT_RATING_4_PLUS = 4;
-
-  /// < Suitable for ages 5 and up
-  static const int MC_CONTENT_RATING_5_PLUS = 5;
-
-  /// < Suitable for ages 6 and up
-  static const int MC_CONTENT_RATING_6_PLUS = 6;
-
-  /// < Suitable for ages 7 and up
-  static const int MC_CONTENT_RATING_7_PLUS = 7;
-
-  /// < Suitable for ages 8 and up
-  static const int MC_CONTENT_RATING_8_PLUS = 8;
-
-  /// < Suitable for ages 9 and up
-  static const int MC_CONTENT_RATING_9_PLUS = 9;
-
-  /// < Suitable for ages 10 and up
-  static const int MC_CONTENT_RATING_10_PLUS = 10;
-
-  /// < Suitable for ages 11 and up
-  static const int MC_CONTENT_RATING_11_PLUS = 11;
-
-  /// < Suitable for ages 12 and up
-  static const int MC_CONTENT_RATING_12_PLUS = 12;
-
-  /// < Suitable for ages 13 and up
-  static const int MC_CONTENT_RATING_13_PLUS = 13;
-
-  /// < Suitable for ages 14 and up
-  static const int MC_CONTENT_RATING_14_PLUS = 14;
-
-  /// < Suitable for ages 15 and up
-  static const int MC_CONTENT_RATING_15_PLUS = 15;
-
-  /// < Suitable for ages 16 and up
-  static const int MC_CONTENT_RATING_16_PLUS = 16;
-
-  /// < Suitable for ages 17 and up
-  static const int MC_CONTENT_RATING_17_PLUS = 17;
-
-  /// < Suitable for ages 18 and up
-  static const int MC_CONTENT_RATING_18_PLUS = 18;
-
-  /// < Suitable for ages 19 and up
-  static const int MC_CONTENT_RATING_19_PLUS = 19;
-}
 
 /// @brief Called when requesting the list of created servers.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
@@ -8131,3 +8211,5 @@ typedef Dartmc_server_search_cmd_received_cbFunction = void Function(
     ffi.Pointer<ffi.Char> request_id,
     mc_search_h search,
     ffi.Pointer<ffi.Void> user_data);
+
+const int MEDIA_CONTROLLER_ERROR_CLASS = -50462720;

--- a/lib/src/bindings/6.0/generated_bindings_capi_media_metadata_editor.dart
+++ b/lib/src/bindings/6.0/generated_bindings_capi_media_metadata_editor.dart
@@ -368,9 +368,34 @@ class Tizen60CapiMediaMetadataEditor {
 }
 
 /// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
-/// @brief The handle of media metadata.
+/// @brief The enumerations of media metadata error.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-typedef metadata_editor_h = ffi.Pointer<ffi.Void>;
+abstract class metadata_editor_error_e {
+  /// < Successful
+  static const int METADATA_EDITOR_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int METADATA_EDITOR_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int METADATA_EDITOR_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < File not exist
+  static const int METADATA_EDITOR_ERROR_FILE_EXISTS = -17;
+
+  /// < Permission denied
+  static const int METADATA_EDITOR_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Unsupported type
+  static const int METADATA_EDITOR_ERROR_NOT_SUPPORTED = -1073741822;
+
+  /// < Invalid internal operation
+  static const int METADATA_EDITOR_ERROR_OPERATION_FAILED = -27000831;
+
+  /// < Update not possible (Since 6.0)
+  static const int METADATA_EDITOR_ERROR_METADATA_UPDATE_NOT_POSSIBLE =
+      -27000830;
+}
 
 /// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
 /// @brief The enumerations of attribute.
@@ -415,3 +440,10 @@ abstract class metadata_editor_attr_e {
   /// < Unsynchronized lyric
   static const int METADATA_EDITOR_ATTR_UNSYNCLYRICS = 12;
 }
+
+/// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
+/// @brief The handle of media metadata.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+typedef metadata_editor_h = ffi.Pointer<ffi.Void>;
+
+const int METADATA_EDITOR_ERROR_CLASS = -27000832;

--- a/lib/src/bindings/6.0/generated_bindings_capi_media_metadata_extractor.dart
+++ b/lib/src/bindings/6.0/generated_bindings_capi_media_metadata_extractor.dart
@@ -384,11 +384,27 @@ class Tizen60CapiMediaMetadataExtractor {
 }
 
 /// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
-/// @brief The metadata extractor handle.
+/// @brief Enumeration for metadata extractor error.
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
-typedef metadata_extractor_h = ffi.Pointer<metadata_extractor_s>;
+abstract class metadata_extractor_error_e {
+  /// < Successful
+  static const int METADATA_EXTRACTOR_ERROR_NONE = 0;
 
-final class metadata_extractor_s extends ffi.Opaque {}
+  /// < Invalid parameter
+  static const int METADATA_EXTRACTOR_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int METADATA_EXTRACTOR_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < File does not exist
+  static const int METADATA_EXTRACTOR_ERROR_FILE_EXISTS = -17;
+
+  /// < Permission denied
+  static const int METADATA_EXTRACTOR_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Invalid internal operation
+  static const int METADATA_EXTRACTOR_ERROR_OPERATION_FAILED = -26411007;
+}
 
 /// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
 /// @brief Enumeration for attribute.
@@ -499,3 +515,12 @@ abstract class metadata_extractor_attr_e {
   /// < Flag indicating if the video is a spherical video (Since 3.0)
   static const int METADATA_360 = 34;
 }
+
+final class metadata_extractor_s extends ffi.Opaque {}
+
+/// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
+/// @brief The metadata extractor handle.
+/// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
+typedef metadata_extractor_h = ffi.Pointer<metadata_extractor_s>;
+
+const int METADATA_EXTRACTOR_ERROR_CLASS = -26411008;

--- a/lib/src/bindings/6.0/generated_bindings_capi_media_screen_mirroring.dart
+++ b/lib/src/bindings/6.0/generated_bindings_capi_media_screen_mirroring.dart
@@ -880,29 +880,6 @@ class Tizen60CapiMediaScreenMirroring {
           int Function(scmirroring_sink_h, ffi.Pointer<ffi.Int32>)>();
 }
 
-/// @brief	The handle to the screen mirroring sink.
-/// @since_tizen 2.4
-typedef scmirroring_sink_h = ffi.Pointer<ffi.Void>;
-
-/// @brief Called when each status is changed.
-/// @since_tizen 2.4
-///
-/// @details This callback is called for state and error of screen mirroring sink
-///
-/// @param[in] error     The error code
-/// @param[in] state     The screen mirroring sink state
-/// @param[in] user_data The user data passed from the scmirroring_sink_set_state_cb() function
-///
-/// @pre scmirroring_sink_create()
-///
-/// @see scmirroring_sink_create()
-typedef scmirroring_sink_state_cb
-    = ffi.Pointer<ffi.NativeFunction<scmirroring_sink_state_cbFunction>>;
-typedef scmirroring_sink_state_cbFunction = ffi.Void Function(
-    ffi.Int32 error, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
-typedef Dartscmirroring_sink_state_cbFunction = void Function(
-    int error, int state, ffi.Pointer<ffi.Void> user_data);
-
 /// @brief Enumeration for screen mirroring error.
 /// @since_tizen 2.4
 abstract class scmirroring_error_e {
@@ -957,6 +934,41 @@ abstract class scmirroring_sink_state_e {
   static const int SCMIRRORING_SINK_STATE_MAX = 7;
 }
 
+/// @brief Enumeration for screen mirroring resolution.
+/// @since_tizen 2.4
+abstract class scmirroring_resolution_e {
+  static const int SCMIRRORING_RESOLUTION_UNKNOWN = 0;
+
+  /// < W-1920, H-1080, 30 fps
+  static const int SCMIRRORING_RESOLUTION_1920x1080_P30 = 1;
+
+  /// < W-1280, H-720, 30 fps
+  static const int SCMIRRORING_RESOLUTION_1280x720_P30 = 2;
+
+  /// < W-960, H-540, 30 fps
+  static const int SCMIRRORING_RESOLUTION_960x540_P30 = 4;
+
+  /// < W-864, H-480, 30 fps
+  static const int SCMIRRORING_RESOLUTION_864x480_P30 = 8;
+
+  /// < W-720, H-480, 30 fps
+  static const int SCMIRRORING_RESOLUTION_720x480_P60 = 16;
+
+  /// < W-640, H-480, 60 fps
+  static const int SCMIRRORING_RESOLUTION_640x480_P60 = 32;
+
+  /// < W-640, H-360, 30 fps
+  static const int SCMIRRORING_RESOLUTION_640x360_P30 = 64;
+  static const int SCMIRRORING_RESOLUTION_MAX = 128;
+}
+
+/// @brief Ability to send to multisink.
+/// @since_tizen 3.0
+abstract class scmirroring_multisink_e {
+  static const int SCMIRRORING_MULTISINK_DISABLE = 0;
+  static const int SCMIRRORING_MULTISINK_ENABLE = 1;
+}
+
 /// @brief Enumeration for screen mirroring display surface type.
 /// @since_tizen 2.4
 abstract class scmirroring_display_type_e {
@@ -966,16 +978,6 @@ abstract class scmirroring_display_type_e {
   /// < Use Evas pixmap surface to display streaming multimedia data
   static const int SCMIRRORING_DISPLAY_TYPE_EVAS = 1;
   static const int SCMIRRORING_DISPLAY_TYPE_MAX = 2;
-}
-
-/// @brief Enumeration for screen mirroring video codec.
-/// @since_tizen 2.4
-abstract class scmirroring_video_codec_e {
-  /// < Screen mirroring is not negotiated yet
-  static const int SCMIRRORING_VIDEO_CODEC_NONE = 0;
-
-  /// < H.264 codec for video
-  static const int SCMIRRORING_VIDEO_CODEC_H264 = 1;
 }
 
 /// @brief Enumeration for screen mirroring audio codec.
@@ -993,3 +995,56 @@ abstract class scmirroring_audio_codec_e {
   /// < LPCM codec for audio
   static const int SCMIRRORING_AUDIO_CODEC_LPCM = 3;
 }
+
+/// @brief Enumeration for screen mirroring video codec.
+/// @since_tizen 2.4
+abstract class scmirroring_video_codec_e {
+  /// < Screen mirroring is not negotiated yet
+  static const int SCMIRRORING_VIDEO_CODEC_NONE = 0;
+
+  /// < H.264 codec for video
+  static const int SCMIRRORING_VIDEO_CODEC_H264 = 1;
+}
+
+/// @brief Enumeration for screen mirroring direct streaming mode.
+/// @since_tizen 3.0
+abstract class scmirroring_direct_streaming_e {
+  /// < Disable screen mirroring direct streaming mode
+  static const int SCMIRRORING_DIRECT_STREAMING_DISABLED = 0;
+
+  /// < Enable direct streaming for files
+  static const int SCMIRRORING_DIRECT_STREAMING_ENABLED = 1;
+}
+
+/// @brief Enumeration for screen mirroring AV streaming transport.
+/// @since_tizen 3.0
+abstract class scmirroring_av_transport_e {
+  /// < UDP transport for AV streaming data
+  static const int SCMIRRORING_AV_TRANSPORT_UDP = 0;
+
+  /// < TCP transport for AV streaming data
+  static const int SCMIRRORING_AV_TRANSPORT_TCP = 1;
+}
+
+/// @brief	The handle to the screen mirroring sink.
+/// @since_tizen 2.4
+typedef scmirroring_sink_h = ffi.Pointer<ffi.Void>;
+
+/// @brief Called when each status is changed.
+/// @since_tizen 2.4
+///
+/// @details This callback is called for state and error of screen mirroring sink
+///
+/// @param[in] error     The error code
+/// @param[in] state     The screen mirroring sink state
+/// @param[in] user_data The user data passed from the scmirroring_sink_set_state_cb() function
+///
+/// @pre scmirroring_sink_create()
+///
+/// @see scmirroring_sink_create()
+typedef scmirroring_sink_state_cb
+    = ffi.Pointer<ffi.NativeFunction<scmirroring_sink_state_cbFunction>>;
+typedef scmirroring_sink_state_cbFunction = ffi.Void Function(
+    ffi.Int32 error, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
+typedef Dartscmirroring_sink_state_cbFunction = void Function(
+    int error, int state, ffi.Pointer<ffi.Void> user_data);

--- a/lib/src/bindings/6.0/generated_bindings_capi_media_sound_pool.dart
+++ b/lib/src/bindings/6.0/generated_bindings_capi_media_sound_pool.dart
@@ -865,10 +865,52 @@ class Tizen60CapiMediaSoundPool {
       .asFunction<int Function(sound_pool_h, int, ffi.Pointer<ffi.Int32>)>();
 }
 
-/// @brief Sound pool handle type.
+/// @brief Enumeration for Tizen Sound Pool error.
 ///
 /// @since_tizen 4.0
-typedef sound_pool_h = ffi.Pointer<ffi.Void>;
+abstract class sound_pool_error_e {
+  static const int SOUND_POOL_ERROR_NONE = 0;
+  static const int SOUND_POOL_ERROR_KEY_NOT_AVAILABLE = -126;
+  static const int SOUND_POOL_ERROR_OUT_OF_MEMORY = -12;
+  static const int SOUND_POOL_ERROR_INVALID_PARAMETER = -22;
+  static const int SOUND_POOL_ERROR_INVALID_OPERATION = -38;
+  static const int SOUND_POOL_ERROR_NOT_PERMITTED = -1;
+  static const int SOUND_POOL_ERROR_NO_SUCH_FILE = -2;
+}
+
+/// @brief Enumeration of sound pool stream state.
+///
+/// @since_tizen 4.0
+abstract class sound_pool_stream_state_e {
+  /// < Stream state isn't determined
+  static const int SOUND_POOL_STREAM_STATE_NONE = 0;
+
+  /// < Stream state is playing
+  static const int SOUND_POOL_STREAM_STATE_PLAYING = 1;
+
+  /// < Stream state is paused
+  static const int SOUND_POOL_STREAM_STATE_PAUSED = 2;
+
+  /// < Stream state is stopped
+  static const int SOUND_POOL_STREAM_STATE_STOPPED = 3;
+
+  /// < Stream state is finished
+  static const int SOUND_POOL_STREAM_STATE_FINISHED = 4;
+
+  /// < Stream state is suspended
+  static const int SOUND_POOL_STREAM_STATE_SUSPENDED = 5;
+}
+
+/// @brief Enumeration of sound pool stream priority policy.
+///
+/// @since_tizen 4.0
+abstract class sound_pool_stream_priority_policy_e {
+  /// < Stream priority policy is mute
+  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_MUTE = 0;
+
+  /// < Stream priority policy is suspended
+  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_SUSPENDED = 1;
+}
 
 /// @brief Enumeration of sound pool state.
 ///
@@ -880,6 +922,11 @@ abstract class sound_pool_state_e {
   /// < Sound pool inactive state: streams can't be played
   static const int SOUND_POOL_STATE_INACTIVE = 1;
 }
+
+/// @brief Sound pool handle type.
+///
+/// @since_tizen 4.0
+typedef sound_pool_h = ffi.Pointer<ffi.Void>;
 
 /// @brief Called when the sound pool state is changed.
 ///
@@ -910,17 +957,6 @@ typedef Dartsound_pool_state_changed_cbFunction = void Function(
     int prev_state,
     int cur_state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration of sound pool stream priority policy.
-///
-/// @since_tizen 4.0
-abstract class sound_pool_stream_priority_policy_e {
-  /// < Stream priority policy is mute
-  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_MUTE = 0;
-
-  /// < Stream priority policy is suspended
-  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_SUSPENDED = 1;
-}
 
 /// @brief Called when the sound pool stream state is changed.
 ///
@@ -954,26 +990,3 @@ typedef Dartsound_pool_stream_state_changed_cbFunction = void Function(
     int prev_state,
     int cur_state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration of sound pool stream state.
-///
-/// @since_tizen 4.0
-abstract class sound_pool_stream_state_e {
-  /// < Stream state isn't determined
-  static const int SOUND_POOL_STREAM_STATE_NONE = 0;
-
-  /// < Stream state is playing
-  static const int SOUND_POOL_STREAM_STATE_PLAYING = 1;
-
-  /// < Stream state is paused
-  static const int SOUND_POOL_STREAM_STATE_PAUSED = 2;
-
-  /// < Stream state is stopped
-  static const int SOUND_POOL_STREAM_STATE_STOPPED = 3;
-
-  /// < Stream state is finished
-  static const int SOUND_POOL_STREAM_STATE_FINISHED = 4;
-
-  /// < Stream state is suspended
-  static const int SOUND_POOL_STREAM_STATE_SUSPENDED = 5;
-}

--- a/lib/src/bindings/6.0/generated_bindings_capi_media_thumbnail_util.dart
+++ b/lib/src/bindings/6.0/generated_bindings_capi_media_thumbnail_util.dart
@@ -380,12 +380,38 @@ class Tizen60CapiMediaThumbnailUtil {
 }
 
 /// @ingroup CAPI_MEDIA_THUMBNAIL_UTIL_MODULE
+/// @brief Enumeration for a thumbnail util error.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class thumbnail_util_error_e {
+  /// < Successful
+  static const int THUMBNAIL_UTIL_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int THUMBNAIL_UTIL_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int THUMBNAIL_UTIL_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Invalid Operation
+  static const int THUMBNAIL_UTIL_ERROR_INVALID_OPERATION = -38;
+
+  /// < No space left on device
+  static const int THUMBNAIL_UTIL_ERROR_FILE_NO_SPACE_ON_DEVICE = -28;
+
+  /// < Permission denied
+  static const int THUMBNAIL_UTIL_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Unsupported Content (Since 4.0)
+  static const int THUMBNAIL_UTIL_ERROR_UNSUPPORTED_CONTENT = -49872895;
+}
+
+final class thumbnail_s extends ffi.Opaque {}
+
+/// @ingroup CAPI_MEDIA_THUMBNAIL_UTIL_MODULE
 /// @deprecated Deprecated since 5.0.
 /// @brief The structure type for the thumbnail info handle.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
 typedef thumbnail_h = ffi.Pointer<thumbnail_s>;
-
-final class thumbnail_s extends ffi.Opaque {}
 
 /// @ingroup CAPI_MEDIA_THUMBNAIL_UTIL_MODULE
 /// @deprecated Deprecated since 5.0.
@@ -431,28 +457,4 @@ typedef Dartthumbnail_extracted_cbFunction = void Function(
     int thumb_size,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_MEDIA_THUMBNAIL_UTIL_MODULE
-/// @brief Enumeration for a thumbnail util error.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class thumbnail_util_error_e {
-  /// < Successful
-  static const int THUMBNAIL_UTIL_ERROR_NONE = 0;
-
-  /// < Invalid parameter
-  static const int THUMBNAIL_UTIL_ERROR_INVALID_PARAMETER = -22;
-
-  /// < Out of memory
-  static const int THUMBNAIL_UTIL_ERROR_OUT_OF_MEMORY = -12;
-
-  /// < Invalid Operation
-  static const int THUMBNAIL_UTIL_ERROR_INVALID_OPERATION = -38;
-
-  /// < No space left on device
-  static const int THUMBNAIL_UTIL_ERROR_FILE_NO_SPACE_ON_DEVICE = -28;
-
-  /// < Permission denied
-  static const int THUMBNAIL_UTIL_ERROR_PERMISSION_DENIED = -13;
-
-  /// < Unsupported Content (Since 4.0)
-  static const int THUMBNAIL_UTIL_ERROR_UNSUPPORTED_CONTENT = -49872895;
-}
+const int THUMBNAIL_UTIL_ERROR_CLASS = -49872896;

--- a/lib/src/bindings/6.0/generated_bindings_capi_network_bluetooth.dart
+++ b/lib/src/bindings/6.0/generated_bindings_capi_network_bluetooth.dart
@@ -9643,6 +9643,185 @@ class Tizen60CapiNetworkBluetooth {
           .asFunction<int Function(ffi.Pointer<ffi.Bool>)>();
 }
 
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of PBAP fields.
+/// @since_tizen 3.0
+abstract class bt_pbap_field_e {
+  /// < All field
+  static const int BT_PBAP_FIELD_ALL = -1;
+
+  /// < vCard Version
+  static const int BT_PBAP_FIELD_VERSION = 1;
+
+  /// < Formatted Name
+  static const int BT_PBAP_FIELD_FN = 2;
+
+  /// < Structured Presentation of Name
+  static const int BT_PBAP_FIELD_N = 4;
+
+  /// < Associated Image or Photo
+  static const int BT_PBAP_FIELD_PHOTO = 8;
+
+  /// < Birthday
+  static const int BT_PBAP_FIELD_BDAY = 16;
+
+  /// < Delivery Address
+  static const int BT_PBAP_FIELD_ADR = 32;
+
+  /// < Delivery
+  static const int BT_PBAP_FIELD_LABEL = 64;
+
+  /// < Telephone Number
+  static const int BT_PBAP_FIELD_TEL = 128;
+
+  /// < Electronic Mail Address
+  static const int BT_PBAP_FIELD_EMAIL = 256;
+
+  /// < Electronic Mail
+  static const int BT_PBAP_FIELD_MAILER = 512;
+
+  /// < Time Zone
+  static const int BT_PBAP_FIELD_TZ = 1024;
+
+  /// < Geographic Position
+  static const int BT_PBAP_FIELD_GEO = 2048;
+
+  /// < Job
+  static const int BT_PBAP_FIELD_TITLE = 4096;
+
+  /// < Role within the Organization
+  static const int BT_PBAP_FIELD_ROLE = 8192;
+
+  /// < Organization Logo
+  static const int BT_PBAP_FIELD_LOGO = 16384;
+
+  /// < vCard of Person Representing
+  static const int BT_PBAP_FIELD_AGENT = 32768;
+
+  /// < Name of Organization
+  static const int BT_PBAP_FIELD_ORG = 65536;
+
+  /// < Comments
+  static const int BT_PBAP_FIELD_NOTE = 131072;
+
+  /// < Revision
+  static const int BT_PBAP_FIELD_REV = 262144;
+
+  /// < Pronunciation of Name
+  static const int BT_PBAP_FIELD_SOUND = 524288;
+
+  /// < Uniform Resource Locator
+  static const int BT_PBAP_FIELD_URL = 1048576;
+
+  /// < Unique ID
+  static const int BT_PBAP_FIELD_UID = 2097152;
+
+  /// < Public Encryption Key
+  static const int BT_PBAP_FIELD_KEY = 4194304;
+
+  /// < Nickname
+  static const int BT_PBAP_FIELD_NICKNAME = 8388608;
+
+  /// < Categories
+  static const int BT_PBAP_FIELD_CATEGORIES = 16777216;
+
+  /// < Product ID
+  static const int BT_PBAP_FIELD_PROID = 33554432;
+
+  /// < Class information
+  static const int BT_PBAP_FIELD_CLASS = 67108864;
+
+  /// < String used for sorting operations
+  static const int BT_PBAP_FIELD_SORT_STRING = 134217728;
+
+  /// < Time stamp
+  static const int BT_PBAP_FIELD_X_IRMC_CALL_DATETIME = 268435456;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_MODULE
+/// @brief Enumerations of Bluetooth error codes.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_error_e {
+  /// < Successful
+  static const int BT_ERROR_NONE = 0;
+
+  /// < Operation cancelled
+  static const int BT_ERROR_CANCELLED = -125;
+
+  /// < Invalid parameter
+  static const int BT_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int BT_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Device or resource busy
+  static const int BT_ERROR_RESOURCE_BUSY = -16;
+
+  /// < Timeout error
+  static const int BT_ERROR_TIMED_OUT = -1073741823;
+
+  /// < Operation now in progress
+  static const int BT_ERROR_NOW_IN_PROGRESS = -115;
+
+  /// < BT is Not Supported
+  static const int BT_ERROR_NOT_SUPPORTED = -1073741822;
+
+  /// < Permission denied
+  static const int BT_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Quota exceeded
+  static const int BT_ERROR_QUOTA_EXCEEDED = -122;
+
+  /// < No data available
+  static const int BT_ERROR_NO_DATA = -61;
+
+  /// < Device policy restriction (Since 3.0)
+  static const int BT_ERROR_DEVICE_POLICY_RESTRICTION = -1073741820;
+
+  /// < Local adapter not initialized
+  static const int BT_ERROR_NOT_INITIALIZED = -29359871;
+
+  /// < Local adapter not enabled
+  static const int BT_ERROR_NOT_ENABLED = -29359870;
+
+  /// < Operation already done
+  static const int BT_ERROR_ALREADY_DONE = -29359869;
+
+  /// < Operation failed
+  static const int BT_ERROR_OPERATION_FAILED = -29359868;
+
+  /// < Operation not in progress
+  static const int BT_ERROR_NOT_IN_PROGRESS = -29359867;
+
+  /// < Remote device not bonded
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_BONDED = -29359866;
+
+  /// < Authentication rejected
+  static const int BT_ERROR_AUTH_REJECTED = -29359865;
+
+  /// < Authentication failed
+  static const int BT_ERROR_AUTH_FAILED = -29359864;
+
+  /// < Remote device not found
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_FOUND = -29359863;
+
+  /// < Service search failed
+  static const int BT_ERROR_SERVICE_SEARCH_FAILED = -29359862;
+
+  /// < Remote device is not connected
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_CONNECTED = -29359861;
+
+  /// < Resource temporarily unavailable
+  static const int BT_ERROR_AGAIN = -29359860;
+
+  /// < Service Not Found
+  static const int BT_ERROR_SERVICE_NOT_FOUND = -29359859;
+
+  /// < Authorization rejected (Since 5.0)
+  static const int BT_ERROR_AUTHORIZATION_REJECTED = -29359858;
+}
+
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
 /// @brief  Enumerations of the Bluetooth adapter state.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
@@ -9667,6 +9846,175 @@ abstract class bt_adapter_visibility_mode_e {
   /// < Discoverable mode with time limit. After specific period,
   /// it is changed to #BT_ADAPTER_VISIBILITY_MODE_NON_DISCOVERABLE.
   static const int BT_ADAPTER_VISIBILITY_MODE_LIMITED_DISCOVERABLE = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief Enumerations of the discovery state of Bluetooth device.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_device_discovery_state_e {
+  /// < Device discovery is started
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_STARTED = 0;
+
+  /// < Device discovery is finished
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_FINISHED = 1;
+
+  /// < The remote Bluetooth device is found
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_FOUND = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising state.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_le_advertising_state_e {
+  /// < Bluetooth advertising is stopped
+  static const int BT_ADAPTER_LE_ADVERTISING_STOPPED = 0;
+
+  /// < Bluetooth advertising is started
+  static const int BT_ADAPTER_LE_ADVERTISING_STARTED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising mode.
+/// @since_tizen 2.3.1
+abstract class bt_adapter_le_advertising_mode_e {
+  /// < Balanced advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_BALANCED = 0;
+
+  /// < Low latency advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_LATENCY = 1;
+
+  /// < Low energy advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_ENERGY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising filter policy.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_le_advertising_filter_policy_e {
+  /// < White list is not in use
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_DEFAULT = 0;
+
+  /// < Allow the scan
+  /// request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_SCAN_WL = 1;
+
+  /// < Allow the connection
+  /// request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_CONN_WL = 2;
+
+  /// < Allow the
+  /// scan and connection request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_SCAN_CONN_WL = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth LE packet type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_le_packet_type_e {
+  /// < Advertising packet
+  static const int BT_ADAPTER_LE_PACKET_ADVERTISING = 0;
+
+  /// < Scan response packet
+  static const int BT_ADAPTER_LE_PACKET_SCAN_RESPONSE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth le scan mode.
+/// @since_tizen 3.0
+abstract class bt_adapter_le_scan_mode_e {
+  /// < Balanced mode of power consumption and connection latency
+  static const int BT_ADAPTER_LE_SCAN_MODE_BALANCED = 0;
+
+  /// < Low connection latency but high power consumption
+  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_LATENCY = 1;
+
+  /// < Low power consumption but high connection latency
+  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_ENERGY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device disconnect reason.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_disconnect_reason_e {
+  /// < Disconnected by unknown reason
+  static const int BT_DEVICE_DISCONNECT_REASON_UNKNOWN = 0;
+
+  /// < Disconnected by timeout
+  static const int BT_DEVICE_DISCONNECT_REASON_TIMEOUT = 1;
+
+  /// < Disconnected by local host
+  static const int BT_DEVICE_DISCONNECT_REASON_LOCAL_HOST = 2;
+
+  /// < Disconnected by remote
+  static const int BT_DEVICE_DISCONNECT_REASON_REMOTE = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of connection link type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_connection_link_type_e {
+  /// < BR/EDR link
+  static const int BT_DEVICE_CONNECTION_LINK_BREDR = 0;
+
+  /// < LE link
+  static const int BT_DEVICE_CONNECTION_LINK_LE = 1;
+
+  /// < The connection type default
+  static const int BT_DEVICE_CONNECTION_LINK_DEFAULT = 255;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device authorization state.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_authorization_e {
+  /// < The remote Bluetooth device is authorized
+  static const int BT_DEVICE_AUTHORIZED = 0;
+
+  /// < The remote Bluetooth device is unauthorized
+  static const int BT_DEVICE_UNAUTHORIZED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of Bluetooth profile.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_profile_e {
+  /// < RFCOMM Profile
+  static const int BT_PROFILE_RFCOMM = 1;
+
+  /// < Advanced Audio Distribution Profile Source role
+  static const int BT_PROFILE_A2DP = 2;
+
+  /// < Headset Profile
+  static const int BT_PROFILE_HSP = 4;
+
+  /// < Human Interface Device Profile
+  static const int BT_PROFILE_HID = 8;
+
+  /// < Network Access Point Profile
+  static const int BT_PROFILE_NAP = 16;
+
+  /// < Audio Gateway Profile
+  static const int BT_PROFILE_AG = 32;
+
+  /// < Generic Attribute Profile
+  static const int BT_PROFILE_GATT = 64;
+
+  /// < NAP server Profile
+  static const int BT_PROFILE_NAP_SERVER = 128;
+
+  /// < Advanced Audio Distribution Profile Sink role
+  static const int BT_PROFILE_A2DP_SINK = 256;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device address type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_address_type_e {
+  /// < Public address
+  static const int BT_DEVICE_PUBLIC_ADDRESS = 0;
+
+  /// < Random address
+  static const int BT_DEVICE_RANDOM_ADDRESS = 1;
 }
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
@@ -9752,88 +10100,36 @@ abstract class bt_service_class_t {
   static const int BT_SC_MAX = 16777216;
 }
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief  Called when you get bonded devices repeatedly.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @param[in] device_info The bonded device information
-/// @param[in] user_data The user data passed from the foreach function
-/// @return @c true to continue with the next iteration of the loop,
-/// \n @c false to break out of the loop.
-/// @pre bt_adapter_foreach_bonded_device() will invoke this function.
-///
-/// @see bt_adapter_foreach_bonded_device()
-typedef bt_adapter_bonded_device_cb
-    = ffi.Pointer<ffi.NativeFunction<bt_adapter_bonded_device_cbFunction>>;
-typedef bt_adapter_bonded_device_cbFunction = ffi.Bool Function(
-    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
-typedef Dartbt_adapter_bonded_device_cbFunction = bool Function(
-    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Device information structure used for identifying pear device.
+/// @brief  Enumerations of major service class.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see #bt_class_s
-/// @see bt_device_bond_created_cb()
-final class bt_device_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
+abstract class bt_major_service_class_e {
+  /// < Limited discoverable mode
+  static const int BT_MAJOR_SERVICE_CLASS_LIMITED_DISCOVERABLE_MODE = 8192;
 
-  /// < The name of remote device
-  external ffi.Pointer<ffi.Char> remote_name;
+  /// < Positioning class
+  static const int BT_MAJOR_SERVICE_CLASS_POSITIONING = 65536;
 
-  /// < The Bluetooth classes
-  external bt_class_s bt_class;
+  /// < Networking class
+  static const int BT_MAJOR_SERVICE_CLASS_NETWORKING = 131072;
 
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+  /// < Rendering class
+  static const int BT_MAJOR_SERVICE_CLASS_RENDERING = 262144;
 
-  /// < The number of services
-  @ffi.Int()
-  external int service_count;
+  /// < Capturing class
+  static const int BT_MAJOR_SERVICE_CLASS_CAPTURING = 524288;
 
-  /// < The bonding state
-  @ffi.Bool()
-  external bool is_bonded;
+  /// < Object transferring class
+  static const int BT_MAJOR_SERVICE_CLASS_OBJECT_TRANSFER = 1048576;
 
-  /// < The connection state
-  @ffi.Bool()
-  external bool is_connected;
+  /// < Audio class
+  static const int BT_MAJOR_SERVICE_CLASS_AUDIO = 2097152;
 
-  /// < The authorization state
-  @ffi.Bool()
-  external bool is_authorized;
+  /// < Telephony class
+  static const int BT_MAJOR_SERVICE_CLASS_TELEPHONY = 4194304;
 
-  /// < manufacturer specific data length
-  @ffi.Int()
-  external int manufacturer_data_len;
-
-  /// < manufacturer specific data
-  external ffi.Pointer<ffi.Char> manufacturer_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Class structure of device and service.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see #bt_device_info_s
-/// @see #bt_adapter_device_discovery_info_s
-/// @see bt_device_bond_created_cb()
-/// @see bt_adapter_device_discovery_state_changed_cb()
-final class bt_class_s extends ffi.Struct {
-  /// < Major device class.
-  @ffi.Int32()
-  external int major_device_class;
-
-  /// < Minor device class.
-  @ffi.Int32()
-  external int minor_device_class;
-
-  /// < Major service class mask.
-  /// This value can be a combination of #bt_major_service_class_e like #BT_MAJOR_SERVICE_CLASS_RENDERING | #BT_MAJOR_SERVICE_CLASS_AUDIO
-  @ffi.Int()
-  external int major_service_class_mask;
+  /// < Information class
+  static const int BT_MAJOR_SERVICE_CLASS_INFORMATION = 8388608;
 }
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
@@ -10134,6 +10430,969 @@ abstract class bt_minor_device_class_e {
   static const int BT_MINOR_DEVICE_CLASS_HEALTH_ANKLE_PROSTHESIS = 52;
 }
 
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief  Enumerations of gap appearance type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_appearance_type_e {
+  /// < Unknown appearance type
+  static const int BT_APPEARANCE_TYPE_UNKNOWN = 0;
+
+  /// < Generic Phone type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_PHONE = 64;
+
+  /// < Generic Computer type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_COMPUTER = 128;
+
+  /// < Generic Watch type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_WATCH = 192;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief  Enumerations of the Bluetooth device's LE connection mode.
+/// @since_tizen 3.0
+abstract class bt_device_le_connection_mode_e {
+  /// < Balanced mode of power consumption and connection latency
+  static const int BT_DEVICE_LE_CONNECTION_MODE_BALANCED = 0;
+
+  /// < Low connection latency but high power consumption
+  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_LATENCY = 1;
+
+  /// < Low power consumption but high connection latency
+  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_ENERGY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief  Enumerations of connected Bluetooth device event role.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_socket_role_e {
+  /// < Unknown role
+  static const int BT_SOCKET_UNKNOWN = 0;
+
+  /// < Server role
+  static const int BT_SOCKET_SERVER = 1;
+
+  /// < Client role
+  static const int BT_SOCKET_CLIENT = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief  Enumerations of Bluetooth socket connection state.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_socket_connection_state_e {
+  /// < RFCOMM is connected
+  static const int BT_SOCKET_CONNECTED = 0;
+
+  /// < RFCOMM is disconnected
+  static const int BT_SOCKET_DISCONNECTED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
+/// @brief  Enumerations for the types of profiles related with audio.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_audio_profile_type_e {
+  /// < All supported profiles related with audio
+  static const int BT_AUDIO_PROFILE_TYPE_ALL = 0;
+
+  /// < HSP(Headset Profile) and HFP(Hands-Free Profile)
+  static const int BT_AUDIO_PROFILE_TYPE_HSP_HFP = 1;
+
+  /// < A2DP(Advanced Audio Distribution Profile)
+  static const int BT_AUDIO_PROFILE_TYPE_A2DP = 2;
+
+  /// < AG(Audio Gateway)
+  static const int BT_AUDIO_PROFILE_TYPE_AG = 3;
+
+  /// < A2DP(Advanced Audio Distribution Profile) Sink role
+  static const int BT_AUDIO_PROFILE_TYPE_A2DP_SINK = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_AG_MODULE
+/// @brief  Enumerations for the call handling event.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_ag_call_handling_event_e {
+  /// < Request to answer an incoming call
+  static const int BT_AG_CALL_HANDLING_EVENT_ANSWER = 0;
+
+  /// < Request to release a call
+  static const int BT_AG_CALL_HANDLING_EVENT_RELEASE = 1;
+
+  /// < Request to reject an incoming call
+  static const int BT_AG_CALL_HANDLING_EVENT_REJECT = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_AG_MODULE
+/// @brief  Enumerations for the multi call handling event.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_ag_multi_call_handling_event_e {
+  /// < Request to release held calls
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_RELEASE_HELD_CALLS = 0;
+
+  /// < Request to release active calls
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_RELEASE_ACTIVE_CALLS = 1;
+
+  /// < Request to put active calls into hold state and activate another (held or waiting) call
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_ACTIVATE_HELD_CALL = 2;
+
+  /// < Request to add a held call to the conversation
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_MERGE_CALLS = 3;
+
+  /// < Request to let a user who has two calls to connect these two calls together and release its connections to both other parties
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_EXPLICIT_CALL_TRANSFER = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the equalizer state.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_equalizer_state_e {
+  /// < Equalizer Off
+  static const int BT_AVRCP_EQUALIZER_STATE_OFF = 1;
+
+  /// < Equalizer On
+  static const int BT_AVRCP_EQUALIZER_STATE_ON = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the repeat mode.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_repeat_mode_e {
+  /// < Repeat Off
+  static const int BT_AVRCP_REPEAT_MODE_OFF = 1;
+
+  /// < Single track repeat
+  static const int BT_AVRCP_REPEAT_MODE_SINGLE_TRACK = 2;
+
+  /// < All track repeat
+  static const int BT_AVRCP_REPEAT_MODE_ALL_TRACK = 3;
+
+  /// < Group repeat
+  static const int BT_AVRCP_REPEAT_MODE_GROUP = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the shuffle mode.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_shuffle_mode_e {
+  /// < Shuffle Off
+  static const int BT_AVRCP_SHUFFLE_MODE_OFF = 1;
+
+  /// < All tracks shuffle
+  static const int BT_AVRCP_SHUFFLE_MODE_ALL_TRACK = 2;
+
+  /// < Group shuffle
+  static const int BT_AVRCP_SHUFFLE_MODE_GROUP = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the scan mode.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_scan_mode_e {
+  /// < Scan Off
+  static const int BT_AVRCP_SCAN_MODE_OFF = 1;
+
+  /// < All tracks scan
+  static const int BT_AVRCP_SCAN_MODE_ALL_TRACK = 2;
+
+  /// < Group scan
+  static const int BT_AVRCP_SCAN_MODE_GROUP = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the player state.
+/// @since_tizen 3.0
+abstract class bt_avrcp_player_state_e {
+  /// < Stopped
+  static const int BT_AVRCP_PLAYER_STATE_STOPPED = 0;
+
+  /// < Playing
+  static const int BT_AVRCP_PLAYER_STATE_PLAYING = 1;
+
+  /// < Paused
+  static const int BT_AVRCP_PLAYER_STATE_PAUSED = 2;
+
+  /// < Seek Forward
+  static const int BT_AVRCP_PLAYER_STATE_FORWARD_SEEK = 3;
+
+  /// < Seek Rewind
+  static const int BT_AVRCP_PLAYER_STATE_REWIND_SEEK = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumeration for the player control commands.
+/// @since_tizen 3.0
+abstract class bt_avrcp_player_command_e {
+  /// < Play
+  static const int BT_AVRCP_CONTROL_PLAY = 1;
+
+  /// < Pause
+  static const int BT_AVRCP_CONTROL_PAUSE = 2;
+
+  /// < Stop
+  static const int BT_AVRCP_CONTROL_STOP = 3;
+
+  /// < Next Track
+  static const int BT_AVRCP_CONTROL_NEXT = 4;
+
+  /// < Previous track
+  static const int BT_AVRCP_CONTROL_PREVIOUS = 5;
+
+  /// < Fast Forward
+  static const int BT_AVRCP_CONTROL_FAST_FORWARD = 6;
+
+  /// < Rewind
+  static const int BT_AVRCP_CONTROL_REWIND = 7;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief Structure of Track metadata information.
+/// @since_tizen 3.0
+///
+/// @see #bt_class_s
+final class bt_avrcp_metadata_attributes_info_s extends ffi.Struct {
+  /// < Title
+  external ffi.Pointer<ffi.Char> title;
+
+  /// < Artist
+  external ffi.Pointer<ffi.Char> artist;
+
+  /// < Album name
+  external ffi.Pointer<ffi.Char> album;
+
+  /// < Album Genre
+  external ffi.Pointer<ffi.Char> genre;
+
+  /// < The total number of tracks
+  @ffi.UnsignedInt()
+  external int total_tracks;
+
+  /// < Track number
+  @ffi.UnsignedInt()
+  external int number;
+
+  /// < Duration
+  @ffi.UnsignedInt()
+  external int duration;
+}
+
+/// @deprecated Deprecated since 5.0.
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
+/// @brief  Enumerations for the data channel type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+/// @remarks Deprecated, because of no usecase and supported devices.
+abstract class bt_hdp_channel_type_e {
+  /// < Reliable Data Channel
+  static const int BT_HDP_CHANNEL_TYPE_RELIABLE = 1;
+
+  /// < Streaming Data Channel
+  static const int BT_HDP_CHANNEL_TYPE_STREAMING = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the integer type for GATT handle's value.
+/// @since_tizen 2.3.1
+abstract class bt_data_type_int_e {
+  /// < 8 bit signed int type
+  static const int BT_DATA_TYPE_SINT8 = 0;
+
+  /// < 16 bit signed int type
+  static const int BT_DATA_TYPE_SINT16 = 1;
+
+  /// < 32 bit signed int type
+  static const int BT_DATA_TYPE_SINT32 = 2;
+
+  /// < 8 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT8 = 3;
+
+  /// < 16 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT16 = 4;
+
+  /// < 32 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT32 = 5;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the float type for GATT handle's value.
+/// @since_tizen 2.3.1
+abstract class bt_data_type_float_e {
+  /// < 32 bit float type
+  static const int BT_DATA_TYPE_FLOAT = 0;
+
+  /// < 16 bit float type
+  static const int BT_DATA_TYPE_SFLOAT = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the write type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_write_type_e {
+  /// < Write without response type
+  static const int BT_GATT_WRITE_TYPE_WRITE_NO_RESPONSE = 0;
+
+  /// < Write type
+  static const int BT_GATT_WRITE_TYPE_WRITE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the GATT handle's type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_type_e {
+  /// < GATT service type
+  static const int BT_GATT_TYPE_SERVICE = 1;
+
+  /// < GATT characteristic type
+  static const int BT_GATT_TYPE_CHARACTERISTIC = 2;
+
+  /// < GATT descriptor type
+  static const int BT_GATT_TYPE_DESCRIPTOR = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the service type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_service_type_e {
+  /// < GATT primary service type
+  static const int BT_GATT_SERVICE_TYPE_PRIMARY = 1;
+
+  /// < GATT secondary service type
+  static const int BT_GATT_SERVICE_TYPE_SECONDARY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the characteristic's property.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_property_e {
+  /// < Broadcast property
+  static const int BT_GATT_PROPERTY_BROADCAST = 1;
+
+  /// < Read property
+  static const int BT_GATT_PROPERTY_READ = 2;
+
+  /// < Write without response property
+  static const int BT_GATT_PROPERTY_WRITE_WITHOUT_RESPONSE = 4;
+
+  /// < Write property
+  static const int BT_GATT_PROPERTY_WRITE = 8;
+
+  /// < Notify property
+  static const int BT_GATT_PROPERTY_NOTIFY = 16;
+
+  /// < Indicate property
+  static const int BT_GATT_PROPERTY_INDICATE = 32;
+
+  /// < Authenticated signed writes property
+  static const int BT_GATT_PROPERTY_AUTHENTICATED_SIGNED_WRITES = 64;
+
+  /// < Extended properties
+  static const int BT_GATT_PROPERTY_EXTENDED_PROPERTIES = 128;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
+/// @brief  Enumerations of gatt server's service changing mode.
+/// @since_tizen 3.0
+abstract class bt_gatt_client_service_change_type_e {
+  /// < Service added
+  static const int BT_GATT_CLIENT_SERVICE_ADDED = 0;
+
+  /// < Service removed
+  static const int BT_GATT_CLIENT_SERVICE_REMOVED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the attribute's permission.
+/// @since_tizen 3.0
+abstract class bt_gatt_permission_e {
+  /// < Readable permission
+  static const int BT_GATT_PERMISSION_READ = 1;
+
+  /// < Writable permission
+  static const int BT_GATT_PERMISSION_WRITE = 2;
+
+  /// < Readable permission required encryption
+  static const int BT_GATT_PERMISSION_ENCRYPT_READ = 4;
+
+  /// < Writable permission required encryption
+  static const int BT_GATT_PERMISSION_ENCRYPT_WRITE = 8;
+
+  /// < Readable permission required encryption and authentication
+  static const int BT_GATT_PERMISSION_ENCRYPT_AUTHENTICATED_READ = 16;
+
+  /// < Writable permission required encryption and authentication
+  static const int BT_GATT_PERMISSION_ENCRYPT_AUTHENTICATED_WRITE = 32;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
+/// @brief  Enumerations of the remote device request types for attributes.
+/// @since_tizen 3.0
+abstract class bt_gatt_att_request_type_e {
+  /// < Read Requested
+  static const int BT_GATT_REQUEST_TYPE_READ = 0;
+
+  /// < Write Requested
+  static const int BT_GATT_REQUEST_TYPE_WRITE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PAN_PANU_MODULE
+/// @brief  Enumerations for the types of PAN (Personal Area Networking) service.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_panu_service_type_e {
+  /// < Network Access Point
+  static const int BT_PANU_SERVICE_TYPE_NAP = 0;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of address book location for PBAP.
+/// @since_tizen 3.0
+abstract class bt_pbap_address_book_source_e {
+  /// < Request for Addressbook from remote device
+  static const int BT_PBAP_SOURCE_DEVICE = 0;
+
+  /// < Request for address book from SIM
+  static const int BT_PBAP_SOURCE_SIM = 1;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of folder type.
+/// @since_tizen 3.0
+abstract class bt_pbap_folder_type_e {
+  /// < Request for address book
+  static const int BT_PBAP_FOLDER_PHONE_BOOK = 0;
+
+  /// < Request for incoming calls
+  static const int BT_PBAP_FOLDER_INCOMING = 1;
+
+  /// < Request for outgoing calls
+  static const int BT_PBAP_FOLDER_OUTGOING = 2;
+
+  /// < Request for missed calls
+  static const int BT_PBAP_FOLDER_MISSED = 3;
+
+  /// < Request for combined calls
+  static const int BT_PBAP_FOLDER_COMBINED = 4;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of phone book search fields.
+/// @since_tizen 3.0
+abstract class bt_pbap_search_field_e {
+  /// < Request for search by name (default)
+  static const int BT_PBAP_SEARCH_NAME = 0;
+
+  /// < Request for search by phone number
+  static const int BT_PBAP_SEARCH_NUMBER = 1;
+
+  /// < Request for search by sound
+  static const int BT_PBAP_SEARCH_SOUND = 2;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of vCard Formats.
+/// @since_tizen 3.0
+abstract class bt_pbap_vcard_format_e {
+  /// < vCard format 2.1 (default)
+  static const int BT_PBAP_VCARD_FORMAT_VCARD21 = 0;
+
+  /// < vCard format 3.0
+  static const int BT_PBAP_VCARD_FORMAT_VCARD30 = 1;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of sorting orders.
+/// @since_tizen 3.0
+abstract class bt_pbap_sort_order_e {
+  /// < Filter order indexed (default)
+  static const int BT_PBAP_ORDER_INDEXED = 0;
+
+  /// < Filter order alphanumeric
+  static const int BT_PBAP_ORDER_ALPHANUMERIC = 1;
+
+  /// < Filter order phonetic
+  static const int BT_PBAP_ORDER_PHONETIC = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Class structure of device and service.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see #bt_device_info_s
+/// @see #bt_adapter_device_discovery_info_s
+/// @see bt_device_bond_created_cb()
+/// @see bt_adapter_device_discovery_state_changed_cb()
+final class bt_class_s extends ffi.Struct {
+  /// < Major device class.
+  @ffi.Int32()
+  external int major_device_class;
+
+  /// < Minor device class.
+  @ffi.Int32()
+  external int minor_device_class;
+
+  /// < Major service class mask.
+  /// This value can be a combination of #bt_major_service_class_e like #BT_MAJOR_SERVICE_CLASS_RENDERING | #BT_MAJOR_SERVICE_CLASS_AUDIO
+  @ffi.Int()
+  external int major_service_class_mask;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief Structure of device discovery information.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see #bt_class_s
+/// @see bt_adapter_device_discovery_state_changed_cb()
+final class bt_adapter_device_discovery_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The name of remote device
+  external ffi.Pointer<ffi.Char> remote_name;
+
+  /// < The Bluetooth classes
+  external bt_class_s bt_class;
+
+  /// < The strength indicator of received signal
+  @ffi.Int()
+  external int rssi;
+
+  /// < The bonding state
+  @ffi.Bool()
+  external bool is_bonded;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services
+  @ffi.Int()
+  external int service_count;
+
+  /// < The Bluetooth appearance
+  @ffi.Int32()
+  external int appearance;
+
+  /// < manufacturer specific data length
+  @ffi.Int()
+  external int manufacturer_data_len;
+
+  /// < manufacturer specific data
+  external ffi.Pointer<ffi.Char> manufacturer_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief Structure of le scan result information.
+/// @since_tizen 2.3.1
+///
+/// @see bt_adapter_le_start_scan()
+final class bt_adapter_le_device_scan_result_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The address type of remote device
+  @ffi.Int32()
+  external int address_type;
+
+  /// < The strength indicator of received signal
+  @ffi.Int()
+  external int rssi;
+
+  /// < advertising indication data length
+  @ffi.Int()
+  external int adv_data_len;
+
+  /// < advertising indication data
+  external ffi.Pointer<ffi.Char> adv_data;
+
+  /// < scan response data length
+  @ffi.Int()
+  external int scan_data_len;
+
+  /// < scan response data
+  external ffi.Pointer<ffi.Char> scan_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief The structure for LE iBeacon scan result information.
+/// @since_tizen 4.0
+///
+/// @see bt_adapter_le_start_scan()
+final class bt_adapter_le_ibeacon_scan_result_info_s extends ffi.Struct {
+  /// < Company ID
+  @ffi.Int()
+  external int company_id;
+
+  /// < iBeacon type
+  @ffi.Int()
+  external int ibeacon_type;
+
+  /// < UUID
+  external ffi.Pointer<ffi.Char> uuid;
+
+  /// < Major ID
+  @ffi.Int()
+  external int major_id;
+
+  /// < Minor ID
+  @ffi.Int()
+  external int minor_id;
+
+  /// < Measured power
+  @ffi.Int()
+  external int measured_power;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief LE service data structure.
+/// @since_tizen 2.3.1
+///
+/// @see bt_adapter_le_get_scan_result_service_data()
+final class bt_adapter_le_service_data_s extends ffi.Struct {
+  /// < 16 bit UUID of the service data
+  external ffi.Pointer<ffi.Char> service_uuid;
+
+  /// < Service data
+  external ffi.Pointer<ffi.Char> service_data;
+
+  /// < Service data length
+  @ffi.Int()
+  external int service_data_len;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Device information structure used for identifying pear device.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see #bt_class_s
+/// @see bt_device_bond_created_cb()
+final class bt_device_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The name of remote device
+  external ffi.Pointer<ffi.Char> remote_name;
+
+  /// < The Bluetooth classes
+  external bt_class_s bt_class;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services
+  @ffi.Int()
+  external int service_count;
+
+  /// < The bonding state
+  @ffi.Bool()
+  external bool is_bonded;
+
+  /// < The connection state
+  @ffi.Bool()
+  external bool is_connected;
+
+  /// < The authorization state
+  @ffi.Bool()
+  external bool is_authorized;
+
+  /// < manufacturer specific data length
+  @ffi.Int()
+  external int manufacturer_data_len;
+
+  /// < manufacturer specific data
+  external ffi.Pointer<ffi.Char> manufacturer_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Service Discovery Protocol (SDP) data structure.
+///
+/// @details This protocol is used for discovering available services or pear device,
+/// and finding one to connect with.
+///
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+/// @see bt_device_service_searched_cb()
+final class bt_device_sdp_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services.
+  @ffi.Int()
+  external int service_count;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Device connection information structure.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see bt_device_connection_state_changed_cb()
+final class bt_device_connection_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < Link type
+  @ffi.Int32()
+  external int link;
+
+  /// < Disconnection reason
+  @ffi.Int32()
+  external int disconn_reason;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief Rfcomm connection data used for exchanging data between Bluetooth devices.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see bt_socket_connection_state_changed_cb()
+final class bt_socket_connection_s extends ffi.Struct {
+  /// < The file descriptor of connected socket
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The file descriptor of the server socket or -1 for client connection
+  @ffi.Int()
+  external int server_fd;
+
+  /// < The local device role in this connection
+  @ffi.Int32()
+  external int local_role;
+
+  /// < The remote device address
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The service UUId
+  external ffi.Pointer<ffi.Char> service_uuid;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief Structure of RFCOMM received data.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @remarks User can use standard linux functions for reading/writing \n
+/// data from/to sockets.
+///
+/// @see bt_socket_data_received_cb()
+final class bt_socket_received_data_s extends ffi.Struct {
+  /// < The socket fd
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The length of the received data
+  @ffi.Int()
+  external int data_size;
+
+  /// < The received data
+  external ffi.Pointer<ffi.Char> data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
+/// @brief Attribute protocol MTU change information structure.
+/// @since_tizen 4.0
+///
+/// @see bt_gatt_client_att_mtu_changed_cb()
+final class bt_gatt_client_att_mtu_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < MTU value
+  @ffi.UnsignedInt()
+  external int mtu;
+
+  /// < Request status
+  @ffi.UnsignedInt()
+  external int status;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID mouse's button.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_mouse_button_e {
+  /// <The mouse's none value
+  static const int BT_HID_MOUSE_BUTTON_NONE = 0;
+
+  /// <The mouse's left button value
+  static const int BT_HID_MOUSE_BUTTON_LEFT = 1;
+
+  /// <The mouse's right button value
+  static const int BT_HID_MOUSE_BUTTON_RIGHT = 2;
+
+  /// <The mouse's middle button value
+  static const int BT_HID_MOUSE_BUTTON_MIDDLE = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing the HID mouse event information.
+/// @since_tizen @if WEARABLE 3.0 @endif
+///
+/// @see bt_hid_device_send_mouse_event()
+final class bt_hid_mouse_data_s extends ffi.Struct {
+  /// < The button values, we can combine key's values when we pressed multiple mouse buttons
+  @ffi.Int()
+  external int buttons;
+
+  /// < The location's x value, -128 ~127
+  @ffi.Int()
+  external int axis_x;
+
+  /// < The location's y value, -128 ~127
+  @ffi.Int()
+  external int axis_y;
+
+  /// < The padding value, -128 ~127
+  @ffi.Int()
+  external int padding;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing the HID keyboard event information.
+/// @details If you want to know more detail values, refer to http://www.usb.org/developers/hidpage/ and see "HID Usage Tables"
+/// @since_tizen @if WEARABLE 3.0 @endif
+///
+/// @see bt_hid_device_send_key_event()
+final class bt_hid_key_data_s extends ffi.Struct {
+  /// < The modifier keys : such as shift, alt
+  @ffi.UnsignedChar()
+  external int modifier;
+
+  /// < The key value - currently pressed keys : Max 8 at once
+  @ffi.Array.multi([8])
+  external ffi.Array<ffi.UnsignedChar> key;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID header type.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_header_type_e {
+  /// < The Bluetooth HID header type: Handshake
+  static const int BT_HID_HEADER_HANDSHAKE = 0;
+
+  /// < The Bluetooth HID header type: HID control
+  static const int BT_HID_HEADER_HID_CONTROL = 1;
+
+  /// < The Bluetooth HID header type: Get report
+  static const int BT_HID_HEADER_GET_REPORT = 2;
+
+  /// < The Bluetooth HID header type: Set report
+  static const int BT_HID_HEADER_SET_REPORT = 3;
+
+  /// < The Bluetooth HID header type: Get protocol
+  static const int BT_HID_HEADER_GET_PROTOCOL = 4;
+
+  /// < The Bluetooth HID header type: Set protocol
+  static const int BT_HID_HEADER_SET_PROTOCOL = 5;
+
+  /// < The Bluetooth HID header type: Data
+  static const int BT_HID_HEADER_DATA = 6;
+
+  /// < The Bluetooth HID header type: Unknown
+  static const int BT_HID_HEADER_UNKNOWN = 7;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID parameter type.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_param_type_e {
+  /// < Parameter type: Input
+  static const int BT_HID_PARAM_DATA_RTYPE_INPUT = 0;
+
+  /// < Parameter type: Output
+  static const int BT_HID_PARAM_DATA_RTYPE_OUTPUT = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID handshake type.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_handshake_type_e {
+  /// < Handshake error code none
+  static const int BT_HID_HANDSHAKE_SUCCESSFUL = 0;
+
+  /// < Handshake error code Not Ready
+  static const int BT_HID_HANDSHAKE_NOT_READY = 1;
+
+  /// < Handshake error code send invalid report id
+  static const int BT_HID_HANDSHAKE_ERR_INVALID_REPORT_ID = 2;
+
+  /// < Handshake error code request unsupported request
+  static const int BT_HID_HANDSHAKE_ERR_UNSUPPORTED_REQUEST = 3;
+
+  /// < Handshake error code received invalid parameter
+  static const int BT_HID_HANDSHAKE_ERR_INVALID_PARAMETER = 4;
+
+  /// < unknown error
+  static const int BT_HID_HANDSHAKE_ERR_UNKNOWN = 14;
+
+  /// < Fatal error
+  static const int BT_HID_HANDSHAKE_ERR_FATAL = 15;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing data received from the HID Host.
+/// @since_tizen @if WEARABLE 3.0 @endif
+final class bt_hid_device_received_data_s extends ffi.Struct {
+  /// < The remote device's address
+  external ffi.Pointer<ffi.Char> address;
+
+  /// < The header type
+  @ffi.Int32()
+  external int header_type;
+
+  /// < The parameter type
+  @ffi.Int32()
+  external int param_type;
+
+  /// < The length of the received data
+  @ffi.Int()
+  external int data_size;
+
+  /// < The received data
+  external ffi.Pointer<ffi.Char> data;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief The structure type containing vCard information.
+/// @since_tizen 3.0
+///
+/// @see bt_pbap_client_pull_vcard()
+final class bt_pbap_vcard_info_s extends ffi.Struct {
+  /// < The vcard index, used as a parameter for bt_pbap_client_pull_vcard()
+  @ffi.Int()
+  external int index;
+
+  /// < The contact name of the vCard
+  external ffi.Pointer<ffi.Char> contact_name;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief Enumeration for the scan filter type.
+/// @since_tizen 4.0
+/// @see bt_adapter_le_scan_filter_set_type()
+abstract class bt_adapter_le_scan_filter_type_e {
+  /// < iBeacon filter type
+  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_IBEACON = 0;
+
+  /// < Proximity UUID filter type
+  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_PROXIMITY_UUID = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief  Called when you get bonded devices repeatedly.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @param[in] device_info The bonded device information
+/// @param[in] user_data The user data passed from the foreach function
+/// @return @c true to continue with the next iteration of the loop,
+/// \n @c false to break out of the loop.
+/// @pre bt_adapter_foreach_bonded_device() will invoke this function.
+///
+/// @see bt_adapter_foreach_bonded_device()
+typedef bt_adapter_bonded_device_cb
+    = ffi.Pointer<ffi.NativeFunction<bt_adapter_bonded_device_cbFunction>>;
+typedef bt_adapter_bonded_device_cbFunction = ffi.Bool Function(
+    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
+typedef Dartbt_adapter_bonded_device_cbFunction = bool Function(
+    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
+
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
 /// @brief  Called when the Bluetooth adapter state changes.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
@@ -10241,80 +11500,6 @@ typedef Dartbt_adapter_device_discovery_state_changed_cbFunction
         ffi.Pointer<bt_adapter_device_discovery_info_s> discovery_info,
         ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief Enumerations of the discovery state of Bluetooth device.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_adapter_device_discovery_state_e {
-  /// < Device discovery is started
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_STARTED = 0;
-
-  /// < Device discovery is finished
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_FINISHED = 1;
-
-  /// < The remote Bluetooth device is found
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_FOUND = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief Structure of device discovery information.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see #bt_class_s
-/// @see bt_adapter_device_discovery_state_changed_cb()
-final class bt_adapter_device_discovery_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The name of remote device
-  external ffi.Pointer<ffi.Char> remote_name;
-
-  /// < The Bluetooth classes
-  external bt_class_s bt_class;
-
-  /// < The strength indicator of received signal
-  @ffi.Int()
-  external int rssi;
-
-  /// < The bonding state
-  @ffi.Bool()
-  external bool is_bonded;
-
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
-
-  /// < The number of services
-  @ffi.Int()
-  external int service_count;
-
-  /// < The Bluetooth appearance
-  @ffi.Int32()
-  external int appearance;
-
-  /// < manufacturer specific data length
-  @ffi.Int()
-  external int manufacturer_data_len;
-
-  /// < manufacturer specific data
-  external ffi.Pointer<ffi.Char> manufacturer_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief  Enumerations of gap appearance type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_appearance_type_e {
-  /// < Unknown appearance type
-  static const int BT_APPEARANCE_TYPE_UNKNOWN = 0;
-
-  /// < Generic Phone type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_PHONE = 64;
-
-  /// < Generic Computer type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_COMPUTER = 128;
-
-  /// < Generic Watch type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_WATCH = 192;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief  Called when the LE advertisement has been found.
 /// @since_tizen 2.3.1
@@ -10334,107 +11519,6 @@ typedef Dartbt_adapter_le_scan_result_cbFunction = void Function(
     int result,
     ffi.Pointer<bt_adapter_le_device_scan_result_info_s> info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief Structure of le scan result information.
-/// @since_tizen 2.3.1
-///
-/// @see bt_adapter_le_start_scan()
-final class bt_adapter_le_device_scan_result_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The address type of remote device
-  @ffi.Int32()
-  external int address_type;
-
-  /// < The strength indicator of received signal
-  @ffi.Int()
-  external int rssi;
-
-  /// < advertising indication data length
-  @ffi.Int()
-  external int adv_data_len;
-
-  /// < advertising indication data
-  external ffi.Pointer<ffi.Char> adv_data;
-
-  /// < scan response data length
-  @ffi.Int()
-  external int scan_data_len;
-
-  /// < scan response data
-  external ffi.Pointer<ffi.Char> scan_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device address type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_address_type_e {
-  /// < Public address
-  static const int BT_DEVICE_PUBLIC_ADDRESS = 0;
-
-  /// < Random address
-  static const int BT_DEVICE_RANDOM_ADDRESS = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth LE packet type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_adapter_le_packet_type_e {
-  /// < Advertising packet
-  static const int BT_ADAPTER_LE_PACKET_ADVERTISING = 0;
-
-  /// < Scan response packet
-  static const int BT_ADAPTER_LE_PACKET_SCAN_RESPONSE = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief LE service data structure.
-/// @since_tizen 2.3.1
-///
-/// @see bt_adapter_le_get_scan_result_service_data()
-final class bt_adapter_le_service_data_s extends ffi.Struct {
-  /// < 16 bit UUID of the service data
-  external ffi.Pointer<ffi.Char> service_uuid;
-
-  /// < Service data
-  external ffi.Pointer<ffi.Char> service_data;
-
-  /// < Service data length
-  @ffi.Int()
-  external int service_data_len;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief The structure for LE iBeacon scan result information.
-/// @since_tizen 4.0
-///
-/// @see bt_adapter_le_start_scan()
-final class bt_adapter_le_ibeacon_scan_result_info_s extends ffi.Struct {
-  /// < Company ID
-  @ffi.Int()
-  external int company_id;
-
-  /// < iBeacon type
-  @ffi.Int()
-  external int ibeacon_type;
-
-  /// < UUID
-  external ffi.Pointer<ffi.Char> uuid;
-
-  /// < Major ID
-  @ffi.Int()
-  external int major_id;
-
-  /// < Minor ID
-  @ffi.Int()
-  external int minor_id;
-
-  /// < Measured power
-  @ffi.Int()
-  external int measured_power;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief The handle to control Bluetooth LE advertising.
@@ -10505,56 +11589,6 @@ typedef Dartbt_adapter_le_advertising_state_changed_cbFunction = void Function(
     int adv_state,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth advertising state.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_adapter_le_advertising_state_e {
-  /// < Bluetooth advertising is stopped
-  static const int BT_ADAPTER_LE_ADVERTISING_STOPPED = 0;
-
-  /// < Bluetooth advertising is started
-  static const int BT_ADAPTER_LE_ADVERTISING_STARTED = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth advertising mode.
-/// @since_tizen 2.3.1
-abstract class bt_adapter_le_advertising_mode_e {
-  /// < Balanced advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_BALANCED = 0;
-
-  /// < Low latency advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_LATENCY = 1;
-
-  /// < Low energy advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_ENERGY = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth le scan mode.
-/// @since_tizen 3.0
-abstract class bt_adapter_le_scan_mode_e {
-  /// < Balanced mode of power consumption and connection latency
-  static const int BT_ADAPTER_LE_SCAN_MODE_BALANCED = 0;
-
-  /// < Low connection latency but high power consumption
-  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_LATENCY = 1;
-
-  /// < Low power consumption but high connection latency
-  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_ENERGY = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device authorization state.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_authorization_e {
-  /// < The remote Bluetooth device is authorized
-  static const int BT_DEVICE_AUTHORIZED = 0;
-
-  /// < The remote Bluetooth device is unauthorized
-  static const int BT_DEVICE_UNAUTHORIZED = 1;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief  Called when you get connected profiles repeatedly.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
@@ -10571,52 +11605,6 @@ typedef bt_device_connected_profileFunction = ffi.Bool Function(
     ffi.Int32 profile, ffi.Pointer<ffi.Void> user_data);
 typedef Dartbt_device_connected_profileFunction = bool Function(
     int profile, ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of Bluetooth profile.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_profile_e {
-  /// < RFCOMM Profile
-  static const int BT_PROFILE_RFCOMM = 1;
-
-  /// < Advanced Audio Distribution Profile Source role
-  static const int BT_PROFILE_A2DP = 2;
-
-  /// < Headset Profile
-  static const int BT_PROFILE_HSP = 4;
-
-  /// < Human Interface Device Profile
-  static const int BT_PROFILE_HID = 8;
-
-  /// < Network Access Point Profile
-  static const int BT_PROFILE_NAP = 16;
-
-  /// < Audio Gateway Profile
-  static const int BT_PROFILE_AG = 32;
-
-  /// < Generic Attribute Profile
-  static const int BT_PROFILE_GATT = 64;
-
-  /// < NAP server Profile
-  static const int BT_PROFILE_NAP_SERVER = 128;
-
-  /// < Advanced Audio Distribution Profile Sink role
-  static const int BT_PROFILE_A2DP_SINK = 256;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief  Enumerations of the Bluetooth device's LE connection mode.
-/// @since_tizen 3.0
-abstract class bt_device_le_connection_mode_e {
-  /// < Balanced mode of power consumption and connection latency
-  static const int BT_DEVICE_LE_CONNECTION_MODE_BALANCED = 0;
-
-  /// < Low connection latency but high power consumption
-  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_LATENCY = 1;
-
-  /// < Low power consumption but high connection latency
-  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_ENERGY = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief Called when the process of creating bond finishes.
@@ -10714,26 +11702,6 @@ typedef Dartbt_device_service_searched_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Service Discovery Protocol (SDP) data structure.
-///
-/// @details This protocol is used for discovering available services or pear device,
-/// and finding one to connect with.
-///
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-/// @see bt_device_service_searched_cb()
-final class bt_device_sdp_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
-
-  /// < The number of services.
-  @ffi.Int()
-  external int service_count;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief  Called when the connection state is changed.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
 ///
@@ -10752,55 +11720,6 @@ typedef Dartbt_device_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<bt_device_connection_info_s> conn_info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Device connection information structure.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see bt_device_connection_state_changed_cb()
-final class bt_device_connection_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < Link type
-  @ffi.Int32()
-  external int link;
-
-  /// < Disconnection reason
-  @ffi.Int32()
-  external int disconn_reason;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of connection link type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_connection_link_type_e {
-  /// < BR/EDR link
-  static const int BT_DEVICE_CONNECTION_LINK_BREDR = 0;
-
-  /// < LE link
-  static const int BT_DEVICE_CONNECTION_LINK_LE = 1;
-
-  /// < The connection type default
-  static const int BT_DEVICE_CONNECTION_LINK_DEFAULT = 255;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device disconnect reason.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_disconnect_reason_e {
-  /// < Disconnected by unknown reason
-  static const int BT_DEVICE_DISCONNECT_REASON_UNKNOWN = 0;
-
-  /// < Disconnected by timeout
-  static const int BT_DEVICE_DISCONNECT_REASON_TIMEOUT = 1;
-
-  /// < Disconnected by local host
-  static const int BT_DEVICE_DISCONNECT_REASON_LOCAL_HOST = 2;
-
-  /// < Disconnected by remote
-  static const int BT_DEVICE_DISCONNECT_REASON_REMOTE = 3;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief Called when you receive data.
@@ -10823,27 +11742,6 @@ typedef bt_socket_data_received_cbFunction = ffi.Void Function(
 typedef Dartbt_socket_data_received_cbFunction = void Function(
     ffi.Pointer<bt_socket_received_data_s> data,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief Structure of RFCOMM received data.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @remarks User can use standard linux functions for reading/writing \n
-/// data from/to sockets.
-///
-/// @see bt_socket_data_received_cb()
-final class bt_socket_received_data_s extends ffi.Struct {
-  /// < The socket fd
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The length of the received data
-  @ffi.Int()
-  external int data_size;
-
-  /// < The received data
-  external ffi.Pointer<ffi.Char> data;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief  Called when a RFCOMM connection is requested.
@@ -10891,56 +11789,6 @@ typedef Dartbt_socket_connection_state_changed_cbFunction = void Function(
     int connection_state,
     ffi.Pointer<bt_socket_connection_s> connection,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief  Enumerations of Bluetooth socket connection state.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_socket_connection_state_e {
-  /// < RFCOMM is connected
-  static const int BT_SOCKET_CONNECTED = 0;
-
-  /// < RFCOMM is disconnected
-  static const int BT_SOCKET_DISCONNECTED = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief Rfcomm connection data used for exchanging data between Bluetooth devices.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see bt_socket_connection_state_changed_cb()
-final class bt_socket_connection_s extends ffi.Struct {
-  /// < The file descriptor of connected socket
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The file descriptor of the server socket or -1 for client connection
-  @ffi.Int()
-  external int server_fd;
-
-  /// < The local device role in this connection
-  @ffi.Int32()
-  external int local_role;
-
-  /// < The remote device address
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The service UUId
-  external ffi.Pointer<ffi.Char> service_uuid;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief  Enumerations of connected Bluetooth device event role.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_socket_role_e {
-  /// < Unknown role
-  static const int BT_SOCKET_UNKNOWN = 0;
-
-  /// < Server role
-  static const int BT_SOCKET_SERVER = 1;
-
-  /// < Client role
-  static const int BT_SOCKET_CLIENT = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_OPP_SERVER_MODULE
 /// @brief  Called when an OPP connection is requested.
@@ -11112,45 +11960,6 @@ typedef Dartbt_hid_device_connection_state_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing the HID mouse event information.
-/// @since_tizen @if WEARABLE 3.0 @endif
-///
-/// @see bt_hid_device_send_mouse_event()
-final class bt_hid_mouse_data_s extends ffi.Struct {
-  /// < The button values, we can combine key's values when we pressed multiple mouse buttons
-  @ffi.Int()
-  external int buttons;
-
-  /// < The location's x value, -128 ~127
-  @ffi.Int()
-  external int axis_x;
-
-  /// < The location's y value, -128 ~127
-  @ffi.Int()
-  external int axis_y;
-
-  /// < The padding value, -128 ~127
-  @ffi.Int()
-  external int padding;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing the HID keyboard event information.
-/// @details If you want to know more detail values, refer to http://www.usb.org/developers/hidpage/ and see "HID Usage Tables"
-/// @since_tizen @if WEARABLE 3.0 @endif
-///
-/// @see bt_hid_device_send_key_event()
-final class bt_hid_key_data_s extends ffi.Struct {
-  /// < The modifier keys : such as shift, alt
-  @ffi.UnsignedChar()
-  external int modifier;
-
-  /// < The key value - currently pressed keys : Max 8 at once
-  @ffi.Array.multi([8])
-  external ffi.Array<ffi.UnsignedChar> key;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
 /// @brief  Called when the HID Device receives data from the HID Host.
 /// @details The following error codes can be delivered: \n
 /// #BT_ERROR_NONE \n
@@ -11168,89 +11977,6 @@ typedef bt_hid_device_data_received_cbFunction = ffi.Void Function(
 typedef Dartbt_hid_device_data_received_cbFunction = void Function(
     ffi.Pointer<bt_hid_device_received_data_s> data,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing data received from the HID Host.
-/// @since_tizen @if WEARABLE 3.0 @endif
-final class bt_hid_device_received_data_s extends ffi.Struct {
-  /// < The remote device's address
-  external ffi.Pointer<ffi.Char> address;
-
-  /// < The header type
-  @ffi.Int32()
-  external int header_type;
-
-  /// < The parameter type
-  @ffi.Int32()
-  external int param_type;
-
-  /// < The length of the received data
-  @ffi.Int()
-  external int data_size;
-
-  /// < The received data
-  external ffi.Pointer<ffi.Char> data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief Enumerations of the Bluetooth HID header type.
-/// @since_tizen @if WEARABLE 3.0 @endif
-abstract class bt_hid_header_type_e {
-  /// < The Bluetooth HID header type: Handshake
-  static const int BT_HID_HEADER_HANDSHAKE = 0;
-
-  /// < The Bluetooth HID header type: HID control
-  static const int BT_HID_HEADER_HID_CONTROL = 1;
-
-  /// < The Bluetooth HID header type: Get report
-  static const int BT_HID_HEADER_GET_REPORT = 2;
-
-  /// < The Bluetooth HID header type: Set report
-  static const int BT_HID_HEADER_SET_REPORT = 3;
-
-  /// < The Bluetooth HID header type: Get protocol
-  static const int BT_HID_HEADER_GET_PROTOCOL = 4;
-
-  /// < The Bluetooth HID header type: Set protocol
-  static const int BT_HID_HEADER_SET_PROTOCOL = 5;
-
-  /// < The Bluetooth HID header type: Data
-  static const int BT_HID_HEADER_DATA = 6;
-
-  /// < The Bluetooth HID header type: Unknown
-  static const int BT_HID_HEADER_UNKNOWN = 7;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief Enumerations of the Bluetooth HID parameter type.
-/// @since_tizen @if WEARABLE 3.0 @endif
-abstract class bt_hid_param_type_e {
-  /// < Parameter type: Input
-  static const int BT_HID_PARAM_DATA_RTYPE_INPUT = 0;
-
-  /// < Parameter type: Output
-  static const int BT_HID_PARAM_DATA_RTYPE_OUTPUT = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
-/// @brief  Enumerations for the types of profiles related with audio.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_audio_profile_type_e {
-  /// < All supported profiles related with audio
-  static const int BT_AUDIO_PROFILE_TYPE_ALL = 0;
-
-  /// < HSP(Headset Profile) and HFP(Hands-Free Profile)
-  static const int BT_AUDIO_PROFILE_TYPE_HSP_HFP = 1;
-
-  /// < A2DP(Advanced Audio Distribution Profile)
-  static const int BT_AUDIO_PROFILE_TYPE_A2DP = 2;
-
-  /// < AG(Audio Gateway)
-  static const int BT_AUDIO_PROFILE_TYPE_AG = 3;
-
-  /// < A2DP(Advanced Audio Distribution Profile) Sink role
-  static const int BT_AUDIO_PROFILE_TYPE_A2DP_SINK = 4;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
 /// @brief  Called when the connection state is changed.
@@ -11299,82 +12025,6 @@ typedef Dartbt_avrcp_target_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<ffi.Char> remote_address,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the equalizer state.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_equalizer_state_e {
-  /// < Equalizer Off
-  static const int BT_AVRCP_EQUALIZER_STATE_OFF = 1;
-
-  /// < Equalizer On
-  static const int BT_AVRCP_EQUALIZER_STATE_ON = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the repeat mode.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_repeat_mode_e {
-  /// < Repeat Off
-  static const int BT_AVRCP_REPEAT_MODE_OFF = 1;
-
-  /// < Single track repeat
-  static const int BT_AVRCP_REPEAT_MODE_SINGLE_TRACK = 2;
-
-  /// < All track repeat
-  static const int BT_AVRCP_REPEAT_MODE_ALL_TRACK = 3;
-
-  /// < Group repeat
-  static const int BT_AVRCP_REPEAT_MODE_GROUP = 4;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the shuffle mode.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_shuffle_mode_e {
-  /// < Shuffle Off
-  static const int BT_AVRCP_SHUFFLE_MODE_OFF = 1;
-
-  /// < All tracks shuffle
-  static const int BT_AVRCP_SHUFFLE_MODE_ALL_TRACK = 2;
-
-  /// < Group shuffle
-  static const int BT_AVRCP_SHUFFLE_MODE_GROUP = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the scan mode.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_scan_mode_e {
-  /// < Scan Off
-  static const int BT_AVRCP_SCAN_MODE_OFF = 1;
-
-  /// < All tracks scan
-  static const int BT_AVRCP_SCAN_MODE_ALL_TRACK = 2;
-
-  /// < Group scan
-  static const int BT_AVRCP_SCAN_MODE_GROUP = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the player state.
-/// @since_tizen 3.0
-abstract class bt_avrcp_player_state_e {
-  /// < Stopped
-  static const int BT_AVRCP_PLAYER_STATE_STOPPED = 0;
-
-  /// < Playing
-  static const int BT_AVRCP_PLAYER_STATE_PLAYING = 1;
-
-  /// < Paused
-  static const int BT_AVRCP_PLAYER_STATE_PAUSED = 2;
-
-  /// < Seek Forward
-  static const int BT_AVRCP_PLAYER_STATE_FORWARD_SEEK = 3;
-
-  /// < Seek Rewind
-  static const int BT_AVRCP_PLAYER_STATE_REWIND_SEEK = 4;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
 /// @brief  Called when the equalizer state is changed by the remote control device.
@@ -11481,37 +12131,6 @@ typedef Dartbt_avrcp_track_info_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief Structure of Track metadata information.
-/// @since_tizen 3.0
-///
-/// @see #bt_class_s
-final class bt_avrcp_metadata_attributes_info_s extends ffi.Struct {
-  /// < Title
-  external ffi.Pointer<ffi.Char> title;
-
-  /// < Artist
-  external ffi.Pointer<ffi.Char> artist;
-
-  /// < Album name
-  external ffi.Pointer<ffi.Char> album;
-
-  /// < Album Genre
-  external ffi.Pointer<ffi.Char> genre;
-
-  /// < The total number of tracks
-  @ffi.UnsignedInt()
-  external int total_tracks;
-
-  /// < Track number
-  @ffi.UnsignedInt()
-  external int number;
-
-  /// < Duration
-  @ffi.UnsignedInt()
-  external int duration;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
 /// @brief  Called when the connection state is changed.
 /// @since_tizen 3.0
 /// @param[in] connected  The state to be changed. true means connected state, Otherwise, false.
@@ -11527,32 +12146,6 @@ typedef bt_avrcp_control_connection_state_changed_cbFunction
 typedef Dartbt_avrcp_control_connection_state_changed_cbFunction
     = void Function(bool connected, ffi.Pointer<ffi.Char> remote_address,
         ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumeration for the player control commands.
-/// @since_tizen 3.0
-abstract class bt_avrcp_player_command_e {
-  /// < Play
-  static const int BT_AVRCP_CONTROL_PLAY = 1;
-
-  /// < Pause
-  static const int BT_AVRCP_CONTROL_PAUSE = 2;
-
-  /// < Stop
-  static const int BT_AVRCP_CONTROL_STOP = 3;
-
-  /// < Next Track
-  static const int BT_AVRCP_CONTROL_NEXT = 4;
-
-  /// < Previous track
-  static const int BT_AVRCP_CONTROL_PREVIOUS = 5;
-
-  /// < Fast Forward
-  static const int BT_AVRCP_CONTROL_FAST_FORWARD = 6;
-
-  /// < Rewind
-  static const int BT_AVRCP_CONTROL_REWIND = 7;
-}
 
 /// @deprecated Deprecated since 5.0.
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
@@ -11584,19 +12177,6 @@ typedef Dartbt_hdp_connected_cbFunction = void Function(
     int type,
     int channel,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @deprecated Deprecated since 5.0.
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
-/// @brief  Enumerations for the data channel type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-/// @remarks Deprecated, because of no usecase and supported devices.
-abstract class bt_hdp_channel_type_e {
-  /// < Reliable Data Channel
-  static const int BT_HDP_CHANNEL_TYPE_RELIABLE = 1;
-
-  /// < Streaming Data Channel
-  static const int BT_HDP_CHANNEL_TYPE_STREAMING = 2;
-}
 
 /// @deprecated Deprecated since 5.0.
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
@@ -11650,54 +12230,6 @@ typedef Dartbt_hdp_data_received_cbFunction = void Function(int channel,
 /// @since_tizen 2.3.1
 typedef bt_gatt_h = ffi.Pointer<ffi.Void>;
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the integer type for GATT handle's value.
-/// @since_tizen 2.3.1
-abstract class bt_data_type_int_e {
-  /// < 8 bit signed int type
-  static const int BT_DATA_TYPE_SINT8 = 0;
-
-  /// < 16 bit signed int type
-  static const int BT_DATA_TYPE_SINT16 = 1;
-
-  /// < 32 bit signed int type
-  static const int BT_DATA_TYPE_SINT32 = 2;
-
-  /// < 8 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT8 = 3;
-
-  /// < 16 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT16 = 4;
-
-  /// < 32 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT32 = 5;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the float type for GATT handle's value.
-/// @since_tizen 2.3.1
-abstract class bt_data_type_float_e {
-  /// < 32 bit float type
-  static const int BT_DATA_TYPE_FLOAT = 0;
-
-  /// < 16 bit float type
-  static const int BT_DATA_TYPE_SFLOAT = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the GATT handle's type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_type_e {
-  /// < GATT service type
-  static const int BT_GATT_TYPE_SERVICE = 1;
-
-  /// < GATT characteristic type
-  static const int BT_GATT_TYPE_CHARACTERISTIC = 2;
-
-  /// < GATT descriptor type
-  static const int BT_GATT_TYPE_DESCRIPTOR = 3;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief The handle of a GATT client which is associated with a remote device.
 /// @since_tizen 2.3.1
@@ -11722,17 +12254,6 @@ typedef bt_gatt_foreach_cbFunction = ffi.Bool Function(ffi.Int total,
     ffi.Int index, bt_gatt_h gatt_handle, ffi.Pointer<ffi.Void> user_data);
 typedef Dartbt_gatt_foreach_cbFunction = bool Function(int total, int index,
     bt_gatt_h gatt_handle, ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the write type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_write_type_e {
-  /// < Write without response type
-  static const int BT_GATT_WRITE_TYPE_WRITE_NO_RESPONSE = 0;
-
-  /// < Write type
-  static const int BT_GATT_WRITE_TYPE_WRITE = 1;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief  Called when the client request(e.g. read / write) has been completed.
@@ -11773,24 +12294,6 @@ typedef Dartbt_gatt_client_att_mtu_changed_cbFunction = void Function(
     bt_gatt_client_h client,
     ffi.Pointer<bt_gatt_client_att_mtu_info_s> mtu_info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
-/// @brief Attribute protocol MTU change information structure.
-/// @since_tizen 4.0
-///
-/// @see bt_gatt_client_att_mtu_changed_cb()
-final class bt_gatt_client_att_mtu_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < MTU value
-  @ffi.UnsignedInt()
-  external int mtu;
-
-  /// < Request status
-  @ffi.UnsignedInt()
-  external int status;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief  Called when a value of a watched characteristic's GATT handle has been changed.
@@ -11837,17 +12340,6 @@ typedef Dartbt_gatt_client_service_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Char> service_uuid,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
-/// @brief  Enumerations of gatt server's service changing mode.
-/// @since_tizen 3.0
-abstract class bt_gatt_client_service_change_type_e {
-  /// < Service added
-  static const int BT_GATT_CLIENT_SERVICE_ADDED = 0;
-
-  /// < Service removed
-  static const int BT_GATT_CLIENT_SERVICE_REMOVED = 1;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
 /// @brief Called when the connection state is changed.
 ///
@@ -11876,17 +12368,6 @@ typedef Dartbt_gatt_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<ffi.Char> remote_address,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the service type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_service_type_e {
-  /// < GATT primary service type
-  static const int BT_GATT_SERVICE_TYPE_PRIMARY = 1;
-
-  /// < GATT secondary service type
-  static const int BT_GATT_SERVICE_TYPE_SECONDARY = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
 /// @brief The handle of a GATT server.
@@ -12003,17 +12484,6 @@ typedef Dartbt_gatt_server_write_value_requested_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
-/// @brief  Enumerations of the remote device request types for attributes.
-/// @since_tizen 3.0
-abstract class bt_gatt_att_request_type_e {
-  /// < Read Requested
-  static const int BT_GATT_REQUEST_TYPE_READ = 0;
-
-  /// < Write Requested
-  static const int BT_GATT_REQUEST_TYPE_WRITE = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
 /// @brief  Called when the sending notification / indication is done.
 /// @since_tizen 3.0
 ///
@@ -12083,39 +12553,6 @@ typedef Dartbt_pbap_connection_state_changed_cbFunction = void Function(
 
 /// @WEARABLE_ONLY
 /// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of address book location for PBAP.
-/// @since_tizen 3.0
-abstract class bt_pbap_address_book_source_e {
-  /// < Request for Addressbook from remote device
-  static const int BT_PBAP_SOURCE_DEVICE = 0;
-
-  /// < Request for address book from SIM
-  static const int BT_PBAP_SOURCE_SIM = 1;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of folder type.
-/// @since_tizen 3.0
-abstract class bt_pbap_folder_type_e {
-  /// < Request for address book
-  static const int BT_PBAP_FOLDER_PHONE_BOOK = 0;
-
-  /// < Request for incoming calls
-  static const int BT_PBAP_FOLDER_INCOMING = 1;
-
-  /// < Request for outgoing calls
-  static const int BT_PBAP_FOLDER_OUTGOING = 2;
-
-  /// < Request for missed calls
-  static const int BT_PBAP_FOLDER_MISSED = 3;
-
-  /// < Request for combined calls
-  static const int BT_PBAP_FOLDER_COMBINED = 4;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
 /// @brief  Called when PBAP Phonebook size calculation completes.
 /// @details The following error codes can be delivered: \n
 /// #BT_ERROR_NONE \n
@@ -12141,33 +12578,6 @@ typedef Dartbt_pbap_phone_book_size_cbFunction = void Function(
     ffi.Pointer<ffi.Char> remote_address,
     int size,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of vCard Formats.
-/// @since_tizen 3.0
-abstract class bt_pbap_vcard_format_e {
-  /// < vCard format 2.1 (default)
-  static const int BT_PBAP_VCARD_FORMAT_VCARD21 = 0;
-
-  /// < vCard format 3.0
-  static const int BT_PBAP_VCARD_FORMAT_VCARD30 = 1;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of sorting orders.
-/// @since_tizen 3.0
-abstract class bt_pbap_sort_order_e {
-  /// < Filter order indexed (default)
-  static const int BT_PBAP_ORDER_INDEXED = 0;
-
-  /// < Filter order alphanumeric
-  static const int BT_PBAP_ORDER_ALPHANUMERIC = 1;
-
-  /// < Filter order phonetic
-  static const int BT_PBAP_ORDER_PHONETIC = 2;
-}
 
 /// @WEARABLE_ONLY
 /// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
@@ -12229,49 +12639,7 @@ typedef Dartbt_pbap_list_vcards_cbFunction = void Function(
     int count,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief The structure type containing vCard information.
-/// @since_tizen 3.0
-///
-/// @see bt_pbap_client_pull_vcard()
-final class bt_pbap_vcard_info_s extends ffi.Struct {
-  /// < The vcard index, used as a parameter for bt_pbap_client_pull_vcard()
-  @ffi.Int()
-  external int index;
-
-  /// < The contact name of the vCard
-  external ffi.Pointer<ffi.Char> contact_name;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of phone book search fields.
-/// @since_tizen 3.0
-abstract class bt_pbap_search_field_e {
-  /// < Request for search by name (default)
-  static const int BT_PBAP_SEARCH_NAME = 0;
-
-  /// < Request for search by phone number
-  static const int BT_PBAP_SEARCH_NUMBER = 1;
-
-  /// < Request for search by sound
-  static const int BT_PBAP_SEARCH_SOUND = 2;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief The handle of a Bluetooth LE scan filter.
 /// @since_tizen 4.0
 typedef bt_scan_filter_h = ffi.Pointer<ffi.Void>;
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief Enumeration for the scan filter type.
-/// @since_tizen 4.0
-/// @see bt_adapter_le_scan_filter_set_type()
-abstract class bt_adapter_le_scan_filter_type_e {
-  /// < iBeacon filter type
-  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_IBEACON = 0;
-
-  /// < Proximity UUID filter type
-  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_PROXIMITY_UUID = 1;
-}

--- a/lib/src/bindings/6.0/generated_bindings_capi_system_info.dart
+++ b/lib/src/bindings/6.0/generated_bindings_capi_system_info.dart
@@ -369,6 +369,36 @@ class Tizen60CapiSystemInfo {
           int Function(ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Int32>)>();
 }
 
+/// @brief Enumeration for system information error codes.
+abstract class system_info_error_e {
+  /// < Successful
+  static const int SYSTEM_INFO_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int SYSTEM_INFO_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int SYSTEM_INFO_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < An input/output error occurred when reading value from system
+  static const int SYSTEM_INFO_ERROR_IO_ERROR = -5;
+
+  /// < No permission to use the API
+  static const int SYSTEM_INFO_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Not supported parameter (Since 3.0)
+  static const int SYSTEM_INFO_ERROR_NOT_SUPPORTED = -1073741822;
+}
+
+/// @internal
+/// @brief It is not decided if it should be opened to public.
+abstract class system_info_type_e {
+  static const int SYSTEM_INFO_BOOL = 0;
+  static const int SYSTEM_INFO_INT = 1;
+  static const int SYSTEM_INFO_DOUBLE = 2;
+  static const int SYSTEM_INFO_STRING = 3;
+}
+
 /// @internal
 /// @brief Enumeration for system information key.
 abstract class system_info_key_e {
@@ -416,13 +446,4 @@ abstract class system_info_key_e {
 
   /// < @internal Indicates whether the device supports tethering
   static const int SYSTEM_INFO_KEY_TETHERING_SUPPORTED = 14;
-}
-
-/// @internal
-/// @brief It is not decided if it should be opened to public.
-abstract class system_info_type_e {
-  static const int SYSTEM_INFO_BOOL = 0;
-  static const int SYSTEM_INFO_INT = 1;
-  static const int SYSTEM_INFO_DOUBLE = 2;
-  static const int SYSTEM_INFO_STRING = 3;
 }

--- a/lib/src/bindings/6.0/generated_bindings_mv_barcode_detector.dart
+++ b/lib/src/bindings/6.0/generated_bindings_mv_barcode_detector.dart
@@ -81,56 +81,6 @@ class Tizen60MvBarcodeDetector {
           ffi.Pointer<ffi.Void>)>();
 }
 
-/// @brief Enumeration to target attribute
-///
-/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
-abstract class mv_barcode_detect_attr_target_e {
-  /// < 1D and 2D
-  static const int MV_BARCODE_DETECT_ATTR_TARGET_ALL = 0;
-
-  /// < 1D barcode only
-  static const int MV_BARCODE_DETECT_ATTR_TARGET_1D_BARCODE = 1;
-
-  /// < 2D barcode only
-  static const int MV_BARCODE_DETECT_ATTR_TARGET_2D_BARCODE = 2;
-}
-
-/// @brief Called when barcode detection is completed.
-/// @details If no barcode is detected then the method will be called, barcodes
-/// and states will be equal to NULL, and @a number_of_barcodes - 0.
-///
-/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
-/// @param [in] source               The handle to the media source
-/// @param [in] engine_cfg           The handle to the configuration of the engine
-/// @param [in] barcode_locations    The quadrangle locations of detected barcodes
-/// @param [in] messages             The decoded messages of barcodes
-/// @param [in] types                The types of detected barcodes
-/// @param [in] number_of_barcodes   The number of detected barcodes
-/// @param [in] user_data            The user data passed from
-/// the mv_barcode_detect() function
-///
-/// @pre mv_barcode_detect() invokes this callback
-///
-/// @see mv_barcode_detect()
-typedef mv_barcode_detected_cb
-    = ffi.Pointer<ffi.NativeFunction<mv_barcode_detected_cbFunction>>;
-typedef mv_barcode_detected_cbFunction = ffi.Void Function(
-    mv_common.mv_source_h source,
-    mv_common.mv_engine_config_h engine_cfg,
-    ffi.Pointer<mv_common.mv_quadrangle_s> barcode_locations,
-    ffi.Pointer<ffi.Pointer<ffi.Char>> messages,
-    ffi.Pointer<ffi.Int32> types,
-    ffi.Int number_of_barcodes,
-    ffi.Pointer<ffi.Void> user_data);
-typedef Dartmv_barcode_detected_cbFunction = void Function(
-    mv_common.mv_source_h source,
-    mv_common.mv_engine_config_h engine_cfg,
-    ffi.Pointer<mv_common.mv_quadrangle_s> barcode_locations,
-    ffi.Pointer<ffi.Pointer<ffi.Char>> messages,
-    ffi.Pointer<ffi.Int32> types,
-    int number_of_barcodes,
-    ffi.Pointer<ffi.Void> user_data);
-
 /// @brief Enumeration for supported barcode types.
 /// @details QR codes (versions 1 to 40) and set of 1D barcodes are supported
 ///
@@ -185,5 +135,117 @@ abstract class mv_barcode_type_e {
   /// < Unknown (since 6.0)
   static const int MV_BARCODE_UNKNOWN = 100;
 }
+
+/// @brief Enumeration for supported QR code error correction level.
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+/// @remarks This is unavailable for 1D barcodes
+abstract class mv_barcode_qr_ecc_e {
+  /// < Recovery up to  7% losses
+  static const int MV_BARCODE_QR_ECC_LOW = 0;
+
+  /// < Recovery up to 15% losses
+  static const int MV_BARCODE_QR_ECC_MEDIUM = 1;
+
+  /// < Recovery up to 25% losses
+  static const int MV_BARCODE_QR_ECC_QUARTILE = 2;
+
+  /// < Recovery up to 30% losses
+  static const int MV_BARCODE_QR_ECC_HIGH = 3;
+
+  /// < Unavailable
+  static const int MV_BARCODE_QR_ECC_UNAVAILABLE = 4;
+}
+
+/// @brief Enumeration for supported QR code encoding mode.
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+/// @remarks This is unavailable for 1D barcodes
+abstract class mv_barcode_qr_mode_e {
+  /// < Numeric digits
+  static const int MV_BARCODE_QR_MODE_NUMERIC = 0;
+
+  /// < Alphanumeric characters
+  static const int MV_BARCODE_QR_MODE_ALPHANUMERIC = 1;
+
+  /// < Raw 8-bit bytes
+  static const int MV_BARCODE_QR_MODE_BYTE = 2;
+
+  /// < UTF-8 character encoding
+  static const int MV_BARCODE_QR_MODE_UTF8 = 3;
+
+  /// < Unavailable
+  static const int MV_BARCODE_QR_MODE_UNAVAILABLE = 4;
+}
+
+/// @brief Enumeration for supported image formats for the barcode generating.
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+abstract class mv_barcode_image_format_e {
+  /// < Unavailable image format
+  static const int MV_BARCODE_IMAGE_FORMAT_UNAVAILABLE = -1;
+
+  /// < BMP image format
+  static const int MV_BARCODE_IMAGE_FORMAT_BMP = 0;
+
+  /// < JPEG image format
+  static const int MV_BARCODE_IMAGE_FORMAT_JPG = 1;
+
+  /// < PNG image format
+  static const int MV_BARCODE_IMAGE_FORMAT_PNG = 2;
+
+  /// < The number of supported image format
+  static const int MV_BARCODE_IMAGE_FORMAT_NUM = 3;
+}
+
+/// @brief Enumeration to target attribute
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+abstract class mv_barcode_detect_attr_target_e {
+  /// < 1D and 2D
+  static const int MV_BARCODE_DETECT_ATTR_TARGET_ALL = 0;
+
+  /// < 1D barcode only
+  static const int MV_BARCODE_DETECT_ATTR_TARGET_1D_BARCODE = 1;
+
+  /// < 2D barcode only
+  static const int MV_BARCODE_DETECT_ATTR_TARGET_2D_BARCODE = 2;
+}
+
+/// @brief Called when barcode detection is completed.
+/// @details If no barcode is detected then the method will be called, barcodes
+/// and states will be equal to NULL, and @a number_of_barcodes - 0.
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+/// @param [in] source               The handle to the media source
+/// @param [in] engine_cfg           The handle to the configuration of the engine
+/// @param [in] barcode_locations    The quadrangle locations of detected barcodes
+/// @param [in] messages             The decoded messages of barcodes
+/// @param [in] types                The types of detected barcodes
+/// @param [in] number_of_barcodes   The number of detected barcodes
+/// @param [in] user_data            The user data passed from
+/// the mv_barcode_detect() function
+///
+/// @pre mv_barcode_detect() invokes this callback
+///
+/// @see mv_barcode_detect()
+typedef mv_barcode_detected_cb
+    = ffi.Pointer<ffi.NativeFunction<mv_barcode_detected_cbFunction>>;
+typedef mv_barcode_detected_cbFunction = ffi.Void Function(
+    mv_common.mv_source_h source,
+    mv_common.mv_engine_config_h engine_cfg,
+    ffi.Pointer<mv_common.mv_quadrangle_s> barcode_locations,
+    ffi.Pointer<ffi.Pointer<ffi.Char>> messages,
+    ffi.Pointer<ffi.Int32> types,
+    ffi.Int number_of_barcodes,
+    ffi.Pointer<ffi.Void> user_data);
+typedef Dartmv_barcode_detected_cbFunction = void Function(
+    mv_common.mv_source_h source,
+    mv_common.mv_engine_config_h engine_cfg,
+    ffi.Pointer<mv_common.mv_quadrangle_s> barcode_locations,
+    ffi.Pointer<ffi.Pointer<ffi.Char>> messages,
+    ffi.Pointer<ffi.Int32> types,
+    int number_of_barcodes,
+    ffi.Pointer<ffi.Void> user_data);
 
 const String MV_BARCODE_DETECT_ATTR_TARGET = 'MV_BARCODE_DETECT_ATTR_TARGET';

--- a/lib/src/bindings/6.0/generated_bindings_mv_barcode_generator.dart
+++ b/lib/src/bindings/6.0/generated_bindings_mv_barcode_generator.dart
@@ -259,7 +259,7 @@ abstract class _mv_barcode_type_e {
 ///
 /// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
 /// @remarks This is unavailable for 1D barcodes
-abstract class mv_barcode_qr_mode_e {
+abstract class _mv_barcode_qr_mode_e {
   /// < Numeric digits
   static const int MV_BARCODE_QR_MODE_NUMERIC = 0;
 
@@ -280,7 +280,7 @@ abstract class mv_barcode_qr_mode_e {
 ///
 /// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
 /// @remarks This is unavailable for 1D barcodes
-abstract class mv_barcode_qr_ecc_e {
+abstract class _mv_barcode_qr_ecc_e {
   /// < Recovery up to  7% losses
   static const int MV_BARCODE_QR_ECC_LOW = 0;
 
@@ -300,7 +300,7 @@ abstract class mv_barcode_qr_ecc_e {
 /// @brief Enumeration for supported image formats for the barcode generating.
 ///
 /// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
-abstract class mv_barcode_image_format_e {
+abstract class _mv_barcode_image_format_e {
   /// < Unavailable image format
   static const int MV_BARCODE_IMAGE_FORMAT_UNAVAILABLE = -1;
 

--- a/lib/src/bindings/6.0/generated_bindings_mv_face.dart
+++ b/lib/src/bindings/6.0/generated_bindings_mv_face.dart
@@ -1100,6 +1100,53 @@ class Tizen60MvFace {
               ffi.Pointer<ffi.Char>, ffi.Pointer<mv_face_tracking_model_h>)>();
 }
 
+/// @brief Enumeration for eyes state type.
+///
+/// @since_tizen 3.0
+///
+/// @see mv_face_eye_condition_recognize()
+abstract class mv_face_eye_condition_e {
+  /// < Eyes are open
+  static const int MV_FACE_EYES_OPEN = 0;
+
+  /// < Eyes are closed
+  static const int MV_FACE_EYES_CLOSED = 1;
+
+  /// < The eyes condition wasn't determined
+  static const int MV_FACE_EYES_NOT_FOUND = 2;
+}
+
+/// @brief Enumeration for expression types can be determined for faces.
+///
+/// @since_tizen 3.0
+///
+/// @see mv_face_facial_expression_recognize()
+abstract class mv_face_facial_expression_e {
+  /// < Unknown face expression
+  static const int MV_FACE_UNKNOWN = 0;
+
+  /// < Face expression is neutral
+  static const int MV_FACE_NEUTRAL = 1;
+
+  /// < Face expression is smiling
+  static const int MV_FACE_SMILE = 2;
+
+  /// < Face expression is sadness
+  static const int MV_FACE_SADNESS = 3;
+
+  /// < Face expression is surprise
+  static const int MV_FACE_SURPRISE = 4;
+
+  /// < Face expression is anger
+  static const int MV_FACE_ANGER = 5;
+
+  /// < Face expression is fear
+  static const int MV_FACE_FEAR = 6;
+
+  /// < Face expression is disgust
+  static const int MV_FACE_DISGUST = 7;
+}
+
 /// @brief Called when faces are detected for the @a source.
 /// @details This type callback can be invoked each time when
 /// mv_face_detect() is called to process the results of face
@@ -1311,22 +1358,6 @@ typedef Dartmv_face_eye_condition_recognized_cbFunction = void Function(
     int eye_condition,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for eyes state type.
-///
-/// @since_tizen 3.0
-///
-/// @see mv_face_eye_condition_recognize()
-abstract class mv_face_eye_condition_e {
-  /// < Eyes are open
-  static const int MV_FACE_EYES_OPEN = 0;
-
-  /// < Eyes are closed
-  static const int MV_FACE_EYES_CLOSED = 1;
-
-  /// < The eyes condition wasn't determined
-  static const int MV_FACE_EYES_NOT_FOUND = 2;
-}
-
 /// @brief Called when facial expression is recognized.
 /// @details This type callback can be invoked each time when
 /// mv_face_facial_expression_recognize() is called for @a face_location to
@@ -1362,37 +1393,6 @@ typedef Dartmv_face_facial_expression_recognized_cbFunction = void Function(
     mv_common.mv_rectangle_s face_location,
     int facial_expression,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for expression types can be determined for faces.
-///
-/// @since_tizen 3.0
-///
-/// @see mv_face_facial_expression_recognize()
-abstract class mv_face_facial_expression_e {
-  /// < Unknown face expression
-  static const int MV_FACE_UNKNOWN = 0;
-
-  /// < Face expression is neutral
-  static const int MV_FACE_NEUTRAL = 1;
-
-  /// < Face expression is smiling
-  static const int MV_FACE_SMILE = 2;
-
-  /// < Face expression is sadness
-  static const int MV_FACE_SADNESS = 3;
-
-  /// < Face expression is surprise
-  static const int MV_FACE_SURPRISE = 4;
-
-  /// < Face expression is anger
-  static const int MV_FACE_ANGER = 5;
-
-  /// < Face expression is fear
-  static const int MV_FACE_FEAR = 6;
-
-  /// < Face expression is disgust
-  static const int MV_FACE_DISGUST = 7;
-}
 
 const String MV_FACE_DETECTION_MODEL_FILE_PATH =
     'MV_FACE_DETECTION_MODEL_FILE_PATH';

--- a/lib/src/bindings/6.0/generated_bindings_mv_inference.dart
+++ b/lib/src/bindings/6.0/generated_bindings_mv_inference.dart
@@ -821,6 +821,179 @@ class Tizen60MvInference {
           ffi.Pointer<ffi.Float>)>();
 }
 
+/// @brief Enumeration for inference backend.
+/// #MV_INFERENCE_BACKEND_OPENCV An open source computer vision and machine learning
+/// software library.
+/// (https://opencv.org/about/)
+/// #MV_INFERENCE_BACKEND_TFLITE Google-introduced open source inference engine for embedded systems,
+/// which runs Tensorflow Lite model.
+/// (https://www.tensorflow.org/lite/guide/get_started)
+/// #MV_INFERENCE_BACKEND_ARMNN ARM-introduced open source inference engine for CPUs, GPUs and NPUs, which
+/// enables efficient translation of existing neural network frameworks
+/// such as TensorFlow, TensorFlow Lite and Caffes, allowing them to
+/// run efficiently without modification on Embedded hardware.
+/// (https://developer.arm.com/ip-products/processors/machine-learning/arm-nn)
+/// #MV_INFERENCE_BACKEND_MLAPI Samsung-introduced open source ML single API framework of NNStreamer, which
+/// runs various NN models via tensor filters of NNStreamer.
+/// (https://github.com/nnstreamer/nnstreamer)
+/// #MV_INFERENCE_BACKEND_ONE Samsung-introduced open source inference engine called On-device Neural Engine, which
+/// performs inference of a given NN model on various devices such as CPU, GPU, DSP and NPU.
+/// (https://github.com/Samsung/ONE)
+///
+/// @since_tizen 5.5
+///
+/// @see mv_inference_prepare()
+abstract class mv_inference_backend_type_e {
+  /// < None
+  static const int MV_INFERENCE_BACKEND_NONE = -1;
+
+  /// < OpenCV
+  static const int MV_INFERENCE_BACKEND_OPENCV = 0;
+
+  /// < TensorFlow-Lite
+  static const int MV_INFERENCE_BACKEND_TFLITE = 1;
+
+  /// < ARMNN (Since 6.0)
+  static const int MV_INFERENCE_BACKEND_ARMNN = 2;
+
+  /// < ML Single API of NNStreamer (Since 6.0)
+  static const int MV_INFERENCE_BACKEND_MLAPI = 3;
+
+  /// < On-device Neural Engine (Since 6.0)
+  static const int MV_INFERENCE_BACKEND_ONE = 4;
+
+  /// < Backend MAX
+  static const int MV_INFERENCE_BACKEND_MAX = 5;
+}
+
+/// @deprecated Deprecated since 6.0. Use #mv_inference_target_device_e instead.
+/// @brief Enumeration for inference target.
+///
+/// @since_tizen 5.5
+abstract class mv_inference_target_type_e {
+  /// < None
+  static const int MV_INFERENCE_TARGET_NONE = -1;
+
+  /// < CPU
+  static const int MV_INFERENCE_TARGET_CPU = 0;
+
+  /// < GPU
+  static const int MV_INFERENCE_TARGET_GPU = 1;
+
+  /// < CUSTOM
+  static const int MV_INFERENCE_TARGET_CUSTOM = 2;
+
+  /// < Target MAX
+  static const int MV_INFERENCE_TARGET_MAX = 3;
+}
+
+/// @brief Enumeration for inference target.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_target_device_e {
+  /// < None
+  static const int MV_INFERENCE_TARGET_DEVICE_NONE = 0;
+
+  /// < CPU
+  static const int MV_INFERENCE_TARGET_DEVICE_CPU = 1;
+
+  /// < GPU
+  static const int MV_INFERENCE_TARGET_DEVICE_GPU = 2;
+
+  /// < CUSTOM
+  static const int MV_INFERENCE_TARGET_DEVICE_CUSTOM = 4;
+
+  /// < Target MAX
+  static const int MV_INFERENCE_TARGET_DEVICE_MAX = 8;
+}
+
+/// @brief Enumeration for input data type.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_data_type_e {
+  /// < Data type of a given pre-trained model is float.
+  static const int MV_INFERENCE_DATA_FLOAT32 = 0;
+
+  /// < Data type of a given pre-trained model is unsigned char.
+  static const int MV_INFERENCE_DATA_UINT8 = 1;
+}
+
+/// @brief Enumeration for human pose landmark.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_human_pose_landmark_e {
+  /// < Head of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_HEAD = 1;
+
+  /// < Neck of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_NECK = 2;
+
+  /// < Thorax of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_THORAX = 3;
+
+  /// < Right shoulder of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_SHOULDER = 4;
+
+  /// < Right elbow of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_ELBOW = 5;
+
+  /// < Right wrist of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_WRIST = 6;
+
+  /// < Left shoulder of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_SHOULDER = 7;
+
+  /// < Left elbow of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_ELBOW = 8;
+
+  /// < Left wrist of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_WRIST = 9;
+
+  /// < Pelvis of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_PELVIS = 10;
+
+  /// < Right hip of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_HIP = 11;
+
+  /// < Right knee of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_KNEE = 12;
+
+  /// < Right ankle of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_ANKLE = 13;
+
+  /// < Left hip of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_HIP = 14;
+
+  /// < Left knee of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_KNEE = 15;
+
+  /// < Left ankle of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_ANKLE = 16;
+}
+
+/// @brief Enumeration for human body parts.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_human_body_part_e {
+  /// < HEAD, NECK, and THORAX
+  static const int MV_INFERENCE_HUMAN_BODY_PART_HEAD = 1;
+
+  /// < RIGHT SHOULDER, ELBOW, and WRIST
+  static const int MV_INFERENCE_HUMAN_BODY_PART_ARM_RIGHT = 2;
+
+  /// < LEFT SHOULDER, ELBOW, and WRIST
+  static const int MV_INFERENCE_HUMAN_BODY_PART_ARM_LEFT = 4;
+
+  /// < THORAX, PELVIS, RIGHT HIP, and LEFT HIP
+  static const int MV_INFERENCE_HUMAN_BODY_PART_BODY = 8;
+
+  /// < RIGHT HIP, KNEE, and ANKLE
+  static const int MV_INFERENCE_HUMAN_BODY_PART_LEG_RIGHT = 16;
+
+  /// < LEFT HIP, KNEE, and ANKLE
+  static const int MV_INFERENCE_HUMAN_BODY_PART_LEG_LEFT = 32;
+}
+
 /// @brief The inference handle.
 /// @details Contains information about location of
 /// detected landmarks for one or more poses.

--- a/lib/src/bindings/6.0/generated_bindings_tbm.dart
+++ b/lib/src/bindings/6.0/generated_bindings_tbm.dart
@@ -449,6 +449,8 @@ class Tizen60Tbm {
       _tbm_surface_get_formatPtr.asFunction<int Function(tbm_surface_h)>();
 }
 
+final class _tbm_surface extends ffi.Opaque {}
+
 /// @brief Enumeration for tbm_surface error type.
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
 abstract class tbm_surface_error_e {
@@ -544,11 +546,127 @@ typedef tbm_surface_plane_s = _tbm_surface_plane;
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
 typedef tbm_surface_h = ffi.Pointer<_tbm_surface>;
 
-final class _tbm_surface extends ffi.Opaque {}
-
 /// @brief Definition for the TBM surface information struct.
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
 typedef tbm_surface_info_s = _tbm_surface_info;
+
+const int TBM_FORMAT_C8 = 538982467;
+
+const int TBM_FORMAT_RGB332 = 943867730;
+
+const int TBM_FORMAT_BGR233 = 944916290;
+
+const int TBM_FORMAT_XRGB4444 = 842093144;
+
+const int TBM_FORMAT_XBGR4444 = 842089048;
+
+const int TBM_FORMAT_RGBX4444 = 842094674;
+
+const int TBM_FORMAT_BGRX4444 = 842094658;
+
+const int TBM_FORMAT_ARGB4444 = 842093121;
+
+const int TBM_FORMAT_ABGR4444 = 842089025;
+
+const int TBM_FORMAT_RGBA4444 = 842088786;
+
+const int TBM_FORMAT_BGRA4444 = 842088770;
+
+const int TBM_FORMAT_XRGB1555 = 892424792;
+
+const int TBM_FORMAT_XBGR1555 = 892420696;
+
+const int TBM_FORMAT_RGBX5551 = 892426322;
+
+const int TBM_FORMAT_BGRX5551 = 892426306;
+
+const int TBM_FORMAT_ARGB1555 = 892424769;
+
+const int TBM_FORMAT_ABGR1555 = 892420673;
+
+const int TBM_FORMAT_RGBA5551 = 892420434;
+
+const int TBM_FORMAT_BGRA5551 = 892420418;
+
+const int TBM_FORMAT_RGB565 = 909199186;
+
+const int TBM_FORMAT_BGR565 = 909199170;
+
+const int TBM_FORMAT_RGB888 = 875710290;
+
+const int TBM_FORMAT_BGR888 = 875710274;
+
+const int TBM_FORMAT_XRGB8888 = 875713112;
+
+const int TBM_FORMAT_XBGR8888 = 875709016;
+
+const int TBM_FORMAT_RGBX8888 = 875714642;
+
+const int TBM_FORMAT_BGRX8888 = 875714626;
+
+const int TBM_FORMAT_ARGB8888 = 875713089;
+
+const int TBM_FORMAT_ABGR8888 = 875708993;
+
+const int TBM_FORMAT_RGBA8888 = 875708754;
+
+const int TBM_FORMAT_BGRA8888 = 875708738;
+
+const int TBM_FORMAT_XRGB2101010 = 808669784;
+
+const int TBM_FORMAT_XBGR2101010 = 808665688;
+
+const int TBM_FORMAT_RGBX1010102 = 808671314;
+
+const int TBM_FORMAT_BGRX1010102 = 808671298;
+
+const int TBM_FORMAT_ARGB2101010 = 808669761;
+
+const int TBM_FORMAT_ABGR2101010 = 808665665;
+
+const int TBM_FORMAT_RGBA1010102 = 808665426;
+
+const int TBM_FORMAT_BGRA1010102 = 808665410;
+
+const int TBM_FORMAT_YUYV = 1448695129;
+
+const int TBM_FORMAT_YVYU = 1431918169;
+
+const int TBM_FORMAT_UYVY = 1498831189;
+
+const int TBM_FORMAT_VYUY = 1498765654;
+
+const int TBM_FORMAT_AYUV = 1448433985;
+
+const int TBM_FORMAT_NV12 = 842094158;
+
+const int TBM_FORMAT_NV21 = 825382478;
+
+const int TBM_FORMAT_NV16 = 909203022;
+
+const int TBM_FORMAT_NV61 = 825644622;
+
+const int TBM_FORMAT_YUV410 = 961959257;
+
+const int TBM_FORMAT_YVU410 = 961893977;
+
+const int TBM_FORMAT_YUV411 = 825316697;
+
+const int TBM_FORMAT_YVU411 = 825316953;
+
+const int TBM_FORMAT_YUV420 = 842093913;
+
+const int TBM_FORMAT_YVU420 = 842094169;
+
+const int TBM_FORMAT_YUV422 = 909202777;
+
+const int TBM_FORMAT_YVU422 = 909203033;
+
+const int TBM_FORMAT_YUV444 = 875713881;
+
+const int TBM_FORMAT_YVU444 = 875714137;
+
+const int TBM_FORMAT_NV12MT = 842091860;
 
 const int TBM_SURF_PLANE_MAX = 4;
 

--- a/lib/src/bindings/6.5/generated_bindings_capi_base_common.dart
+++ b/lib/src/bindings/6.5/generated_bindings_capi_base_common.dart
@@ -386,6 +386,8 @@ abstract class tizen_error_e {
   static const int TIZEN_ERROR_END_OF_COLLECTION = -1073741819;
 }
 
+const int NULL = 0;
+
 const int TIZEN_ERROR_MAX_PLATFORM_ERROR = 0;
 
 const int TIZEN_ERROR_MIN_PLATFORM_ERROR = -1073741824;

--- a/lib/src/bindings/6.5/generated_bindings_capi_geofence_manager.dart
+++ b/lib/src/bindings/6.5/generated_bindings_capi_geofence_manager.dart
@@ -1223,71 +1223,6 @@ class Tizen65CapiGeofenceManager {
       .asFunction<int Function(geofence_status_h, ffi.Pointer<ffi.Int>)>();
 }
 
-/// @brief The geofence manager handle.
-/// @since_tizen 2.4
-typedef geofence_manager_h = ffi.Pointer<geofence_manager_s>;
-
-final class geofence_manager_s extends ffi.Opaque {}
-
-/// @brief The geofence handle.
-/// @since_tizen 2.4
-typedef geofence_h = ffi.Pointer<geofence_s>;
-
-final class geofence_s extends ffi.Opaque {}
-
-/// @brief Called when a device enters or exits the given geofence.
-/// @since_tizen 2.4
-/// @param[in] geofence_id The specified geofence ID
-/// @param[in] state The geofence state
-/// @param[in] user_data The user data passed from callback registration function
-/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_state_changed_cb().
-/// @see geofence_state_e
-/// @see geofence_manager_start()
-/// @see geofence_manager_set_geofence_state_changed_cb()
-typedef geofence_state_changed_cb
-    = ffi.Pointer<ffi.NativeFunction<geofence_state_changed_cbFunction>>;
-typedef geofence_state_changed_cbFunction = ffi.Void Function(
-    ffi.Int geofence_id, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
-typedef Dartgeofence_state_changed_cbFunction = void Function(
-    int geofence_id, int state, ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the state of geofence manager.
-/// @since_tizen 2.4
-abstract class geofence_state_e {
-  /// < Uncertain state of geofence
-  static const int GEOFENCE_STATE_UNCERTAIN = 0;
-
-  /// < Geofence In state
-  static const int GEOFENCE_STATE_IN = 1;
-
-  /// < Geofence Out state
-  static const int GEOFENCE_STATE_OUT = 2;
-}
-
-/// @brief Called when the some event occurs in geofence and place such as add, update, etc..
-/// @details The events of public geofence is also received if there are public geofences.
-/// @since_tizen 2.4
-/// @remarks The value of place_id or geofence_id is -1 when the place ID or geofence ID is not assigned.
-/// @param[in] place_id The place ID
-/// @param[in] geofence_id The specified geofence ID
-/// @param[in] error The error code for the particular action
-/// @param[in] manage The result code for the particular place and geofence management
-/// @param[in] user_data The user data passed from callback registration function
-/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_event_cb()
-/// @see geofence_manage_e
-/// @see geofence_manager_start()
-/// @see geofence_manager_set_geofence_event_cb()
-typedef geofence_event_cb
-    = ffi.Pointer<ffi.NativeFunction<geofence_event_cbFunction>>;
-typedef geofence_event_cbFunction = ffi.Void Function(
-    ffi.Int place_id,
-    ffi.Int geofence_id,
-    ffi.Int32 error,
-    ffi.Int32 manage,
-    ffi.Pointer<ffi.Void> user_data);
-typedef Dartgeofence_event_cbFunction = void Function(int place_id,
-    int geofence_id, int error, int manage, ffi.Pointer<ffi.Void> user_data);
-
 /// @brief Enumeration for Geofence manager of error code.
 /// @since_tizen 2.4
 abstract class geofence_manager_error_e {
@@ -1334,57 +1269,18 @@ abstract class geofence_manager_error_e {
   static const int GEOFENCE_MANAGER_ERROR_GEOFENCE_ACCESS_DENIED = -46202871;
 }
 
-/// @brief Enumeration for geofence management events.
+/// @brief Enumeration for the state of geofence manager.
 /// @since_tizen 2.4
-abstract class geofence_manage_e {
-  /// < Geofence is added
-  static const int GEOFENCE_MANAGE_FENCE_ADDED = 0;
+abstract class geofence_state_e {
+  /// < Uncertain state of geofence
+  static const int GEOFENCE_STATE_UNCERTAIN = 0;
 
-  /// < Geofence is removed
-  static const int GEOFENCE_MANAGE_FENCE_REMOVED = 1;
+  /// < Geofence In state
+  static const int GEOFENCE_STATE_IN = 1;
 
-  /// < Geofencing is started
-  static const int GEOFENCE_MANAGE_FENCE_STARTED = 2;
-
-  /// < Geofencing is stopped
-  static const int GEOFENCE_MANAGE_FENCE_STOPPED = 3;
-
-  /// < Place is added
-  static const int GEOFENCE_MANAGE_PLACE_ADDED = 16;
-
-  /// < Place is removed
-  static const int GEOFENCE_MANAGE_PLACE_REMOVED = 17;
-
-  /// < Place is updated
-  static const int GEOFENCE_MANAGE_PLACE_UPDATED = 18;
-
-  /// < Setting for geofencing is enabled
-  static const int GEOFENCE_MANAGE_SETTING_ENABLED = 32;
-
-  /// < Setting for geofencing is disabled
-  static const int GEOFENCE_MANAGE_SETTING_DISABLED = 33;
+  /// < Geofence Out state
+  static const int GEOFENCE_STATE_OUT = 2;
 }
-
-/// @brief Called when a proximity state of device is changed.
-/// @since_tizen 3.0
-/// @param[in] geofence_id The specified geofence ID
-/// @param[in] state The proximity state
-/// @param[in] provider The proximity provider
-/// @param[in] user_data The user data passed from callback registration function
-/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_proximity_state_changed_cb().
-/// @see geofence_proximity_state_e
-/// @see geofence_proximity_provider_e
-/// @see geofence_manager_start()
-/// @see geofence_manager_set_geofence_proximity_state_changed_cb()
-typedef geofence_proximity_state_changed_cb = ffi
-    .Pointer<ffi.NativeFunction<geofence_proximity_state_changed_cbFunction>>;
-typedef geofence_proximity_state_changed_cbFunction = ffi.Void Function(
-    ffi.Int geofence_id,
-    ffi.Int32 state,
-    ffi.Int32 provider,
-    ffi.Pointer<ffi.Void> user_data);
-typedef Dartgeofence_proximity_state_changed_cbFunction = void Function(
-    int geofence_id, int state, int provider, ffi.Pointer<ffi.Void> user_data);
 
 /// @brief Enumeration for the state of proximity.
 /// @since_tizen 3.0
@@ -1420,6 +1316,125 @@ abstract class geofence_proximity_provider_e {
   /// < Proximity is specified by Sensor
   static const int GEOFENCE_PROXIMITY_PROVIDER_SENSOR = 4;
 }
+
+/// @brief Enumeration for geofence type.
+/// @since_tizen 2.4
+abstract class geofence_type_e {
+  /// < Geofence is specified by geospatial coordinate
+  static const int GEOFENCE_TYPE_GEOPOINT = 1;
+
+  /// < Geofence is specified by Wi-Fi access point
+  static const int GEOFENCE_TYPE_WIFI = 2;
+
+  /// < Geofence is specified by Bluetooth device
+  static const int GEOFENCE_TYPE_BT = 3;
+}
+
+/// @brief Enumeration for geofence management events.
+/// @since_tizen 2.4
+abstract class geofence_manage_e {
+  /// < Geofence is added
+  static const int GEOFENCE_MANAGE_FENCE_ADDED = 0;
+
+  /// < Geofence is removed
+  static const int GEOFENCE_MANAGE_FENCE_REMOVED = 1;
+
+  /// < Geofencing is started
+  static const int GEOFENCE_MANAGE_FENCE_STARTED = 2;
+
+  /// < Geofencing is stopped
+  static const int GEOFENCE_MANAGE_FENCE_STOPPED = 3;
+
+  /// < Place is added
+  static const int GEOFENCE_MANAGE_PLACE_ADDED = 16;
+
+  /// < Place is removed
+  static const int GEOFENCE_MANAGE_PLACE_REMOVED = 17;
+
+  /// < Place is updated
+  static const int GEOFENCE_MANAGE_PLACE_UPDATED = 18;
+
+  /// < Setting for geofencing is enabled
+  static const int GEOFENCE_MANAGE_SETTING_ENABLED = 32;
+
+  /// < Setting for geofencing is disabled
+  static const int GEOFENCE_MANAGE_SETTING_DISABLED = 33;
+}
+
+final class geofence_manager_s extends ffi.Opaque {}
+
+final class geofence_s extends ffi.Opaque {}
+
+final class geofence_status_s extends ffi.Opaque {}
+
+/// @brief The geofence manager handle.
+/// @since_tizen 2.4
+typedef geofence_manager_h = ffi.Pointer<geofence_manager_s>;
+
+/// @brief The geofence handle.
+/// @since_tizen 2.4
+typedef geofence_h = ffi.Pointer<geofence_s>;
+
+/// @brief Called when a device enters or exits the given geofence.
+/// @since_tizen 2.4
+/// @param[in] geofence_id The specified geofence ID
+/// @param[in] state The geofence state
+/// @param[in] user_data The user data passed from callback registration function
+/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_state_changed_cb().
+/// @see geofence_state_e
+/// @see geofence_manager_start()
+/// @see geofence_manager_set_geofence_state_changed_cb()
+typedef geofence_state_changed_cb
+    = ffi.Pointer<ffi.NativeFunction<geofence_state_changed_cbFunction>>;
+typedef geofence_state_changed_cbFunction = ffi.Void Function(
+    ffi.Int geofence_id, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
+typedef Dartgeofence_state_changed_cbFunction = void Function(
+    int geofence_id, int state, ffi.Pointer<ffi.Void> user_data);
+
+/// @brief Called when the some event occurs in geofence and place such as add, update, etc..
+/// @details The events of public geofence is also received if there are public geofences.
+/// @since_tizen 2.4
+/// @remarks The value of place_id or geofence_id is -1 when the place ID or geofence ID is not assigned.
+/// @param[in] place_id The place ID
+/// @param[in] geofence_id The specified geofence ID
+/// @param[in] error The error code for the particular action
+/// @param[in] manage The result code for the particular place and geofence management
+/// @param[in] user_data The user data passed from callback registration function
+/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_event_cb()
+/// @see geofence_manage_e
+/// @see geofence_manager_start()
+/// @see geofence_manager_set_geofence_event_cb()
+typedef geofence_event_cb
+    = ffi.Pointer<ffi.NativeFunction<geofence_event_cbFunction>>;
+typedef geofence_event_cbFunction = ffi.Void Function(
+    ffi.Int place_id,
+    ffi.Int geofence_id,
+    ffi.Int32 error,
+    ffi.Int32 manage,
+    ffi.Pointer<ffi.Void> user_data);
+typedef Dartgeofence_event_cbFunction = void Function(int place_id,
+    int geofence_id, int error, int manage, ffi.Pointer<ffi.Void> user_data);
+
+/// @brief Called when a proximity state of device is changed.
+/// @since_tizen 3.0
+/// @param[in] geofence_id The specified geofence ID
+/// @param[in] state The proximity state
+/// @param[in] provider The proximity provider
+/// @param[in] user_data The user data passed from callback registration function
+/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_proximity_state_changed_cb().
+/// @see geofence_proximity_state_e
+/// @see geofence_proximity_provider_e
+/// @see geofence_manager_start()
+/// @see geofence_manager_set_geofence_proximity_state_changed_cb()
+typedef geofence_proximity_state_changed_cb = ffi
+    .Pointer<ffi.NativeFunction<geofence_proximity_state_changed_cbFunction>>;
+typedef geofence_proximity_state_changed_cbFunction = ffi.Void Function(
+    ffi.Int geofence_id,
+    ffi.Int32 state,
+    ffi.Int32 provider,
+    ffi.Pointer<ffi.Void> user_data);
+typedef Dartgeofence_proximity_state_changed_cbFunction = void Function(
+    int geofence_id, int state, int provider, ffi.Pointer<ffi.Void> user_data);
 
 /// @brief Called when the fence list is requested.
 /// @since_tizen 2.4
@@ -1476,21 +1491,6 @@ typedef Dartgeofence_manager_place_cbFunction = bool Function(
     int place_cnt,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for geofence type.
-/// @since_tizen 2.4
-abstract class geofence_type_e {
-  /// < Geofence is specified by geospatial coordinate
-  static const int GEOFENCE_TYPE_GEOPOINT = 1;
-
-  /// < Geofence is specified by Wi-Fi access point
-  static const int GEOFENCE_TYPE_WIFI = 2;
-
-  /// < Geofence is specified by Bluetooth device
-  static const int GEOFENCE_TYPE_BT = 3;
-}
-
 /// @brief The geofence status handle.
 /// @since_tizen 2.4
 typedef geofence_status_h = ffi.Pointer<geofence_status_s>;
-
-final class geofence_status_s extends ffi.Opaque {}

--- a/lib/src/bindings/6.5/generated_bindings_capi_media_controller.dart
+++ b/lib/src/bindings/6.5/generated_bindings_capi_media_controller.dart
@@ -6781,6 +6781,461 @@ class Tizen65CapiMediaController {
       .asFunction<int Function(mc_server_h, ffi.Pointer<ffi.Char>)>();
 }
 
+/// @brief Enumeration for the media controller error.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_error_e {
+  /// < Successful
+  static const int MEDIA_CONTROLLER_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int MEDIA_CONTROLLER_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int MEDIA_CONTROLLER_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Invalid Operation
+  static const int MEDIA_CONTROLLER_ERROR_INVALID_OPERATION = -38;
+
+  /// < No space left on device
+  static const int MEDIA_CONTROLLER_ERROR_FILE_NO_SPACE_ON_DEVICE = -28;
+
+  /// < Permission denied
+  static const int MEDIA_CONTROLLER_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Limited by server application (since 5.5)
+  static const int MEDIA_CONTROLLER_ERROR_ABILITY_LIMITED_BY_SERVER_APP =
+      -50462719;
+}
+
+/// @brief Enumeration for the media controller server state.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_server_state_e {
+  /// < None state
+  static const int MC_SERVER_STATE_NONE = 0;
+
+  /// < Activate state
+  static const int MC_SERVER_STATE_ACTIVATE = 1;
+
+  /// < Deactivate state
+  static const int MC_SERVER_STATE_DEACTIVATE = 2;
+}
+
+/// @brief Enumeration for the media meta info.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_meta_e {
+  /// < Title
+  static const int MC_META_MEDIA_TITLE = 0;
+
+  /// < Artist
+  static const int MC_META_MEDIA_ARTIST = 1;
+
+  /// < Album
+  static const int MC_META_MEDIA_ALBUM = 2;
+
+  /// < Author
+  static const int MC_META_MEDIA_AUTHOR = 3;
+
+  /// < Genre
+  static const int MC_META_MEDIA_GENRE = 4;
+
+  /// < Duration
+  static const int MC_META_MEDIA_DURATION = 5;
+
+  /// < Date
+  static const int MC_META_MEDIA_DATE = 6;
+
+  /// < Copyright
+  static const int MC_META_MEDIA_COPYRIGHT = 7;
+
+  /// < Description
+  static const int MC_META_MEDIA_DESCRIPTION = 8;
+
+  /// < Track Number
+  static const int MC_META_MEDIA_TRACK_NUM = 9;
+
+  /// < Picture. Album Art
+  static const int MC_META_MEDIA_PICTURE = 10;
+
+  /// < Season (Since 5.5)
+  static const int MC_META_MEDIA_SEASON = 11;
+
+  /// < Episode (Since 5.5)
+  static const int MC_META_MEDIA_EPISODE = 12;
+
+  /// < Content resolution (Since 5.5)
+  static const int MC_META_MEDIA_RESOLUTION = 13;
+}
+
+/// @brief Enumeration for the media playback state.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_playback_states_e {
+  /// < None
+  static const int MC_PLAYBACK_STATE_NONE = 0;
+
+  /// < Playing
+  static const int MC_PLAYBACK_STATE_PLAYING = 1;
+
+  /// < Paused
+  static const int MC_PLAYBACK_STATE_PAUSED = 2;
+
+  /// < Stopped
+  static const int MC_PLAYBACK_STATE_STOPPED = 3;
+
+  /// < Moving to the next item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_MOVING_TO_NEXT = 8;
+
+  /// < Moving to the previous item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_MOVING_TO_PREVIOUS = 9;
+
+  /// < Fast forwarding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_FAST_FORWARDING = 10;
+
+  /// < Rewinding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_REWINDING = 11;
+
+  /// < Connecting (Since 6.0)
+  static const int MC_PLAYBACK_STATE_CONNECTING = 12;
+
+  /// < Buffering (Since 6.0)
+  static const int MC_PLAYBACK_STATE_BUFFERING = 13;
+
+  /// < Error (Since 6.0)
+  static const int MC_PLAYBACK_STATE_ERROR = 14;
+}
+
+/// @brief Enumeration for the media playback action.
+/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
+abstract class mc_playback_action_e {
+  /// < Play
+  static const int MC_PLAYBACK_ACTION_PLAY = 0;
+
+  /// < Pause
+  static const int MC_PLAYBACK_ACTION_PAUSE = 1;
+
+  /// < Stop
+  static const int MC_PLAYBACK_ACTION_STOP = 2;
+
+  /// < Next item
+  static const int MC_PLAYBACK_ACTION_NEXT = 3;
+
+  /// < Previous item
+  static const int MC_PLAYBACK_ACTION_PREV = 4;
+
+  /// < Fast forward
+  static const int MC_PLAYBACK_ACTION_FAST_FORWARD = 5;
+
+  /// < Rewind
+  static const int MC_PLAYBACK_ACTION_REWIND = 6;
+
+  /// < Play/Pause toggle
+  static const int MC_PLAYBACK_ACTION_TOGGLE_PLAY_PAUSE = 7;
+}
+
+/// @brief Enumeration for the shuffle mode.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_shuffle_mode_e {
+  /// < Shuffle mode on
+  static const int MC_SHUFFLE_MODE_ON = 0;
+
+  /// < Shuffle mode off
+  static const int MC_SHUFFLE_MODE_OFF = 1;
+}
+
+/// @brief Enumeration for the repeat mode.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_repeat_mode_e {
+  /// < Repeat mode on for all media
+  static const int MC_REPEAT_MODE_ON = 0;
+
+  /// < Repeat mode off
+  static const int MC_REPEAT_MODE_OFF = 1;
+
+  /// < Repeat mode on for one media (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_REPEAT_MODE_ONE_MEDIA = 2;
+}
+
+/// @brief Enumeration for the subscription type.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_subscription_type_e {
+  /// < Server state
+  static const int MC_SUBSCRIPTION_TYPE_SERVER_STATE = 0;
+
+  /// < Playback
+  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK = 1;
+
+  /// < Metadata
+  static const int MC_SUBSCRIPTION_TYPE_METADATA = 2;
+
+  /// < Shuffle mode
+  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_MODE = 3;
+
+  /// < Repeat mode
+  static const int MC_SUBSCRIPTION_TYPE_REPEAT_MODE = 4;
+
+  /// < Playlist (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_SUBSCRIPTION_TYPE_PLAYLIST = 5;
+
+  /// < Playback ability (Since 5.0)
+  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK_ABILITY = 6;
+
+  /// < Shuffle ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
+  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_ABILITY = 7;
+
+  /// < Repeat ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
+  static const int MC_SUBSCRIPTION_TYPE_REPEAT_ABILITY = 8;
+
+  /// < Ability support (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT = 9;
+
+  /// < Display mode ability (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_MODE_ABILITY = 10;
+
+  /// < Display rotation ability (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_ROTATION_ABILITY = 11;
+}
+
+/// @brief Enumeration for the playlist update mode.
+/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
+abstract class mc_playlist_update_mode_e {
+  /// < Create or Update playlist
+  static const int MC_PLAYLIST_UPDATED = 0;
+
+  /// < Remove playlist
+  static const int MC_PLAYLIST_REMOVED = 1;
+}
+
+/// @brief Enumeration for the content type of the content.
+/// @since_tizen 5.0
+abstract class mc_content_type_e {
+  /// < Image content type
+  static const int MC_CONTENT_TYPE_IMAGE = 0;
+
+  /// < Video content type
+  static const int MC_CONTENT_TYPE_VIDEO = 1;
+
+  /// < Music content type
+  static const int MC_CONTENT_TYPE_MUSIC = 2;
+
+  /// < Other content type
+  static const int MC_CONTENT_TYPE_OTHER = 3;
+
+  /// < Not decided
+  static const int MC_CONTENT_TYPE_UNDECIDED = 4;
+}
+
+/// @brief Enumeration for the content age rating of the content.
+/// @since_tizen 5.0
+abstract class mc_content_age_rating_e {
+  /// < Suitable for all ages
+  static const int MC_CONTENT_RATING_ALL = 0;
+
+  /// < Suitable for ages 1 and up
+  static const int MC_CONTENT_RATING_1_PLUS = 1;
+
+  /// < Suitable for ages 2 and up
+  static const int MC_CONTENT_RATING_2_PLUS = 2;
+
+  /// < Suitable for ages 3 and up
+  static const int MC_CONTENT_RATING_3_PLUS = 3;
+
+  /// < Suitable for ages 4 and up
+  static const int MC_CONTENT_RATING_4_PLUS = 4;
+
+  /// < Suitable for ages 5 and up
+  static const int MC_CONTENT_RATING_5_PLUS = 5;
+
+  /// < Suitable for ages 6 and up
+  static const int MC_CONTENT_RATING_6_PLUS = 6;
+
+  /// < Suitable for ages 7 and up
+  static const int MC_CONTENT_RATING_7_PLUS = 7;
+
+  /// < Suitable for ages 8 and up
+  static const int MC_CONTENT_RATING_8_PLUS = 8;
+
+  /// < Suitable for ages 9 and up
+  static const int MC_CONTENT_RATING_9_PLUS = 9;
+
+  /// < Suitable for ages 10 and up
+  static const int MC_CONTENT_RATING_10_PLUS = 10;
+
+  /// < Suitable for ages 11 and up
+  static const int MC_CONTENT_RATING_11_PLUS = 11;
+
+  /// < Suitable for ages 12 and up
+  static const int MC_CONTENT_RATING_12_PLUS = 12;
+
+  /// < Suitable for ages 13 and up
+  static const int MC_CONTENT_RATING_13_PLUS = 13;
+
+  /// < Suitable for ages 14 and up
+  static const int MC_CONTENT_RATING_14_PLUS = 14;
+
+  /// < Suitable for ages 15 and up
+  static const int MC_CONTENT_RATING_15_PLUS = 15;
+
+  /// < Suitable for ages 16 and up
+  static const int MC_CONTENT_RATING_16_PLUS = 16;
+
+  /// < Suitable for ages 17 and up
+  static const int MC_CONTENT_RATING_17_PLUS = 17;
+
+  /// < Suitable for ages 18 and up
+  static const int MC_CONTENT_RATING_18_PLUS = 18;
+
+  /// < Suitable for ages 19 and up
+  static const int MC_CONTENT_RATING_19_PLUS = 19;
+}
+
+/// @brief Enumeration for the support of the ability.
+/// @since_tizen 5.0
+abstract class mc_ability_support_e {
+  /// < Supported
+  static const int MC_ABILITY_SUPPORTED_YES = 0;
+
+  /// < Not supported
+  static const int MC_ABILITY_SUPPORTED_NO = 1;
+
+  /// < Not decided
+  static const int MC_ABILITY_SUPPORTED_UNDECIDED = 2;
+}
+
+/// @brief Enumeration for the ability.
+/// @since_tizen 5.5
+abstract class mc_ability_e {
+  /// < Shuffle
+  static const int MC_ABILITY_SHUFFLE = 0;
+
+  /// < Repeat
+  static const int MC_ABILITY_REPEAT = 1;
+
+  /// < Playback Position
+  static const int MC_ABILITY_PLAYBACK_POSITION = 2;
+
+  /// < Playlist
+  static const int MC_ABILITY_PLAYLIST = 3;
+
+  /// < Custom command from a client
+  static const int MC_ABILITY_CLIENT_CUSTOM = 4;
+
+  /// < Search
+  static const int MC_ABILITY_SEARCH = 5;
+
+  /// < Subtitles display
+  static const int MC_ABILITY_SUBTITLES = 6;
+
+  /// < 360 content mode display
+  static const int MC_ABILITY_360_MODE = 7;
+}
+
+/// @brief Enumeration for the search category.
+/// @since_tizen 5.0
+abstract class mc_search_category_e {
+  /// < No search category
+  static const int MC_SEARCH_NO_CATEGORY = 0;
+
+  /// < Search by content title
+  static const int MC_SEARCH_TITLE = 1;
+
+  /// < Search by content artist
+  static const int MC_SEARCH_ARTIST = 2;
+
+  /// < Search by content album
+  static const int MC_SEARCH_ALBUM = 3;
+
+  /// < Search by content genre
+  static const int MC_SEARCH_GENRE = 4;
+
+  /// < Search by Time Place Occasion
+  static const int MC_SEARCH_TPO = 5;
+}
+
+/// @brief Enumeration for the display mode.
+/// @since_tizen 5.5
+abstract class mc_display_mode_e {
+  /// < Letter box
+  static const int MC_DISPLAY_MODE_LETTER_BOX = 1;
+
+  /// < Origin size
+  static const int MC_DISPLAY_MODE_ORIGIN_SIZE = 2;
+
+  /// < Full-screen
+  static const int MC_DISPLAY_MODE_FULL_SCREEN = 4;
+
+  /// < Cropped full-screen
+  static const int MC_DISPLAY_MODE_CROPPED_FULL = 8;
+}
+
+/// @brief Enumeration for the display rotation.
+/// @since_tizen 5.5
+abstract class mc_display_rotation_e {
+  /// < Display is not rotated
+  static const int MC_DISPLAY_ROTATION_NONE = 1;
+
+  /// < Display is rotated 90 degrees
+  static const int MC_DISPLAY_ROTATION_90 = 2;
+
+  /// < Display is rotated 180 degrees
+  static const int MC_DISPLAY_ROTATION_180 = 4;
+
+  /// < Display is rotated 270 degrees
+  static const int MC_DISPLAY_ROTATION_270 = 8;
+}
+
+/// @brief The result codes of the reply for the command or the event.
+/// @since_tizen 6.0
+///
+/// @see mc_cmd_reply_received_cb()
+/// @see mc_client_send_event_reply()
+/// @see mc_server_event_reply_received_cb()
+/// @see mc_server_send_cmd_reply()
+abstract class mc_result_code_e {
+  /// < The command or the event has been successfully completed.
+  static const int MC_RESULT_CODE_SUCCESS = 0;
+
+  /// < The command or the event had already been completed.
+  static const int MC_RESULT_CODE_ALREADY_DONE = 200;
+
+  /// < The command or the event is aborted by some external event (e.g. aborted play command by incoming call).
+  static const int MC_RESULT_CODE_ABORTED = 300;
+
+  /// < The command or the event is denied due to application policy (e.g. cannot rewind in recording).
+  static const int MC_RESULT_CODE_DENIED = 301;
+
+  /// < The command or the event is not supported.
+  static const int MC_RESULT_CODE_NOT_SUPPORTED = 302;
+
+  /// < The command or the event is out of supported range or the limit is reached.
+  static const int MC_RESULT_CODE_INVALID = 303;
+
+  /// < Timeout has occurred.
+  static const int MC_RESULT_CODE_TIMEOUT = 400;
+
+  /// < The application has failed.
+  static const int MC_RESULT_CODE_APP_FAILED = 401;
+
+  /// < The command or the event has failed because the application has no media.
+  static const int MC_RESULT_CODE_NO_MEDIA = 402;
+
+  /// < The command or the event has failed because there is no audio output device.
+  static const int MC_RESULT_CODE_NO_AUDIO_OUTPUT_DEVICE = 403;
+
+  /// < The command or the event has failed because there is no peer.
+  static const int MC_RESULT_CODE_NO_PEER = 404;
+
+  /// < The network has failed.
+  static const int MC_RESULT_CODE_NETWORK_FAILED = 500;
+
+  /// < The application needs to have an account to which it's logged in.
+  static const int MC_RESULT_CODE_NO_ACCOUNT = 600;
+
+  /// < The application could not log in.
+  static const int MC_RESULT_CODE_LOGIN_FAILED = 601;
+
+  /// < Unknown error.
+  static const int MC_RESULT_CODE_UNKNOWN = 2147483647;
+}
+
 /// @brief The structure type for the media controller playlist handle.
 /// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
 typedef mc_playlist_h = ffi.Pointer<ffi.Void>;
@@ -6848,141 +7303,13 @@ typedef mc_playlist_cbFunction = ffi.Bool Function(
 typedef Dartmc_playlist_cbFunction = bool Function(
     mc_playlist_h playlist, ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the media meta info.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_meta_e {
-  /// < Title
-  static const int MC_META_MEDIA_TITLE = 0;
-
-  /// < Artist
-  static const int MC_META_MEDIA_ARTIST = 1;
-
-  /// < Album
-  static const int MC_META_MEDIA_ALBUM = 2;
-
-  /// < Author
-  static const int MC_META_MEDIA_AUTHOR = 3;
-
-  /// < Genre
-  static const int MC_META_MEDIA_GENRE = 4;
-
-  /// < Duration
-  static const int MC_META_MEDIA_DURATION = 5;
-
-  /// < Date
-  static const int MC_META_MEDIA_DATE = 6;
-
-  /// < Copyright
-  static const int MC_META_MEDIA_COPYRIGHT = 7;
-
-  /// < Description
-  static const int MC_META_MEDIA_DESCRIPTION = 8;
-
-  /// < Track Number
-  static const int MC_META_MEDIA_TRACK_NUM = 9;
-
-  /// < Picture. Album Art
-  static const int MC_META_MEDIA_PICTURE = 10;
-
-  /// < Season (Since 5.5)
-  static const int MC_META_MEDIA_SEASON = 11;
-
-  /// < Episode (Since 5.5)
-  static const int MC_META_MEDIA_EPISODE = 12;
-
-  /// < Content resolution (Since 5.5)
-  static const int MC_META_MEDIA_RESOLUTION = 13;
-}
-
 /// @brief The structure type for the media controller ability handle.
 /// @since_tizen 5.0
 typedef mc_playback_ability_h = ffi.Pointer<ffi.Void>;
 
-/// @brief Enumeration for the media playback action.
-/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
-abstract class mc_playback_action_e {
-  /// < Play
-  static const int MC_PLAYBACK_ACTION_PLAY = 0;
-
-  /// < Pause
-  static const int MC_PLAYBACK_ACTION_PAUSE = 1;
-
-  /// < Stop
-  static const int MC_PLAYBACK_ACTION_STOP = 2;
-
-  /// < Next item
-  static const int MC_PLAYBACK_ACTION_NEXT = 3;
-
-  /// < Previous item
-  static const int MC_PLAYBACK_ACTION_PREV = 4;
-
-  /// < Fast forward
-  static const int MC_PLAYBACK_ACTION_FAST_FORWARD = 5;
-
-  /// < Rewind
-  static const int MC_PLAYBACK_ACTION_REWIND = 6;
-
-  /// < Play/Pause toggle
-  static const int MC_PLAYBACK_ACTION_TOGGLE_PLAY_PAUSE = 7;
-}
-
-/// @brief Enumeration for the support of the ability.
-/// @since_tizen 5.0
-abstract class mc_ability_support_e {
-  /// < Supported
-  static const int MC_ABILITY_SUPPORTED_YES = 0;
-
-  /// < Not supported
-  static const int MC_ABILITY_SUPPORTED_NO = 1;
-
-  /// < Not decided
-  static const int MC_ABILITY_SUPPORTED_UNDECIDED = 2;
-}
-
 /// @brief The structure type for the media controller search handle.
 /// @since_tizen 5.0
 typedef mc_search_h = ffi.Pointer<ffi.Void>;
-
-/// @brief Enumeration for the content type of the content.
-/// @since_tizen 5.0
-abstract class mc_content_type_e {
-  /// < Image content type
-  static const int MC_CONTENT_TYPE_IMAGE = 0;
-
-  /// < Video content type
-  static const int MC_CONTENT_TYPE_VIDEO = 1;
-
-  /// < Music content type
-  static const int MC_CONTENT_TYPE_MUSIC = 2;
-
-  /// < Other content type
-  static const int MC_CONTENT_TYPE_OTHER = 3;
-
-  /// < Not decided
-  static const int MC_CONTENT_TYPE_UNDECIDED = 4;
-}
-
-/// @brief Enumeration for the search category.
-/// @since_tizen 5.0
-abstract class mc_search_category_e {
-  /// < No search category
-  static const int MC_SEARCH_NO_CATEGORY = 0;
-
-  /// < Search by content title
-  static const int MC_SEARCH_TITLE = 1;
-
-  /// < Search by content artist
-  static const int MC_SEARCH_ARTIST = 2;
-
-  /// < Search by content album
-  static const int MC_SEARCH_ALBUM = 3;
-
-  /// < Search by content genre
-  static const int MC_SEARCH_GENRE = 4;
-
-  /// < Search by Time Place Occasion
-  static const int MC_SEARCH_TPO = 5;
-}
 
 /// @brief Called for every search condition information in the obtained list of search.
 /// @details Iterates over a search list.
@@ -7047,19 +7374,6 @@ typedef Dartmc_server_state_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the media controller server state.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_server_state_e {
-  /// < None state
-  static const int MC_SERVER_STATE_NONE = 0;
-
-  /// < Activate state
-  static const int MC_SERVER_STATE_ACTIVATE = 1;
-
-  /// < Deactivate state
-  static const int MC_SERVER_STATE_DEACTIVATE = 2;
-}
 
 /// @brief Called when the playback information of the media controller server is updated.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
@@ -7146,16 +7460,6 @@ typedef Dartmc_shuffle_mode_updated_cbFunction = void Function(
     int mode,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the shuffle mode.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_shuffle_mode_e {
-  /// < Shuffle mode on
-  static const int MC_SHUFFLE_MODE_ON = 0;
-
-  /// < Shuffle mode off
-  static const int MC_SHUFFLE_MODE_OFF = 1;
-}
-
 /// @brief Called when the repeat mode of the media controller server is updated.
 /// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
 ///
@@ -7180,19 +7484,6 @@ typedef Dartmc_repeat_mode_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int mode,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the repeat mode.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_repeat_mode_e {
-  /// < Repeat mode on for all media
-  static const int MC_REPEAT_MODE_ON = 0;
-
-  /// < Repeat mode off
-  static const int MC_REPEAT_MODE_OFF = 1;
-
-  /// < Repeat mode on for one media (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_REPEAT_MODE_ONE_MEDIA = 2;
-}
 
 /// @brief Called when the playback ability support of the media controller server is updated.
 /// @since_tizen 5.0
@@ -7299,34 +7590,6 @@ typedef Dartmc_ability_support_updated_cbFunction = void Function(
     int support,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the ability.
-/// @since_tizen 5.5
-abstract class mc_ability_e {
-  /// < Shuffle
-  static const int MC_ABILITY_SHUFFLE = 0;
-
-  /// < Repeat
-  static const int MC_ABILITY_REPEAT = 1;
-
-  /// < Playback Position
-  static const int MC_ABILITY_PLAYBACK_POSITION = 2;
-
-  /// < Playlist
-  static const int MC_ABILITY_PLAYLIST = 3;
-
-  /// < Custom command from a client
-  static const int MC_ABILITY_CLIENT_CUSTOM = 4;
-
-  /// < Search
-  static const int MC_ABILITY_SEARCH = 5;
-
-  /// < Subtitles display
-  static const int MC_ABILITY_SUBTITLES = 6;
-
-  /// < 360 content mode display
-  static const int MC_ABILITY_360_MODE = 7;
-}
-
 /// @brief Called when a media controller server's supported items for an ability is updated.
 /// @since_tizen 5.5
 ///
@@ -7416,16 +7679,6 @@ typedef Dartmc_playlist_updated_cbFunction = void Function(
     mc_playlist_h playlist,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the playlist update mode.
-/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
-abstract class mc_playlist_update_mode_e {
-  /// < Create or Update playlist
-  static const int MC_PLAYLIST_UPDATED = 0;
-
-  /// < Remove playlist
-  static const int MC_PLAYLIST_REMOVED = 1;
-}
-
 /// @brief Called when the status of a media controller server's boolean attribute (subtitles or 360 mode) is updated.
 /// @since_tizen 5.5
 ///
@@ -7473,22 +7726,6 @@ typedef Dartmc_display_mode_updated_cbFunction = void Function(
     int mode,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the display mode.
-/// @since_tizen 5.5
-abstract class mc_display_mode_e {
-  /// < Letter box
-  static const int MC_DISPLAY_MODE_LETTER_BOX = 1;
-
-  /// < Origin size
-  static const int MC_DISPLAY_MODE_ORIGIN_SIZE = 2;
-
-  /// < Full-screen
-  static const int MC_DISPLAY_MODE_FULL_SCREEN = 4;
-
-  /// < Cropped full-screen
-  static const int MC_DISPLAY_MODE_CROPPED_FULL = 8;
-}
-
 /// @brief Called when a media controller server's display rotation is updated.
 /// @since_tizen 5.5
 ///
@@ -7511,22 +7748,6 @@ typedef Dartmc_display_rotation_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int rotation,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the display rotation.
-/// @since_tizen 5.5
-abstract class mc_display_rotation_e {
-  /// < Display is not rotated
-  static const int MC_DISPLAY_ROTATION_NONE = 1;
-
-  /// < Display is rotated 90 degrees
-  static const int MC_DISPLAY_ROTATION_90 = 2;
-
-  /// < Display is rotated 180 degrees
-  static const int MC_DISPLAY_ROTATION_180 = 4;
-
-  /// < Display is rotated 270 degrees
-  static const int MC_DISPLAY_ROTATION_270 = 8;
-}
 
 /// @brief Called when receiving custom event of media controller servers.
 /// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
@@ -7563,46 +7784,6 @@ typedef Dartmc_client_custom_event_received_cbFunction = void Function(
     ffi.Pointer<bundle.bundle> data,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the subscription type.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_subscription_type_e {
-  /// < Server state
-  static const int MC_SUBSCRIPTION_TYPE_SERVER_STATE = 0;
-
-  /// < Playback
-  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK = 1;
-
-  /// < Metadata
-  static const int MC_SUBSCRIPTION_TYPE_METADATA = 2;
-
-  /// < Shuffle mode
-  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_MODE = 3;
-
-  /// < Repeat mode
-  static const int MC_SUBSCRIPTION_TYPE_REPEAT_MODE = 4;
-
-  /// < Playlist (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_SUBSCRIPTION_TYPE_PLAYLIST = 5;
-
-  /// < Playback ability (Since 5.0)
-  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK_ABILITY = 6;
-
-  /// < Shuffle ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
-  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_ABILITY = 7;
-
-  /// < Repeat ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
-  static const int MC_SUBSCRIPTION_TYPE_REPEAT_ABILITY = 8;
-
-  /// < Ability support (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT = 9;
-
-  /// < Display mode ability (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_MODE_ABILITY = 10;
-
-  /// < Display rotation ability (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_ROTATION_ABILITY = 11;
-}
-
 /// @brief Called when requesting the list of subscribed servers.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
 ///
@@ -7625,107 +7806,6 @@ typedef mc_subscribed_server_cbFunction = ffi.Bool Function(
     ffi.Pointer<ffi.Char> server_name, ffi.Pointer<ffi.Void> user_data);
 typedef Dartmc_subscribed_server_cbFunction = bool Function(
     ffi.Pointer<ffi.Char> server_name, ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the media playback state.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_playback_states_e {
-  /// < None
-  static const int MC_PLAYBACK_STATE_NONE = 0;
-
-  /// < Playing
-  static const int MC_PLAYBACK_STATE_PLAYING = 1;
-
-  /// < Paused
-  static const int MC_PLAYBACK_STATE_PAUSED = 2;
-
-  /// < Stopped
-  static const int MC_PLAYBACK_STATE_STOPPED = 3;
-
-  /// < Moving to the next item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_MOVING_TO_NEXT = 8;
-
-  /// < Moving to the previous item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_MOVING_TO_PREVIOUS = 9;
-
-  /// < Fast forwarding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_FAST_FORWARDING = 10;
-
-  /// < Rewinding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_REWINDING = 11;
-
-  /// < Connecting (Since 6.0)
-  static const int MC_PLAYBACK_STATE_CONNECTING = 12;
-
-  /// < Buffering (Since 6.0)
-  static const int MC_PLAYBACK_STATE_BUFFERING = 13;
-
-  /// < Error (Since 6.0)
-  static const int MC_PLAYBACK_STATE_ERROR = 14;
-}
-
-/// @brief Enumeration for the content age rating of the content.
-/// @since_tizen 5.0
-abstract class mc_content_age_rating_e {
-  /// < Suitable for all ages
-  static const int MC_CONTENT_RATING_ALL = 0;
-
-  /// < Suitable for ages 1 and up
-  static const int MC_CONTENT_RATING_1_PLUS = 1;
-
-  /// < Suitable for ages 2 and up
-  static const int MC_CONTENT_RATING_2_PLUS = 2;
-
-  /// < Suitable for ages 3 and up
-  static const int MC_CONTENT_RATING_3_PLUS = 3;
-
-  /// < Suitable for ages 4 and up
-  static const int MC_CONTENT_RATING_4_PLUS = 4;
-
-  /// < Suitable for ages 5 and up
-  static const int MC_CONTENT_RATING_5_PLUS = 5;
-
-  /// < Suitable for ages 6 and up
-  static const int MC_CONTENT_RATING_6_PLUS = 6;
-
-  /// < Suitable for ages 7 and up
-  static const int MC_CONTENT_RATING_7_PLUS = 7;
-
-  /// < Suitable for ages 8 and up
-  static const int MC_CONTENT_RATING_8_PLUS = 8;
-
-  /// < Suitable for ages 9 and up
-  static const int MC_CONTENT_RATING_9_PLUS = 9;
-
-  /// < Suitable for ages 10 and up
-  static const int MC_CONTENT_RATING_10_PLUS = 10;
-
-  /// < Suitable for ages 11 and up
-  static const int MC_CONTENT_RATING_11_PLUS = 11;
-
-  /// < Suitable for ages 12 and up
-  static const int MC_CONTENT_RATING_12_PLUS = 12;
-
-  /// < Suitable for ages 13 and up
-  static const int MC_CONTENT_RATING_13_PLUS = 13;
-
-  /// < Suitable for ages 14 and up
-  static const int MC_CONTENT_RATING_14_PLUS = 14;
-
-  /// < Suitable for ages 15 and up
-  static const int MC_CONTENT_RATING_15_PLUS = 15;
-
-  /// < Suitable for ages 16 and up
-  static const int MC_CONTENT_RATING_16_PLUS = 16;
-
-  /// < Suitable for ages 17 and up
-  static const int MC_CONTENT_RATING_17_PLUS = 17;
-
-  /// < Suitable for ages 18 and up
-  static const int MC_CONTENT_RATING_18_PLUS = 18;
-
-  /// < Suitable for ages 19 and up
-  static const int MC_CONTENT_RATING_19_PLUS = 19;
-}
 
 /// @brief Called when requesting the list of created servers.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
@@ -8131,3 +8211,5 @@ typedef Dartmc_server_search_cmd_received_cbFunction = void Function(
     ffi.Pointer<ffi.Char> request_id,
     mc_search_h search,
     ffi.Pointer<ffi.Void> user_data);
+
+const int MEDIA_CONTROLLER_ERROR_CLASS = -50462720;

--- a/lib/src/bindings/6.5/generated_bindings_capi_media_metadata_editor.dart
+++ b/lib/src/bindings/6.5/generated_bindings_capi_media_metadata_editor.dart
@@ -368,9 +368,34 @@ class Tizen65CapiMediaMetadataEditor {
 }
 
 /// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
-/// @brief The handle of media metadata.
+/// @brief The enumerations of media metadata error.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-typedef metadata_editor_h = ffi.Pointer<ffi.Void>;
+abstract class metadata_editor_error_e {
+  /// < Successful
+  static const int METADATA_EDITOR_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int METADATA_EDITOR_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int METADATA_EDITOR_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < File not exist
+  static const int METADATA_EDITOR_ERROR_FILE_EXISTS = -17;
+
+  /// < Permission denied
+  static const int METADATA_EDITOR_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Unsupported type
+  static const int METADATA_EDITOR_ERROR_NOT_SUPPORTED = -1073741822;
+
+  /// < Invalid internal operation
+  static const int METADATA_EDITOR_ERROR_OPERATION_FAILED = -27000831;
+
+  /// < Update not possible (Since 6.0)
+  static const int METADATA_EDITOR_ERROR_METADATA_UPDATE_NOT_POSSIBLE =
+      -27000830;
+}
 
 /// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
 /// @brief The enumerations of attribute.
@@ -415,3 +440,10 @@ abstract class metadata_editor_attr_e {
   /// < Unsynchronized lyric
   static const int METADATA_EDITOR_ATTR_UNSYNCLYRICS = 12;
 }
+
+/// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
+/// @brief The handle of media metadata.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+typedef metadata_editor_h = ffi.Pointer<ffi.Void>;
+
+const int METADATA_EDITOR_ERROR_CLASS = -27000832;

--- a/lib/src/bindings/6.5/generated_bindings_capi_media_metadata_extractor.dart
+++ b/lib/src/bindings/6.5/generated_bindings_capi_media_metadata_extractor.dart
@@ -384,11 +384,27 @@ class Tizen65CapiMediaMetadataExtractor {
 }
 
 /// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
-/// @brief The metadata extractor handle.
+/// @brief Enumeration for metadata extractor error.
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
-typedef metadata_extractor_h = ffi.Pointer<metadata_extractor_s>;
+abstract class metadata_extractor_error_e {
+  /// < Successful
+  static const int METADATA_EXTRACTOR_ERROR_NONE = 0;
 
-final class metadata_extractor_s extends ffi.Opaque {}
+  /// < Invalid parameter
+  static const int METADATA_EXTRACTOR_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int METADATA_EXTRACTOR_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < File does not exist
+  static const int METADATA_EXTRACTOR_ERROR_FILE_EXISTS = -17;
+
+  /// < Permission denied
+  static const int METADATA_EXTRACTOR_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Invalid internal operation
+  static const int METADATA_EXTRACTOR_ERROR_OPERATION_FAILED = -26411007;
+}
 
 /// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
 /// @brief Enumeration for attribute.
@@ -499,3 +515,12 @@ abstract class metadata_extractor_attr_e {
   /// < Flag indicating if the video is a spherical video (Since 3.0)
   static const int METADATA_360 = 34;
 }
+
+final class metadata_extractor_s extends ffi.Opaque {}
+
+/// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
+/// @brief The metadata extractor handle.
+/// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
+typedef metadata_extractor_h = ffi.Pointer<metadata_extractor_s>;
+
+const int METADATA_EXTRACTOR_ERROR_CLASS = -26411008;

--- a/lib/src/bindings/6.5/generated_bindings_capi_media_screen_mirroring.dart
+++ b/lib/src/bindings/6.5/generated_bindings_capi_media_screen_mirroring.dart
@@ -880,29 +880,6 @@ class Tizen65CapiMediaScreenMirroring {
           int Function(scmirroring_sink_h, ffi.Pointer<ffi.Int32>)>();
 }
 
-/// @brief	The handle to the screen mirroring sink.
-/// @since_tizen 2.4
-typedef scmirroring_sink_h = ffi.Pointer<ffi.Void>;
-
-/// @brief Called when each status is changed.
-/// @since_tizen 2.4
-///
-/// @details This callback is called for state and error of screen mirroring sink
-///
-/// @param[in] error     The error code
-/// @param[in] state     The screen mirroring sink state
-/// @param[in] user_data The user data passed from the scmirroring_sink_set_state_cb() function
-///
-/// @pre scmirroring_sink_create()
-///
-/// @see scmirroring_sink_create()
-typedef scmirroring_sink_state_cb
-    = ffi.Pointer<ffi.NativeFunction<scmirroring_sink_state_cbFunction>>;
-typedef scmirroring_sink_state_cbFunction = ffi.Void Function(
-    ffi.Int32 error, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
-typedef Dartscmirroring_sink_state_cbFunction = void Function(
-    int error, int state, ffi.Pointer<ffi.Void> user_data);
-
 /// @brief Enumeration for screen mirroring error.
 /// @since_tizen 2.4
 abstract class scmirroring_error_e {
@@ -957,6 +934,41 @@ abstract class scmirroring_sink_state_e {
   static const int SCMIRRORING_SINK_STATE_MAX = 7;
 }
 
+/// @brief Enumeration for screen mirroring resolution.
+/// @since_tizen 2.4
+abstract class scmirroring_resolution_e {
+  static const int SCMIRRORING_RESOLUTION_UNKNOWN = 0;
+
+  /// < W-1920, H-1080, 30 fps
+  static const int SCMIRRORING_RESOLUTION_1920x1080_P30 = 1;
+
+  /// < W-1280, H-720, 30 fps
+  static const int SCMIRRORING_RESOLUTION_1280x720_P30 = 2;
+
+  /// < W-960, H-540, 30 fps
+  static const int SCMIRRORING_RESOLUTION_960x540_P30 = 4;
+
+  /// < W-864, H-480, 30 fps
+  static const int SCMIRRORING_RESOLUTION_864x480_P30 = 8;
+
+  /// < W-720, H-480, 30 fps
+  static const int SCMIRRORING_RESOLUTION_720x480_P60 = 16;
+
+  /// < W-640, H-480, 60 fps
+  static const int SCMIRRORING_RESOLUTION_640x480_P60 = 32;
+
+  /// < W-640, H-360, 30 fps
+  static const int SCMIRRORING_RESOLUTION_640x360_P30 = 64;
+  static const int SCMIRRORING_RESOLUTION_MAX = 128;
+}
+
+/// @brief Ability to send to multisink.
+/// @since_tizen 3.0
+abstract class scmirroring_multisink_e {
+  static const int SCMIRRORING_MULTISINK_DISABLE = 0;
+  static const int SCMIRRORING_MULTISINK_ENABLE = 1;
+}
+
 /// @brief Enumeration for screen mirroring display surface type.
 /// @since_tizen 2.4
 abstract class scmirroring_display_type_e {
@@ -966,16 +978,6 @@ abstract class scmirroring_display_type_e {
   /// < Use Evas pixmap surface to display streaming multimedia data
   static const int SCMIRRORING_DISPLAY_TYPE_EVAS = 1;
   static const int SCMIRRORING_DISPLAY_TYPE_MAX = 2;
-}
-
-/// @brief Enumeration for screen mirroring video codec.
-/// @since_tizen 2.4
-abstract class scmirroring_video_codec_e {
-  /// < Screen mirroring is not negotiated yet
-  static const int SCMIRRORING_VIDEO_CODEC_NONE = 0;
-
-  /// < H.264 codec for video
-  static const int SCMIRRORING_VIDEO_CODEC_H264 = 1;
 }
 
 /// @brief Enumeration for screen mirroring audio codec.
@@ -993,3 +995,56 @@ abstract class scmirroring_audio_codec_e {
   /// < LPCM codec for audio
   static const int SCMIRRORING_AUDIO_CODEC_LPCM = 3;
 }
+
+/// @brief Enumeration for screen mirroring video codec.
+/// @since_tizen 2.4
+abstract class scmirroring_video_codec_e {
+  /// < Screen mirroring is not negotiated yet
+  static const int SCMIRRORING_VIDEO_CODEC_NONE = 0;
+
+  /// < H.264 codec for video
+  static const int SCMIRRORING_VIDEO_CODEC_H264 = 1;
+}
+
+/// @brief Enumeration for screen mirroring direct streaming mode.
+/// @since_tizen 3.0
+abstract class scmirroring_direct_streaming_e {
+  /// < Disable screen mirroring direct streaming mode
+  static const int SCMIRRORING_DIRECT_STREAMING_DISABLED = 0;
+
+  /// < Enable direct streaming for files
+  static const int SCMIRRORING_DIRECT_STREAMING_ENABLED = 1;
+}
+
+/// @brief Enumeration for screen mirroring AV streaming transport.
+/// @since_tizen 3.0
+abstract class scmirroring_av_transport_e {
+  /// < UDP transport for AV streaming data
+  static const int SCMIRRORING_AV_TRANSPORT_UDP = 0;
+
+  /// < TCP transport for AV streaming data
+  static const int SCMIRRORING_AV_TRANSPORT_TCP = 1;
+}
+
+/// @brief	The handle to the screen mirroring sink.
+/// @since_tizen 2.4
+typedef scmirroring_sink_h = ffi.Pointer<ffi.Void>;
+
+/// @brief Called when each status is changed.
+/// @since_tizen 2.4
+///
+/// @details This callback is called for state and error of screen mirroring sink
+///
+/// @param[in] error     The error code
+/// @param[in] state     The screen mirroring sink state
+/// @param[in] user_data The user data passed from the scmirroring_sink_set_state_cb() function
+///
+/// @pre scmirroring_sink_create()
+///
+/// @see scmirroring_sink_create()
+typedef scmirroring_sink_state_cb
+    = ffi.Pointer<ffi.NativeFunction<scmirroring_sink_state_cbFunction>>;
+typedef scmirroring_sink_state_cbFunction = ffi.Void Function(
+    ffi.Int32 error, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
+typedef Dartscmirroring_sink_state_cbFunction = void Function(
+    int error, int state, ffi.Pointer<ffi.Void> user_data);

--- a/lib/src/bindings/6.5/generated_bindings_capi_media_sound_pool.dart
+++ b/lib/src/bindings/6.5/generated_bindings_capi_media_sound_pool.dart
@@ -865,10 +865,52 @@ class Tizen65CapiMediaSoundPool {
       .asFunction<int Function(sound_pool_h, int, ffi.Pointer<ffi.Int32>)>();
 }
 
-/// @brief Sound pool handle type.
+/// @brief Enumeration for Tizen Sound Pool error.
 ///
 /// @since_tizen 4.0
-typedef sound_pool_h = ffi.Pointer<ffi.Void>;
+abstract class sound_pool_error_e {
+  static const int SOUND_POOL_ERROR_NONE = 0;
+  static const int SOUND_POOL_ERROR_KEY_NOT_AVAILABLE = -126;
+  static const int SOUND_POOL_ERROR_OUT_OF_MEMORY = -12;
+  static const int SOUND_POOL_ERROR_INVALID_PARAMETER = -22;
+  static const int SOUND_POOL_ERROR_INVALID_OPERATION = -38;
+  static const int SOUND_POOL_ERROR_NOT_PERMITTED = -1;
+  static const int SOUND_POOL_ERROR_NO_SUCH_FILE = -2;
+}
+
+/// @brief Enumeration of sound pool stream state.
+///
+/// @since_tizen 4.0
+abstract class sound_pool_stream_state_e {
+  /// < Stream state isn't determined
+  static const int SOUND_POOL_STREAM_STATE_NONE = 0;
+
+  /// < Stream state is playing
+  static const int SOUND_POOL_STREAM_STATE_PLAYING = 1;
+
+  /// < Stream state is paused
+  static const int SOUND_POOL_STREAM_STATE_PAUSED = 2;
+
+  /// < Stream state is stopped
+  static const int SOUND_POOL_STREAM_STATE_STOPPED = 3;
+
+  /// < Stream state is finished
+  static const int SOUND_POOL_STREAM_STATE_FINISHED = 4;
+
+  /// < Stream state is suspended
+  static const int SOUND_POOL_STREAM_STATE_SUSPENDED = 5;
+}
+
+/// @brief Enumeration of sound pool stream priority policy.
+///
+/// @since_tizen 4.0
+abstract class sound_pool_stream_priority_policy_e {
+  /// < Stream priority policy is mute
+  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_MUTE = 0;
+
+  /// < Stream priority policy is suspended
+  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_SUSPENDED = 1;
+}
 
 /// @brief Enumeration of sound pool state.
 ///
@@ -880,6 +922,11 @@ abstract class sound_pool_state_e {
   /// < Sound pool inactive state: streams can't be played
   static const int SOUND_POOL_STATE_INACTIVE = 1;
 }
+
+/// @brief Sound pool handle type.
+///
+/// @since_tizen 4.0
+typedef sound_pool_h = ffi.Pointer<ffi.Void>;
 
 /// @brief Called when the sound pool state is changed.
 ///
@@ -910,17 +957,6 @@ typedef Dartsound_pool_state_changed_cbFunction = void Function(
     int prev_state,
     int cur_state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration of sound pool stream priority policy.
-///
-/// @since_tizen 4.0
-abstract class sound_pool_stream_priority_policy_e {
-  /// < Stream priority policy is mute
-  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_MUTE = 0;
-
-  /// < Stream priority policy is suspended
-  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_SUSPENDED = 1;
-}
 
 /// @brief Called when the sound pool stream state is changed.
 ///
@@ -954,26 +990,3 @@ typedef Dartsound_pool_stream_state_changed_cbFunction = void Function(
     int prev_state,
     int cur_state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration of sound pool stream state.
-///
-/// @since_tizen 4.0
-abstract class sound_pool_stream_state_e {
-  /// < Stream state isn't determined
-  static const int SOUND_POOL_STREAM_STATE_NONE = 0;
-
-  /// < Stream state is playing
-  static const int SOUND_POOL_STREAM_STATE_PLAYING = 1;
-
-  /// < Stream state is paused
-  static const int SOUND_POOL_STREAM_STATE_PAUSED = 2;
-
-  /// < Stream state is stopped
-  static const int SOUND_POOL_STREAM_STATE_STOPPED = 3;
-
-  /// < Stream state is finished
-  static const int SOUND_POOL_STREAM_STATE_FINISHED = 4;
-
-  /// < Stream state is suspended
-  static const int SOUND_POOL_STREAM_STATE_SUSPENDED = 5;
-}

--- a/lib/src/bindings/6.5/generated_bindings_capi_media_thumbnail_util.dart
+++ b/lib/src/bindings/6.5/generated_bindings_capi_media_thumbnail_util.dart
@@ -380,12 +380,38 @@ class Tizen65CapiMediaThumbnailUtil {
 }
 
 /// @ingroup CAPI_MEDIA_THUMBNAIL_UTIL_MODULE
+/// @brief Enumeration for a thumbnail util error.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class thumbnail_util_error_e {
+  /// < Successful
+  static const int THUMBNAIL_UTIL_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int THUMBNAIL_UTIL_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int THUMBNAIL_UTIL_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Invalid Operation
+  static const int THUMBNAIL_UTIL_ERROR_INVALID_OPERATION = -38;
+
+  /// < No space left on device
+  static const int THUMBNAIL_UTIL_ERROR_FILE_NO_SPACE_ON_DEVICE = -28;
+
+  /// < Permission denied
+  static const int THUMBNAIL_UTIL_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Unsupported Content (Since 4.0)
+  static const int THUMBNAIL_UTIL_ERROR_UNSUPPORTED_CONTENT = -49872895;
+}
+
+final class thumbnail_s extends ffi.Opaque {}
+
+/// @ingroup CAPI_MEDIA_THUMBNAIL_UTIL_MODULE
 /// @deprecated Deprecated since 5.0.
 /// @brief The structure type for the thumbnail info handle.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
 typedef thumbnail_h = ffi.Pointer<thumbnail_s>;
-
-final class thumbnail_s extends ffi.Opaque {}
 
 /// @ingroup CAPI_MEDIA_THUMBNAIL_UTIL_MODULE
 /// @deprecated Deprecated since 5.0.
@@ -431,28 +457,4 @@ typedef Dartthumbnail_extracted_cbFunction = void Function(
     int thumb_size,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_MEDIA_THUMBNAIL_UTIL_MODULE
-/// @brief Enumeration for a thumbnail util error.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class thumbnail_util_error_e {
-  /// < Successful
-  static const int THUMBNAIL_UTIL_ERROR_NONE = 0;
-
-  /// < Invalid parameter
-  static const int THUMBNAIL_UTIL_ERROR_INVALID_PARAMETER = -22;
-
-  /// < Out of memory
-  static const int THUMBNAIL_UTIL_ERROR_OUT_OF_MEMORY = -12;
-
-  /// < Invalid Operation
-  static const int THUMBNAIL_UTIL_ERROR_INVALID_OPERATION = -38;
-
-  /// < No space left on device
-  static const int THUMBNAIL_UTIL_ERROR_FILE_NO_SPACE_ON_DEVICE = -28;
-
-  /// < Permission denied
-  static const int THUMBNAIL_UTIL_ERROR_PERMISSION_DENIED = -13;
-
-  /// < Unsupported Content (Since 4.0)
-  static const int THUMBNAIL_UTIL_ERROR_UNSUPPORTED_CONTENT = -49872895;
-}
+const int THUMBNAIL_UTIL_ERROR_CLASS = -49872896;

--- a/lib/src/bindings/6.5/generated_bindings_capi_network_bluetooth.dart
+++ b/lib/src/bindings/6.5/generated_bindings_capi_network_bluetooth.dart
@@ -9643,6 +9643,185 @@ class Tizen65CapiNetworkBluetooth {
           .asFunction<int Function(ffi.Pointer<ffi.Bool>)>();
 }
 
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of PBAP fields.
+/// @since_tizen 3.0
+abstract class bt_pbap_field_e {
+  /// < All field
+  static const int BT_PBAP_FIELD_ALL = -1;
+
+  /// < vCard Version
+  static const int BT_PBAP_FIELD_VERSION = 1;
+
+  /// < Formatted Name
+  static const int BT_PBAP_FIELD_FN = 2;
+
+  /// < Structured Presentation of Name
+  static const int BT_PBAP_FIELD_N = 4;
+
+  /// < Associated Image or Photo
+  static const int BT_PBAP_FIELD_PHOTO = 8;
+
+  /// < Birthday
+  static const int BT_PBAP_FIELD_BDAY = 16;
+
+  /// < Delivery Address
+  static const int BT_PBAP_FIELD_ADR = 32;
+
+  /// < Delivery
+  static const int BT_PBAP_FIELD_LABEL = 64;
+
+  /// < Telephone Number
+  static const int BT_PBAP_FIELD_TEL = 128;
+
+  /// < Electronic Mail Address
+  static const int BT_PBAP_FIELD_EMAIL = 256;
+
+  /// < Electronic Mail
+  static const int BT_PBAP_FIELD_MAILER = 512;
+
+  /// < Time Zone
+  static const int BT_PBAP_FIELD_TZ = 1024;
+
+  /// < Geographic Position
+  static const int BT_PBAP_FIELD_GEO = 2048;
+
+  /// < Job
+  static const int BT_PBAP_FIELD_TITLE = 4096;
+
+  /// < Role within the Organization
+  static const int BT_PBAP_FIELD_ROLE = 8192;
+
+  /// < Organization Logo
+  static const int BT_PBAP_FIELD_LOGO = 16384;
+
+  /// < vCard of Person Representing
+  static const int BT_PBAP_FIELD_AGENT = 32768;
+
+  /// < Name of Organization
+  static const int BT_PBAP_FIELD_ORG = 65536;
+
+  /// < Comments
+  static const int BT_PBAP_FIELD_NOTE = 131072;
+
+  /// < Revision
+  static const int BT_PBAP_FIELD_REV = 262144;
+
+  /// < Pronunciation of Name
+  static const int BT_PBAP_FIELD_SOUND = 524288;
+
+  /// < Uniform Resource Locator
+  static const int BT_PBAP_FIELD_URL = 1048576;
+
+  /// < Unique ID
+  static const int BT_PBAP_FIELD_UID = 2097152;
+
+  /// < Public Encryption Key
+  static const int BT_PBAP_FIELD_KEY = 4194304;
+
+  /// < Nickname
+  static const int BT_PBAP_FIELD_NICKNAME = 8388608;
+
+  /// < Categories
+  static const int BT_PBAP_FIELD_CATEGORIES = 16777216;
+
+  /// < Product ID
+  static const int BT_PBAP_FIELD_PROID = 33554432;
+
+  /// < Class information
+  static const int BT_PBAP_FIELD_CLASS = 67108864;
+
+  /// < String used for sorting operations
+  static const int BT_PBAP_FIELD_SORT_STRING = 134217728;
+
+  /// < Time stamp
+  static const int BT_PBAP_FIELD_X_IRMC_CALL_DATETIME = 268435456;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_MODULE
+/// @brief Enumerations of Bluetooth error codes.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_error_e {
+  /// < Successful
+  static const int BT_ERROR_NONE = 0;
+
+  /// < Operation cancelled
+  static const int BT_ERROR_CANCELLED = -125;
+
+  /// < Invalid parameter
+  static const int BT_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int BT_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Device or resource busy
+  static const int BT_ERROR_RESOURCE_BUSY = -16;
+
+  /// < Timeout error
+  static const int BT_ERROR_TIMED_OUT = -1073741823;
+
+  /// < Operation now in progress
+  static const int BT_ERROR_NOW_IN_PROGRESS = -115;
+
+  /// < BT is Not Supported
+  static const int BT_ERROR_NOT_SUPPORTED = -1073741822;
+
+  /// < Permission denied
+  static const int BT_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Quota exceeded
+  static const int BT_ERROR_QUOTA_EXCEEDED = -122;
+
+  /// < No data available
+  static const int BT_ERROR_NO_DATA = -61;
+
+  /// < Device policy restriction (Since 3.0)
+  static const int BT_ERROR_DEVICE_POLICY_RESTRICTION = -1073741820;
+
+  /// < Local adapter not initialized
+  static const int BT_ERROR_NOT_INITIALIZED = -29359871;
+
+  /// < Local adapter not enabled
+  static const int BT_ERROR_NOT_ENABLED = -29359870;
+
+  /// < Operation already done
+  static const int BT_ERROR_ALREADY_DONE = -29359869;
+
+  /// < Operation failed
+  static const int BT_ERROR_OPERATION_FAILED = -29359868;
+
+  /// < Operation not in progress
+  static const int BT_ERROR_NOT_IN_PROGRESS = -29359867;
+
+  /// < Remote device not bonded
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_BONDED = -29359866;
+
+  /// < Authentication rejected
+  static const int BT_ERROR_AUTH_REJECTED = -29359865;
+
+  /// < Authentication failed
+  static const int BT_ERROR_AUTH_FAILED = -29359864;
+
+  /// < Remote device not found
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_FOUND = -29359863;
+
+  /// < Service search failed
+  static const int BT_ERROR_SERVICE_SEARCH_FAILED = -29359862;
+
+  /// < Remote device is not connected
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_CONNECTED = -29359861;
+
+  /// < Resource temporarily unavailable
+  static const int BT_ERROR_AGAIN = -29359860;
+
+  /// < Service Not Found
+  static const int BT_ERROR_SERVICE_NOT_FOUND = -29359859;
+
+  /// < Authorization rejected (Since 5.0)
+  static const int BT_ERROR_AUTHORIZATION_REJECTED = -29359858;
+}
+
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
 /// @brief  Enumerations of the Bluetooth adapter state.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
@@ -9667,6 +9846,178 @@ abstract class bt_adapter_visibility_mode_e {
   /// < Discoverable mode with time limit. After specific period,
   /// it is changed to #BT_ADAPTER_VISIBILITY_MODE_NON_DISCOVERABLE.
   static const int BT_ADAPTER_VISIBILITY_MODE_LIMITED_DISCOVERABLE = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief Enumerations of the discovery state of Bluetooth device.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_device_discovery_state_e {
+  /// < Device discovery is started
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_STARTED = 0;
+
+  /// < Device discovery is finished
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_FINISHED = 1;
+
+  /// < The remote Bluetooth device is found
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_FOUND = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising state.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_le_advertising_state_e {
+  /// < Bluetooth advertising is stopped
+  static const int BT_ADAPTER_LE_ADVERTISING_STOPPED = 0;
+
+  /// < Bluetooth advertising is started
+  static const int BT_ADAPTER_LE_ADVERTISING_STARTED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising mode.
+/// @since_tizen 2.3.1
+abstract class bt_adapter_le_advertising_mode_e {
+  /// < Balanced advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_BALANCED = 0;
+
+  /// < Low latency advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_LATENCY = 1;
+
+  /// < Low energy advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_ENERGY = 2;
+
+  /// < Custom mode to set advertising parameters
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_CUSTOM = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising filter policy.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_le_advertising_filter_policy_e {
+  /// < White list is not in use
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_DEFAULT = 0;
+
+  /// < Allow the scan
+  /// request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_SCAN_WL = 1;
+
+  /// < Allow the connection
+  /// request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_CONN_WL = 2;
+
+  /// < Allow the
+  /// scan and connection request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_SCAN_CONN_WL = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth LE packet type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_le_packet_type_e {
+  /// < Advertising packet
+  static const int BT_ADAPTER_LE_PACKET_ADVERTISING = 0;
+
+  /// < Scan response packet
+  static const int BT_ADAPTER_LE_PACKET_SCAN_RESPONSE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth le scan mode.
+/// @since_tizen 3.0
+abstract class bt_adapter_le_scan_mode_e {
+  /// < Balanced mode of power consumption and connection latency
+  static const int BT_ADAPTER_LE_SCAN_MODE_BALANCED = 0;
+
+  /// < Low connection latency but high power consumption
+  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_LATENCY = 1;
+
+  /// < Low power consumption but high connection latency
+  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_ENERGY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device disconnect reason.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_disconnect_reason_e {
+  /// < Disconnected by unknown reason
+  static const int BT_DEVICE_DISCONNECT_REASON_UNKNOWN = 0;
+
+  /// < Disconnected by timeout
+  static const int BT_DEVICE_DISCONNECT_REASON_TIMEOUT = 1;
+
+  /// < Disconnected by local host
+  static const int BT_DEVICE_DISCONNECT_REASON_LOCAL_HOST = 2;
+
+  /// < Disconnected by remote
+  static const int BT_DEVICE_DISCONNECT_REASON_REMOTE = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of connection link type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_connection_link_type_e {
+  /// < BR/EDR link
+  static const int BT_DEVICE_CONNECTION_LINK_BREDR = 0;
+
+  /// < LE link
+  static const int BT_DEVICE_CONNECTION_LINK_LE = 1;
+
+  /// < The connection type default
+  static const int BT_DEVICE_CONNECTION_LINK_DEFAULT = 255;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device authorization state.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_authorization_e {
+  /// < The remote Bluetooth device is authorized
+  static const int BT_DEVICE_AUTHORIZED = 0;
+
+  /// < The remote Bluetooth device is unauthorized
+  static const int BT_DEVICE_UNAUTHORIZED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of Bluetooth profile.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_profile_e {
+  /// < RFCOMM Profile
+  static const int BT_PROFILE_RFCOMM = 1;
+
+  /// < Advanced Audio Distribution Profile Source role
+  static const int BT_PROFILE_A2DP = 2;
+
+  /// < Headset Profile
+  static const int BT_PROFILE_HSP = 4;
+
+  /// < Human Interface Device Profile
+  static const int BT_PROFILE_HID = 8;
+
+  /// < Network Access Point Profile
+  static const int BT_PROFILE_NAP = 16;
+
+  /// < Audio Gateway Profile
+  static const int BT_PROFILE_AG = 32;
+
+  /// < Generic Attribute Profile
+  static const int BT_PROFILE_GATT = 64;
+
+  /// < NAP server Profile
+  static const int BT_PROFILE_NAP_SERVER = 128;
+
+  /// < Advanced Audio Distribution Profile Sink role
+  static const int BT_PROFILE_A2DP_SINK = 256;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device address type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_address_type_e {
+  /// < Public address
+  static const int BT_DEVICE_PUBLIC_ADDRESS = 0;
+
+  /// < Random address
+  static const int BT_DEVICE_RANDOM_ADDRESS = 1;
 }
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
@@ -9752,88 +10103,36 @@ abstract class bt_service_class_t {
   static const int BT_SC_MAX = 16777216;
 }
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief  Called when you get bonded devices repeatedly.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @param[in] device_info The bonded device information
-/// @param[in] user_data The user data passed from the foreach function
-/// @return @c true to continue with the next iteration of the loop,
-/// \n @c false to break out of the loop.
-/// @pre bt_adapter_foreach_bonded_device() will invoke this function.
-///
-/// @see bt_adapter_foreach_bonded_device()
-typedef bt_adapter_bonded_device_cb
-    = ffi.Pointer<ffi.NativeFunction<bt_adapter_bonded_device_cbFunction>>;
-typedef bt_adapter_bonded_device_cbFunction = ffi.Bool Function(
-    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
-typedef Dartbt_adapter_bonded_device_cbFunction = bool Function(
-    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Device information structure used for identifying pear device.
+/// @brief  Enumerations of major service class.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see #bt_class_s
-/// @see bt_device_bond_created_cb()
-final class bt_device_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
+abstract class bt_major_service_class_e {
+  /// < Limited discoverable mode
+  static const int BT_MAJOR_SERVICE_CLASS_LIMITED_DISCOVERABLE_MODE = 8192;
 
-  /// < The name of remote device
-  external ffi.Pointer<ffi.Char> remote_name;
+  /// < Positioning class
+  static const int BT_MAJOR_SERVICE_CLASS_POSITIONING = 65536;
 
-  /// < The Bluetooth classes
-  external bt_class_s bt_class;
+  /// < Networking class
+  static const int BT_MAJOR_SERVICE_CLASS_NETWORKING = 131072;
 
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+  /// < Rendering class
+  static const int BT_MAJOR_SERVICE_CLASS_RENDERING = 262144;
 
-  /// < The number of services
-  @ffi.Int()
-  external int service_count;
+  /// < Capturing class
+  static const int BT_MAJOR_SERVICE_CLASS_CAPTURING = 524288;
 
-  /// < The bonding state
-  @ffi.Bool()
-  external bool is_bonded;
+  /// < Object transferring class
+  static const int BT_MAJOR_SERVICE_CLASS_OBJECT_TRANSFER = 1048576;
 
-  /// < The connection state
-  @ffi.Bool()
-  external bool is_connected;
+  /// < Audio class
+  static const int BT_MAJOR_SERVICE_CLASS_AUDIO = 2097152;
 
-  /// < The authorization state
-  @ffi.Bool()
-  external bool is_authorized;
+  /// < Telephony class
+  static const int BT_MAJOR_SERVICE_CLASS_TELEPHONY = 4194304;
 
-  /// < manufacturer specific data length
-  @ffi.Int()
-  external int manufacturer_data_len;
-
-  /// < manufacturer specific data
-  external ffi.Pointer<ffi.Char> manufacturer_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Class structure of device and service.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see #bt_device_info_s
-/// @see #bt_adapter_device_discovery_info_s
-/// @see bt_device_bond_created_cb()
-/// @see bt_adapter_device_discovery_state_changed_cb()
-final class bt_class_s extends ffi.Struct {
-  /// < Major device class.
-  @ffi.Int32()
-  external int major_device_class;
-
-  /// < Minor device class.
-  @ffi.Int32()
-  external int minor_device_class;
-
-  /// < Major service class mask.
-  /// This value can be a combination of #bt_major_service_class_e like #BT_MAJOR_SERVICE_CLASS_RENDERING | #BT_MAJOR_SERVICE_CLASS_AUDIO
-  @ffi.Int()
-  external int major_service_class_mask;
+  /// < Information class
+  static const int BT_MAJOR_SERVICE_CLASS_INFORMATION = 8388608;
 }
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
@@ -10134,6 +10433,972 @@ abstract class bt_minor_device_class_e {
   static const int BT_MINOR_DEVICE_CLASS_HEALTH_ANKLE_PROSTHESIS = 52;
 }
 
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief  Enumerations of gap appearance type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_appearance_type_e {
+  /// < Unknown appearance type
+  static const int BT_APPEARANCE_TYPE_UNKNOWN = 0;
+
+  /// < Generic Phone type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_PHONE = 64;
+
+  /// < Generic Computer type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_COMPUTER = 128;
+
+  /// < Generic Watch type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_WATCH = 192;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief  Enumerations of the Bluetooth device's LE connection mode.
+/// @since_tizen 3.0
+abstract class bt_device_le_connection_mode_e {
+  /// < Balanced mode of power consumption and connection latency
+  static const int BT_DEVICE_LE_CONNECTION_MODE_BALANCED = 0;
+
+  /// < Low connection latency but high power consumption
+  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_LATENCY = 1;
+
+  /// < Low power consumption but high connection latency
+  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_ENERGY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief  Enumerations of connected Bluetooth device event role.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_socket_role_e {
+  /// < Unknown role
+  static const int BT_SOCKET_UNKNOWN = 0;
+
+  /// < Server role
+  static const int BT_SOCKET_SERVER = 1;
+
+  /// < Client role
+  static const int BT_SOCKET_CLIENT = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief  Enumerations of Bluetooth socket connection state.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_socket_connection_state_e {
+  /// < RFCOMM is connected
+  static const int BT_SOCKET_CONNECTED = 0;
+
+  /// < RFCOMM is disconnected
+  static const int BT_SOCKET_DISCONNECTED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
+/// @brief  Enumerations for the types of profiles related with audio.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_audio_profile_type_e {
+  /// < All supported profiles related with audio (Both Host and Device role)
+  static const int BT_AUDIO_PROFILE_TYPE_ALL = 0;
+
+  /// < local device AG and remote device HF Client (Host role, ex: mobile)
+  static const int BT_AUDIO_PROFILE_TYPE_HSP_HFP = 1;
+
+  /// < A2DP Source Connection, remote device is A2DP Sink (Host role, ex: mobile)
+  static const int BT_AUDIO_PROFILE_TYPE_A2DP = 2;
+
+  /// < local device HF Client and remote device AG (Device role, ex: headset)
+  static const int BT_AUDIO_PROFILE_TYPE_AG = 3;
+
+  /// < A2DP Sink Connection, remote device is A2DP Source (Device role, ex: headset)
+  static const int BT_AUDIO_PROFILE_TYPE_A2DP_SINK = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_AG_MODULE
+/// @brief  Enumerations for the call handling event.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_ag_call_handling_event_e {
+  /// < Request to answer an incoming call
+  static const int BT_AG_CALL_HANDLING_EVENT_ANSWER = 0;
+
+  /// < Request to release a call
+  static const int BT_AG_CALL_HANDLING_EVENT_RELEASE = 1;
+
+  /// < Request to reject an incoming call
+  static const int BT_AG_CALL_HANDLING_EVENT_REJECT = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_AG_MODULE
+/// @brief  Enumerations for the multi call handling event.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_ag_multi_call_handling_event_e {
+  /// < Request to release held calls
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_RELEASE_HELD_CALLS = 0;
+
+  /// < Request to release active calls
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_RELEASE_ACTIVE_CALLS = 1;
+
+  /// < Request to put active calls into hold state and activate another (held or waiting) call
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_ACTIVATE_HELD_CALL = 2;
+
+  /// < Request to add a held call to the conversation
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_MERGE_CALLS = 3;
+
+  /// < Request to let a user who has two calls to connect these two calls together and release its connections to both other parties
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_EXPLICIT_CALL_TRANSFER = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the equalizer state.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_equalizer_state_e {
+  /// < Equalizer Off
+  static const int BT_AVRCP_EQUALIZER_STATE_OFF = 1;
+
+  /// < Equalizer On
+  static const int BT_AVRCP_EQUALIZER_STATE_ON = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the repeat mode.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_repeat_mode_e {
+  /// < Repeat Off
+  static const int BT_AVRCP_REPEAT_MODE_OFF = 1;
+
+  /// < Single track repeat
+  static const int BT_AVRCP_REPEAT_MODE_SINGLE_TRACK = 2;
+
+  /// < All track repeat
+  static const int BT_AVRCP_REPEAT_MODE_ALL_TRACK = 3;
+
+  /// < Group repeat
+  static const int BT_AVRCP_REPEAT_MODE_GROUP = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the shuffle mode.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_shuffle_mode_e {
+  /// < Shuffle Off
+  static const int BT_AVRCP_SHUFFLE_MODE_OFF = 1;
+
+  /// < All tracks shuffle
+  static const int BT_AVRCP_SHUFFLE_MODE_ALL_TRACK = 2;
+
+  /// < Group shuffle
+  static const int BT_AVRCP_SHUFFLE_MODE_GROUP = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the scan mode.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_scan_mode_e {
+  /// < Scan Off
+  static const int BT_AVRCP_SCAN_MODE_OFF = 1;
+
+  /// < All tracks scan
+  static const int BT_AVRCP_SCAN_MODE_ALL_TRACK = 2;
+
+  /// < Group scan
+  static const int BT_AVRCP_SCAN_MODE_GROUP = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the player state.
+/// @since_tizen 3.0
+abstract class bt_avrcp_player_state_e {
+  /// < Stopped
+  static const int BT_AVRCP_PLAYER_STATE_STOPPED = 0;
+
+  /// < Playing
+  static const int BT_AVRCP_PLAYER_STATE_PLAYING = 1;
+
+  /// < Paused
+  static const int BT_AVRCP_PLAYER_STATE_PAUSED = 2;
+
+  /// < Seek Forward
+  static const int BT_AVRCP_PLAYER_STATE_FORWARD_SEEK = 3;
+
+  /// < Seek Rewind
+  static const int BT_AVRCP_PLAYER_STATE_REWIND_SEEK = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumeration for the player control commands.
+/// @since_tizen 3.0
+abstract class bt_avrcp_player_command_e {
+  /// < Play
+  static const int BT_AVRCP_CONTROL_PLAY = 1;
+
+  /// < Pause
+  static const int BT_AVRCP_CONTROL_PAUSE = 2;
+
+  /// < Stop
+  static const int BT_AVRCP_CONTROL_STOP = 3;
+
+  /// < Next Track
+  static const int BT_AVRCP_CONTROL_NEXT = 4;
+
+  /// < Previous track
+  static const int BT_AVRCP_CONTROL_PREVIOUS = 5;
+
+  /// < Fast Forward
+  static const int BT_AVRCP_CONTROL_FAST_FORWARD = 6;
+
+  /// < Rewind
+  static const int BT_AVRCP_CONTROL_REWIND = 7;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief Structure of Track metadata information.
+/// @since_tizen 3.0
+///
+/// @see #bt_class_s
+final class bt_avrcp_metadata_attributes_info_s extends ffi.Struct {
+  /// < Title
+  external ffi.Pointer<ffi.Char> title;
+
+  /// < Artist
+  external ffi.Pointer<ffi.Char> artist;
+
+  /// < Album name
+  external ffi.Pointer<ffi.Char> album;
+
+  /// < Album Genre
+  external ffi.Pointer<ffi.Char> genre;
+
+  /// < The total number of tracks
+  @ffi.UnsignedInt()
+  external int total_tracks;
+
+  /// < Track number
+  @ffi.UnsignedInt()
+  external int number;
+
+  /// < Duration
+  @ffi.UnsignedInt()
+  external int duration;
+}
+
+/// @deprecated Deprecated since 5.0.
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
+/// @brief  Enumerations for the data channel type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+/// @remarks Deprecated, because of no usecase and supported devices.
+abstract class bt_hdp_channel_type_e {
+  /// < Reliable Data Channel
+  static const int BT_HDP_CHANNEL_TYPE_RELIABLE = 1;
+
+  /// < Streaming Data Channel
+  static const int BT_HDP_CHANNEL_TYPE_STREAMING = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the integer type for GATT handle's value.
+/// @since_tizen 2.3.1
+abstract class bt_data_type_int_e {
+  /// < 8 bit signed int type
+  static const int BT_DATA_TYPE_SINT8 = 0;
+
+  /// < 16 bit signed int type
+  static const int BT_DATA_TYPE_SINT16 = 1;
+
+  /// < 32 bit signed int type
+  static const int BT_DATA_TYPE_SINT32 = 2;
+
+  /// < 8 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT8 = 3;
+
+  /// < 16 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT16 = 4;
+
+  /// < 32 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT32 = 5;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the float type for GATT handle's value.
+/// @since_tizen 2.3.1
+abstract class bt_data_type_float_e {
+  /// < 32 bit float type
+  static const int BT_DATA_TYPE_FLOAT = 0;
+
+  /// < 16 bit float type
+  static const int BT_DATA_TYPE_SFLOAT = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the write type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_write_type_e {
+  /// < Write without response type
+  static const int BT_GATT_WRITE_TYPE_WRITE_NO_RESPONSE = 0;
+
+  /// < Write type
+  static const int BT_GATT_WRITE_TYPE_WRITE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the GATT handle's type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_type_e {
+  /// < GATT service type
+  static const int BT_GATT_TYPE_SERVICE = 1;
+
+  /// < GATT characteristic type
+  static const int BT_GATT_TYPE_CHARACTERISTIC = 2;
+
+  /// < GATT descriptor type
+  static const int BT_GATT_TYPE_DESCRIPTOR = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the service type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_service_type_e {
+  /// < GATT primary service type
+  static const int BT_GATT_SERVICE_TYPE_PRIMARY = 1;
+
+  /// < GATT secondary service type
+  static const int BT_GATT_SERVICE_TYPE_SECONDARY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the characteristic's property.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_property_e {
+  /// < Broadcast property
+  static const int BT_GATT_PROPERTY_BROADCAST = 1;
+
+  /// < Read property
+  static const int BT_GATT_PROPERTY_READ = 2;
+
+  /// < Write without response property
+  static const int BT_GATT_PROPERTY_WRITE_WITHOUT_RESPONSE = 4;
+
+  /// < Write property
+  static const int BT_GATT_PROPERTY_WRITE = 8;
+
+  /// < Notify property
+  static const int BT_GATT_PROPERTY_NOTIFY = 16;
+
+  /// < Indicate property
+  static const int BT_GATT_PROPERTY_INDICATE = 32;
+
+  /// < Authenticated signed writes property
+  static const int BT_GATT_PROPERTY_AUTHENTICATED_SIGNED_WRITES = 64;
+
+  /// < Extended properties
+  static const int BT_GATT_PROPERTY_EXTENDED_PROPERTIES = 128;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
+/// @brief  Enumerations of gatt server's service changing mode.
+/// @since_tizen 3.0
+abstract class bt_gatt_client_service_change_type_e {
+  /// < Service added
+  static const int BT_GATT_CLIENT_SERVICE_ADDED = 0;
+
+  /// < Service removed
+  static const int BT_GATT_CLIENT_SERVICE_REMOVED = 1;
+
+  /// < Resync is required (Since 6.5)
+  static const int BT_GATT_CLIENT_SERVICE_RESYNC = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the attribute's permission.
+/// @since_tizen 3.0
+abstract class bt_gatt_permission_e {
+  /// < Readable permission
+  static const int BT_GATT_PERMISSION_READ = 1;
+
+  /// < Writable permission
+  static const int BT_GATT_PERMISSION_WRITE = 2;
+
+  /// < Readable permission required encryption
+  static const int BT_GATT_PERMISSION_ENCRYPT_READ = 4;
+
+  /// < Writable permission required encryption
+  static const int BT_GATT_PERMISSION_ENCRYPT_WRITE = 8;
+
+  /// < Readable permission required encryption and authentication
+  static const int BT_GATT_PERMISSION_ENCRYPT_AUTHENTICATED_READ = 16;
+
+  /// < Writable permission required encryption and authentication
+  static const int BT_GATT_PERMISSION_ENCRYPT_AUTHENTICATED_WRITE = 32;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
+/// @brief  Enumerations of the remote device request types for attributes.
+/// @since_tizen 3.0
+abstract class bt_gatt_att_request_type_e {
+  /// < Read Requested
+  static const int BT_GATT_REQUEST_TYPE_READ = 0;
+
+  /// < Write Requested
+  static const int BT_GATT_REQUEST_TYPE_WRITE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PAN_PANU_MODULE
+/// @brief  Enumerations for the types of PAN (Personal Area Networking) service.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_panu_service_type_e {
+  /// < Network Access Point
+  static const int BT_PANU_SERVICE_TYPE_NAP = 0;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of address book location for PBAP.
+/// @since_tizen 3.0
+abstract class bt_pbap_address_book_source_e {
+  /// < Request for Addressbook from remote device
+  static const int BT_PBAP_SOURCE_DEVICE = 0;
+
+  /// < Request for address book from SIM
+  static const int BT_PBAP_SOURCE_SIM = 1;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of folder type.
+/// @since_tizen 3.0
+abstract class bt_pbap_folder_type_e {
+  /// < Request for address book
+  static const int BT_PBAP_FOLDER_PHONE_BOOK = 0;
+
+  /// < Request for incoming calls
+  static const int BT_PBAP_FOLDER_INCOMING = 1;
+
+  /// < Request for outgoing calls
+  static const int BT_PBAP_FOLDER_OUTGOING = 2;
+
+  /// < Request for missed calls
+  static const int BT_PBAP_FOLDER_MISSED = 3;
+
+  /// < Request for combined calls
+  static const int BT_PBAP_FOLDER_COMBINED = 4;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of phone book search fields.
+/// @since_tizen 3.0
+abstract class bt_pbap_search_field_e {
+  /// < Request for search by name (default)
+  static const int BT_PBAP_SEARCH_NAME = 0;
+
+  /// < Request for search by phone number
+  static const int BT_PBAP_SEARCH_NUMBER = 1;
+
+  /// < Request for search by sound
+  static const int BT_PBAP_SEARCH_SOUND = 2;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of vCard Formats.
+/// @since_tizen 3.0
+abstract class bt_pbap_vcard_format_e {
+  /// < vCard format 2.1 (default)
+  static const int BT_PBAP_VCARD_FORMAT_VCARD21 = 0;
+
+  /// < vCard format 3.0
+  static const int BT_PBAP_VCARD_FORMAT_VCARD30 = 1;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of sorting orders.
+/// @since_tizen 3.0
+abstract class bt_pbap_sort_order_e {
+  /// < Filter order indexed (default)
+  static const int BT_PBAP_ORDER_INDEXED = 0;
+
+  /// < Filter order alphanumeric
+  static const int BT_PBAP_ORDER_ALPHANUMERIC = 1;
+
+  /// < Filter order phonetic
+  static const int BT_PBAP_ORDER_PHONETIC = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Class structure of device and service.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see #bt_device_info_s
+/// @see #bt_adapter_device_discovery_info_s
+/// @see bt_device_bond_created_cb()
+/// @see bt_adapter_device_discovery_state_changed_cb()
+final class bt_class_s extends ffi.Struct {
+  /// < Major device class.
+  @ffi.Int32()
+  external int major_device_class;
+
+  /// < Minor device class.
+  @ffi.Int32()
+  external int minor_device_class;
+
+  /// < Major service class mask.
+  /// This value can be a combination of #bt_major_service_class_e like #BT_MAJOR_SERVICE_CLASS_RENDERING | #BT_MAJOR_SERVICE_CLASS_AUDIO
+  @ffi.Int()
+  external int major_service_class_mask;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief Structure of device discovery information.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see #bt_class_s
+/// @see bt_adapter_device_discovery_state_changed_cb()
+final class bt_adapter_device_discovery_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The name of remote device
+  external ffi.Pointer<ffi.Char> remote_name;
+
+  /// < The Bluetooth classes
+  external bt_class_s bt_class;
+
+  /// < The strength indicator of received signal
+  @ffi.Int()
+  external int rssi;
+
+  /// < The bonding state
+  @ffi.Bool()
+  external bool is_bonded;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services
+  @ffi.Int()
+  external int service_count;
+
+  /// < The Bluetooth appearance
+  @ffi.Int32()
+  external int appearance;
+
+  /// < manufacturer specific data length
+  @ffi.Int()
+  external int manufacturer_data_len;
+
+  /// < manufacturer specific data
+  external ffi.Pointer<ffi.Char> manufacturer_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief Structure of le scan result information.
+/// @since_tizen 2.3.1
+///
+/// @see bt_adapter_le_start_scan()
+final class bt_adapter_le_device_scan_result_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The address type of remote device
+  @ffi.Int32()
+  external int address_type;
+
+  /// < The strength indicator of received signal
+  @ffi.Int()
+  external int rssi;
+
+  /// < advertising indication data length
+  @ffi.Int()
+  external int adv_data_len;
+
+  /// < advertising indication data
+  external ffi.Pointer<ffi.Char> adv_data;
+
+  /// < scan response data length
+  @ffi.Int()
+  external int scan_data_len;
+
+  /// < scan response data
+  external ffi.Pointer<ffi.Char> scan_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief The structure for LE iBeacon scan result information.
+/// @since_tizen 4.0
+///
+/// @see bt_adapter_le_start_scan()
+final class bt_adapter_le_ibeacon_scan_result_info_s extends ffi.Struct {
+  /// < Company ID
+  @ffi.Int()
+  external int company_id;
+
+  /// < iBeacon type
+  @ffi.Int()
+  external int ibeacon_type;
+
+  /// < UUID
+  external ffi.Pointer<ffi.Char> uuid;
+
+  /// < Major ID
+  @ffi.Int()
+  external int major_id;
+
+  /// < Minor ID
+  @ffi.Int()
+  external int minor_id;
+
+  /// < Measured power
+  @ffi.Int()
+  external int measured_power;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief LE service data structure.
+/// @since_tizen 2.3.1
+///
+/// @see bt_adapter_le_get_scan_result_service_data()
+final class bt_adapter_le_service_data_s extends ffi.Struct {
+  /// < 16 bit UUID of the service data
+  external ffi.Pointer<ffi.Char> service_uuid;
+
+  /// < Service data
+  external ffi.Pointer<ffi.Char> service_data;
+
+  /// < Service data length
+  @ffi.Int()
+  external int service_data_len;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Device information structure used for identifying pear device.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see #bt_class_s
+/// @see bt_device_bond_created_cb()
+final class bt_device_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The name of remote device
+  external ffi.Pointer<ffi.Char> remote_name;
+
+  /// < The Bluetooth classes
+  external bt_class_s bt_class;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services
+  @ffi.Int()
+  external int service_count;
+
+  /// < The bonding state
+  @ffi.Bool()
+  external bool is_bonded;
+
+  /// < The connection state
+  @ffi.Bool()
+  external bool is_connected;
+
+  /// < The authorization state
+  @ffi.Bool()
+  external bool is_authorized;
+
+  /// < manufacturer specific data length
+  @ffi.Int()
+  external int manufacturer_data_len;
+
+  /// < manufacturer specific data
+  external ffi.Pointer<ffi.Char> manufacturer_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Service Discovery Protocol (SDP) data structure.
+///
+/// @details This protocol is used for discovering available services or pear device,
+/// and finding one to connect with.
+///
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+/// @see bt_device_service_searched_cb()
+final class bt_device_sdp_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services.
+  @ffi.Int()
+  external int service_count;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Device connection information structure.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see bt_device_connection_state_changed_cb()
+final class bt_device_connection_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < Link type
+  @ffi.Int32()
+  external int link;
+
+  /// < Disconnection reason
+  @ffi.Int32()
+  external int disconn_reason;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief Rfcomm connection data used for exchanging data between Bluetooth devices.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see bt_socket_connection_state_changed_cb()
+final class bt_socket_connection_s extends ffi.Struct {
+  /// < The file descriptor of connected socket
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The file descriptor of the server socket or -1 for client connection
+  @ffi.Int()
+  external int server_fd;
+
+  /// < The local device role in this connection
+  @ffi.Int32()
+  external int local_role;
+
+  /// < The remote device address
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The service UUId
+  external ffi.Pointer<ffi.Char> service_uuid;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief Structure of RFCOMM received data.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @remarks User can use standard linux functions for reading/writing \n
+/// data from/to sockets.
+///
+/// @see bt_socket_data_received_cb()
+final class bt_socket_received_data_s extends ffi.Struct {
+  /// < The socket fd
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The length of the received data
+  @ffi.Int()
+  external int data_size;
+
+  /// < The received data
+  external ffi.Pointer<ffi.Char> data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
+/// @brief Attribute protocol MTU change information structure.
+/// @since_tizen 4.0
+///
+/// @see bt_gatt_client_att_mtu_changed_cb()
+final class bt_gatt_client_att_mtu_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < MTU value
+  @ffi.UnsignedInt()
+  external int mtu;
+
+  /// < Request status
+  @ffi.UnsignedInt()
+  external int status;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID mouse's button.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_mouse_button_e {
+  /// <The mouse's none value
+  static const int BT_HID_MOUSE_BUTTON_NONE = 0;
+
+  /// <The mouse's left button value
+  static const int BT_HID_MOUSE_BUTTON_LEFT = 1;
+
+  /// <The mouse's right button value
+  static const int BT_HID_MOUSE_BUTTON_RIGHT = 2;
+
+  /// <The mouse's middle button value
+  static const int BT_HID_MOUSE_BUTTON_MIDDLE = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing the HID mouse event information.
+/// @since_tizen @if WEARABLE 3.0 @endif
+///
+/// @see bt_hid_device_send_mouse_event()
+final class bt_hid_mouse_data_s extends ffi.Struct {
+  /// < The button values, we can combine key's values when we pressed multiple mouse buttons
+  @ffi.Int()
+  external int buttons;
+
+  /// < The location's x value, -128 ~127
+  @ffi.Int()
+  external int axis_x;
+
+  /// < The location's y value, -128 ~127
+  @ffi.Int()
+  external int axis_y;
+
+  /// < The padding value, -128 ~127
+  @ffi.Int()
+  external int padding;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing the HID keyboard event information.
+/// @details If you want to know more detail values, refer to http://www.usb.org/developers/hidpage/ and see "HID Usage Tables"
+/// @since_tizen @if WEARABLE 3.0 @endif
+///
+/// @see bt_hid_device_send_key_event()
+final class bt_hid_key_data_s extends ffi.Struct {
+  /// < The modifier keys : such as shift, alt
+  @ffi.UnsignedChar()
+  external int modifier;
+
+  /// < The key value - currently pressed keys : Max 8 at once
+  @ffi.Array.multi([8])
+  external ffi.Array<ffi.UnsignedChar> key;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID header type.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_header_type_e {
+  /// < The Bluetooth HID header type: Handshake
+  static const int BT_HID_HEADER_HANDSHAKE = 0;
+
+  /// < The Bluetooth HID header type: HID control
+  static const int BT_HID_HEADER_HID_CONTROL = 1;
+
+  /// < The Bluetooth HID header type: Get report
+  static const int BT_HID_HEADER_GET_REPORT = 2;
+
+  /// < The Bluetooth HID header type: Set report
+  static const int BT_HID_HEADER_SET_REPORT = 3;
+
+  /// < The Bluetooth HID header type: Get protocol
+  static const int BT_HID_HEADER_GET_PROTOCOL = 4;
+
+  /// < The Bluetooth HID header type: Set protocol
+  static const int BT_HID_HEADER_SET_PROTOCOL = 5;
+
+  /// < The Bluetooth HID header type: Data
+  static const int BT_HID_HEADER_DATA = 6;
+
+  /// < The Bluetooth HID header type: Unknown
+  static const int BT_HID_HEADER_UNKNOWN = 7;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID parameter type.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_param_type_e {
+  /// < Parameter type: Input
+  static const int BT_HID_PARAM_DATA_RTYPE_INPUT = 0;
+
+  /// < Parameter type: Output
+  static const int BT_HID_PARAM_DATA_RTYPE_OUTPUT = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID handshake type.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_handshake_type_e {
+  /// < Handshake error code none
+  static const int BT_HID_HANDSHAKE_SUCCESSFUL = 0;
+
+  /// < Handshake error code Not Ready
+  static const int BT_HID_HANDSHAKE_NOT_READY = 1;
+
+  /// < Handshake error code send invalid report id
+  static const int BT_HID_HANDSHAKE_ERR_INVALID_REPORT_ID = 2;
+
+  /// < Handshake error code request unsupported request
+  static const int BT_HID_HANDSHAKE_ERR_UNSUPPORTED_REQUEST = 3;
+
+  /// < Handshake error code received invalid parameter
+  static const int BT_HID_HANDSHAKE_ERR_INVALID_PARAMETER = 4;
+
+  /// < unknown error
+  static const int BT_HID_HANDSHAKE_ERR_UNKNOWN = 14;
+
+  /// < Fatal error
+  static const int BT_HID_HANDSHAKE_ERR_FATAL = 15;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing data received from the HID Host.
+/// @since_tizen @if WEARABLE 3.0 @endif
+final class bt_hid_device_received_data_s extends ffi.Struct {
+  /// < The remote device's address
+  external ffi.Pointer<ffi.Char> address;
+
+  /// < The header type
+  @ffi.Int32()
+  external int header_type;
+
+  /// < The parameter type
+  @ffi.Int32()
+  external int param_type;
+
+  /// < The length of the received data
+  @ffi.Int()
+  external int data_size;
+
+  /// < The received data
+  external ffi.Pointer<ffi.Char> data;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief The structure type containing vCard information.
+/// @since_tizen 3.0
+///
+/// @see bt_pbap_client_pull_vcard()
+final class bt_pbap_vcard_info_s extends ffi.Struct {
+  /// < The vcard index, used as a parameter for bt_pbap_client_pull_vcard()
+  @ffi.Int()
+  external int index;
+
+  /// < The contact name of the vCard
+  external ffi.Pointer<ffi.Char> contact_name;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief Enumeration for the scan filter type.
+/// @since_tizen 4.0
+/// @see bt_adapter_le_scan_filter_set_type()
+abstract class bt_adapter_le_scan_filter_type_e {
+  /// < iBeacon filter type
+  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_IBEACON = 0;
+
+  /// < Proximity UUID filter type
+  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_PROXIMITY_UUID = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief  Called when you get bonded devices repeatedly.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @param[in] device_info The bonded device information
+/// @param[in] user_data The user data passed from the foreach function
+/// @return @c true to continue with the next iteration of the loop,
+/// \n @c false to break out of the loop.
+/// @pre bt_adapter_foreach_bonded_device() will invoke this function.
+///
+/// @see bt_adapter_foreach_bonded_device()
+typedef bt_adapter_bonded_device_cb
+    = ffi.Pointer<ffi.NativeFunction<bt_adapter_bonded_device_cbFunction>>;
+typedef bt_adapter_bonded_device_cbFunction = ffi.Bool Function(
+    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
+typedef Dartbt_adapter_bonded_device_cbFunction = bool Function(
+    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
+
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
 /// @brief  Called when the Bluetooth adapter state changes.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
@@ -10241,80 +11506,6 @@ typedef Dartbt_adapter_device_discovery_state_changed_cbFunction
         ffi.Pointer<bt_adapter_device_discovery_info_s> discovery_info,
         ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief Enumerations of the discovery state of Bluetooth device.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_adapter_device_discovery_state_e {
-  /// < Device discovery is started
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_STARTED = 0;
-
-  /// < Device discovery is finished
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_FINISHED = 1;
-
-  /// < The remote Bluetooth device is found
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_FOUND = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief Structure of device discovery information.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see #bt_class_s
-/// @see bt_adapter_device_discovery_state_changed_cb()
-final class bt_adapter_device_discovery_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The name of remote device
-  external ffi.Pointer<ffi.Char> remote_name;
-
-  /// < The Bluetooth classes
-  external bt_class_s bt_class;
-
-  /// < The strength indicator of received signal
-  @ffi.Int()
-  external int rssi;
-
-  /// < The bonding state
-  @ffi.Bool()
-  external bool is_bonded;
-
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
-
-  /// < The number of services
-  @ffi.Int()
-  external int service_count;
-
-  /// < The Bluetooth appearance
-  @ffi.Int32()
-  external int appearance;
-
-  /// < manufacturer specific data length
-  @ffi.Int()
-  external int manufacturer_data_len;
-
-  /// < manufacturer specific data
-  external ffi.Pointer<ffi.Char> manufacturer_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief  Enumerations of gap appearance type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_appearance_type_e {
-  /// < Unknown appearance type
-  static const int BT_APPEARANCE_TYPE_UNKNOWN = 0;
-
-  /// < Generic Phone type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_PHONE = 64;
-
-  /// < Generic Computer type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_COMPUTER = 128;
-
-  /// < Generic Watch type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_WATCH = 192;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief  Called when the LE advertisement has been found.
 /// @since_tizen 2.3.1
@@ -10334,107 +11525,6 @@ typedef Dartbt_adapter_le_scan_result_cbFunction = void Function(
     int result,
     ffi.Pointer<bt_adapter_le_device_scan_result_info_s> info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief Structure of le scan result information.
-/// @since_tizen 2.3.1
-///
-/// @see bt_adapter_le_start_scan()
-final class bt_adapter_le_device_scan_result_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The address type of remote device
-  @ffi.Int32()
-  external int address_type;
-
-  /// < The strength indicator of received signal
-  @ffi.Int()
-  external int rssi;
-
-  /// < advertising indication data length
-  @ffi.Int()
-  external int adv_data_len;
-
-  /// < advertising indication data
-  external ffi.Pointer<ffi.Char> adv_data;
-
-  /// < scan response data length
-  @ffi.Int()
-  external int scan_data_len;
-
-  /// < scan response data
-  external ffi.Pointer<ffi.Char> scan_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device address type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_address_type_e {
-  /// < Public address
-  static const int BT_DEVICE_PUBLIC_ADDRESS = 0;
-
-  /// < Random address
-  static const int BT_DEVICE_RANDOM_ADDRESS = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth LE packet type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_adapter_le_packet_type_e {
-  /// < Advertising packet
-  static const int BT_ADAPTER_LE_PACKET_ADVERTISING = 0;
-
-  /// < Scan response packet
-  static const int BT_ADAPTER_LE_PACKET_SCAN_RESPONSE = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief LE service data structure.
-/// @since_tizen 2.3.1
-///
-/// @see bt_adapter_le_get_scan_result_service_data()
-final class bt_adapter_le_service_data_s extends ffi.Struct {
-  /// < 16 bit UUID of the service data
-  external ffi.Pointer<ffi.Char> service_uuid;
-
-  /// < Service data
-  external ffi.Pointer<ffi.Char> service_data;
-
-  /// < Service data length
-  @ffi.Int()
-  external int service_data_len;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief The structure for LE iBeacon scan result information.
-/// @since_tizen 4.0
-///
-/// @see bt_adapter_le_start_scan()
-final class bt_adapter_le_ibeacon_scan_result_info_s extends ffi.Struct {
-  /// < Company ID
-  @ffi.Int()
-  external int company_id;
-
-  /// < iBeacon type
-  @ffi.Int()
-  external int ibeacon_type;
-
-  /// < UUID
-  external ffi.Pointer<ffi.Char> uuid;
-
-  /// < Major ID
-  @ffi.Int()
-  external int major_id;
-
-  /// < Minor ID
-  @ffi.Int()
-  external int minor_id;
-
-  /// < Measured power
-  @ffi.Int()
-  external int measured_power;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief The handle to control Bluetooth LE advertising.
@@ -10505,59 +11595,6 @@ typedef Dartbt_adapter_le_advertising_state_changed_cbFunction = void Function(
     int adv_state,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth advertising state.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_adapter_le_advertising_state_e {
-  /// < Bluetooth advertising is stopped
-  static const int BT_ADAPTER_LE_ADVERTISING_STOPPED = 0;
-
-  /// < Bluetooth advertising is started
-  static const int BT_ADAPTER_LE_ADVERTISING_STARTED = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth advertising mode.
-/// @since_tizen 2.3.1
-abstract class bt_adapter_le_advertising_mode_e {
-  /// < Balanced advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_BALANCED = 0;
-
-  /// < Low latency advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_LATENCY = 1;
-
-  /// < Low energy advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_ENERGY = 2;
-
-  /// < Custom mode to set advertising parameters
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_CUSTOM = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth le scan mode.
-/// @since_tizen 3.0
-abstract class bt_adapter_le_scan_mode_e {
-  /// < Balanced mode of power consumption and connection latency
-  static const int BT_ADAPTER_LE_SCAN_MODE_BALANCED = 0;
-
-  /// < Low connection latency but high power consumption
-  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_LATENCY = 1;
-
-  /// < Low power consumption but high connection latency
-  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_ENERGY = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device authorization state.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_authorization_e {
-  /// < The remote Bluetooth device is authorized
-  static const int BT_DEVICE_AUTHORIZED = 0;
-
-  /// < The remote Bluetooth device is unauthorized
-  static const int BT_DEVICE_UNAUTHORIZED = 1;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief  Called when you get connected profiles repeatedly.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
@@ -10574,52 +11611,6 @@ typedef bt_device_connected_profileFunction = ffi.Bool Function(
     ffi.Int32 profile, ffi.Pointer<ffi.Void> user_data);
 typedef Dartbt_device_connected_profileFunction = bool Function(
     int profile, ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of Bluetooth profile.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_profile_e {
-  /// < RFCOMM Profile
-  static const int BT_PROFILE_RFCOMM = 1;
-
-  /// < Advanced Audio Distribution Profile Source role
-  static const int BT_PROFILE_A2DP = 2;
-
-  /// < Headset Profile
-  static const int BT_PROFILE_HSP = 4;
-
-  /// < Human Interface Device Profile
-  static const int BT_PROFILE_HID = 8;
-
-  /// < Network Access Point Profile
-  static const int BT_PROFILE_NAP = 16;
-
-  /// < Audio Gateway Profile
-  static const int BT_PROFILE_AG = 32;
-
-  /// < Generic Attribute Profile
-  static const int BT_PROFILE_GATT = 64;
-
-  /// < NAP server Profile
-  static const int BT_PROFILE_NAP_SERVER = 128;
-
-  /// < Advanced Audio Distribution Profile Sink role
-  static const int BT_PROFILE_A2DP_SINK = 256;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief  Enumerations of the Bluetooth device's LE connection mode.
-/// @since_tizen 3.0
-abstract class bt_device_le_connection_mode_e {
-  /// < Balanced mode of power consumption and connection latency
-  static const int BT_DEVICE_LE_CONNECTION_MODE_BALANCED = 0;
-
-  /// < Low connection latency but high power consumption
-  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_LATENCY = 1;
-
-  /// < Low power consumption but high connection latency
-  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_ENERGY = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief Called when the process of creating bond finishes.
@@ -10717,26 +11708,6 @@ typedef Dartbt_device_service_searched_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Service Discovery Protocol (SDP) data structure.
-///
-/// @details This protocol is used for discovering available services or pear device,
-/// and finding one to connect with.
-///
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-/// @see bt_device_service_searched_cb()
-final class bt_device_sdp_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
-
-  /// < The number of services.
-  @ffi.Int()
-  external int service_count;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief  Called when the connection state is changed.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
 ///
@@ -10755,55 +11726,6 @@ typedef Dartbt_device_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<bt_device_connection_info_s> conn_info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Device connection information structure.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see bt_device_connection_state_changed_cb()
-final class bt_device_connection_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < Link type
-  @ffi.Int32()
-  external int link;
-
-  /// < Disconnection reason
-  @ffi.Int32()
-  external int disconn_reason;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of connection link type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_connection_link_type_e {
-  /// < BR/EDR link
-  static const int BT_DEVICE_CONNECTION_LINK_BREDR = 0;
-
-  /// < LE link
-  static const int BT_DEVICE_CONNECTION_LINK_LE = 1;
-
-  /// < The connection type default
-  static const int BT_DEVICE_CONNECTION_LINK_DEFAULT = 255;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device disconnect reason.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_disconnect_reason_e {
-  /// < Disconnected by unknown reason
-  static const int BT_DEVICE_DISCONNECT_REASON_UNKNOWN = 0;
-
-  /// < Disconnected by timeout
-  static const int BT_DEVICE_DISCONNECT_REASON_TIMEOUT = 1;
-
-  /// < Disconnected by local host
-  static const int BT_DEVICE_DISCONNECT_REASON_LOCAL_HOST = 2;
-
-  /// < Disconnected by remote
-  static const int BT_DEVICE_DISCONNECT_REASON_REMOTE = 3;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief Called when you receive data.
@@ -10826,27 +11748,6 @@ typedef bt_socket_data_received_cbFunction = ffi.Void Function(
 typedef Dartbt_socket_data_received_cbFunction = void Function(
     ffi.Pointer<bt_socket_received_data_s> data,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief Structure of RFCOMM received data.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @remarks User can use standard linux functions for reading/writing \n
-/// data from/to sockets.
-///
-/// @see bt_socket_data_received_cb()
-final class bt_socket_received_data_s extends ffi.Struct {
-  /// < The socket fd
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The length of the received data
-  @ffi.Int()
-  external int data_size;
-
-  /// < The received data
-  external ffi.Pointer<ffi.Char> data;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief  Called when a RFCOMM connection is requested.
@@ -10894,56 +11795,6 @@ typedef Dartbt_socket_connection_state_changed_cbFunction = void Function(
     int connection_state,
     ffi.Pointer<bt_socket_connection_s> connection,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief  Enumerations of Bluetooth socket connection state.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_socket_connection_state_e {
-  /// < RFCOMM is connected
-  static const int BT_SOCKET_CONNECTED = 0;
-
-  /// < RFCOMM is disconnected
-  static const int BT_SOCKET_DISCONNECTED = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief Rfcomm connection data used for exchanging data between Bluetooth devices.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see bt_socket_connection_state_changed_cb()
-final class bt_socket_connection_s extends ffi.Struct {
-  /// < The file descriptor of connected socket
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The file descriptor of the server socket or -1 for client connection
-  @ffi.Int()
-  external int server_fd;
-
-  /// < The local device role in this connection
-  @ffi.Int32()
-  external int local_role;
-
-  /// < The remote device address
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The service UUId
-  external ffi.Pointer<ffi.Char> service_uuid;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief  Enumerations of connected Bluetooth device event role.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_socket_role_e {
-  /// < Unknown role
-  static const int BT_SOCKET_UNKNOWN = 0;
-
-  /// < Server role
-  static const int BT_SOCKET_SERVER = 1;
-
-  /// < Client role
-  static const int BT_SOCKET_CLIENT = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_OPP_SERVER_MODULE
 /// @brief  Called when an OPP connection is requested.
@@ -11115,45 +11966,6 @@ typedef Dartbt_hid_device_connection_state_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing the HID mouse event information.
-/// @since_tizen @if WEARABLE 3.0 @endif
-///
-/// @see bt_hid_device_send_mouse_event()
-final class bt_hid_mouse_data_s extends ffi.Struct {
-  /// < The button values, we can combine key's values when we pressed multiple mouse buttons
-  @ffi.Int()
-  external int buttons;
-
-  /// < The location's x value, -128 ~127
-  @ffi.Int()
-  external int axis_x;
-
-  /// < The location's y value, -128 ~127
-  @ffi.Int()
-  external int axis_y;
-
-  /// < The padding value, -128 ~127
-  @ffi.Int()
-  external int padding;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing the HID keyboard event information.
-/// @details If you want to know more detail values, refer to http://www.usb.org/developers/hidpage/ and see "HID Usage Tables"
-/// @since_tizen @if WEARABLE 3.0 @endif
-///
-/// @see bt_hid_device_send_key_event()
-final class bt_hid_key_data_s extends ffi.Struct {
-  /// < The modifier keys : such as shift, alt
-  @ffi.UnsignedChar()
-  external int modifier;
-
-  /// < The key value - currently pressed keys : Max 8 at once
-  @ffi.Array.multi([8])
-  external ffi.Array<ffi.UnsignedChar> key;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
 /// @brief  Called when the HID Device receives data from the HID Host.
 /// @details The following error codes can be delivered: \n
 /// #BT_ERROR_NONE \n
@@ -11171,89 +11983,6 @@ typedef bt_hid_device_data_received_cbFunction = ffi.Void Function(
 typedef Dartbt_hid_device_data_received_cbFunction = void Function(
     ffi.Pointer<bt_hid_device_received_data_s> data,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing data received from the HID Host.
-/// @since_tizen @if WEARABLE 3.0 @endif
-final class bt_hid_device_received_data_s extends ffi.Struct {
-  /// < The remote device's address
-  external ffi.Pointer<ffi.Char> address;
-
-  /// < The header type
-  @ffi.Int32()
-  external int header_type;
-
-  /// < The parameter type
-  @ffi.Int32()
-  external int param_type;
-
-  /// < The length of the received data
-  @ffi.Int()
-  external int data_size;
-
-  /// < The received data
-  external ffi.Pointer<ffi.Char> data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief Enumerations of the Bluetooth HID header type.
-/// @since_tizen @if WEARABLE 3.0 @endif
-abstract class bt_hid_header_type_e {
-  /// < The Bluetooth HID header type: Handshake
-  static const int BT_HID_HEADER_HANDSHAKE = 0;
-
-  /// < The Bluetooth HID header type: HID control
-  static const int BT_HID_HEADER_HID_CONTROL = 1;
-
-  /// < The Bluetooth HID header type: Get report
-  static const int BT_HID_HEADER_GET_REPORT = 2;
-
-  /// < The Bluetooth HID header type: Set report
-  static const int BT_HID_HEADER_SET_REPORT = 3;
-
-  /// < The Bluetooth HID header type: Get protocol
-  static const int BT_HID_HEADER_GET_PROTOCOL = 4;
-
-  /// < The Bluetooth HID header type: Set protocol
-  static const int BT_HID_HEADER_SET_PROTOCOL = 5;
-
-  /// < The Bluetooth HID header type: Data
-  static const int BT_HID_HEADER_DATA = 6;
-
-  /// < The Bluetooth HID header type: Unknown
-  static const int BT_HID_HEADER_UNKNOWN = 7;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief Enumerations of the Bluetooth HID parameter type.
-/// @since_tizen @if WEARABLE 3.0 @endif
-abstract class bt_hid_param_type_e {
-  /// < Parameter type: Input
-  static const int BT_HID_PARAM_DATA_RTYPE_INPUT = 0;
-
-  /// < Parameter type: Output
-  static const int BT_HID_PARAM_DATA_RTYPE_OUTPUT = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
-/// @brief  Enumerations for the types of profiles related with audio.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_audio_profile_type_e {
-  /// < All supported profiles related with audio (Both Host and Device role)
-  static const int BT_AUDIO_PROFILE_TYPE_ALL = 0;
-
-  /// < local device AG and remote device HF Client (Host role, ex: mobile)
-  static const int BT_AUDIO_PROFILE_TYPE_HSP_HFP = 1;
-
-  /// < A2DP Source Connection, remote device is A2DP Sink (Host role, ex: mobile)
-  static const int BT_AUDIO_PROFILE_TYPE_A2DP = 2;
-
-  /// < local device HF Client and remote device AG (Device role, ex: headset)
-  static const int BT_AUDIO_PROFILE_TYPE_AG = 3;
-
-  /// < A2DP Sink Connection, remote device is A2DP Source (Device role, ex: headset)
-  static const int BT_AUDIO_PROFILE_TYPE_A2DP_SINK = 4;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
 /// @brief  Called when the connection state is changed.
@@ -11302,82 +12031,6 @@ typedef Dartbt_avrcp_target_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<ffi.Char> remote_address,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the equalizer state.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_equalizer_state_e {
-  /// < Equalizer Off
-  static const int BT_AVRCP_EQUALIZER_STATE_OFF = 1;
-
-  /// < Equalizer On
-  static const int BT_AVRCP_EQUALIZER_STATE_ON = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the repeat mode.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_repeat_mode_e {
-  /// < Repeat Off
-  static const int BT_AVRCP_REPEAT_MODE_OFF = 1;
-
-  /// < Single track repeat
-  static const int BT_AVRCP_REPEAT_MODE_SINGLE_TRACK = 2;
-
-  /// < All track repeat
-  static const int BT_AVRCP_REPEAT_MODE_ALL_TRACK = 3;
-
-  /// < Group repeat
-  static const int BT_AVRCP_REPEAT_MODE_GROUP = 4;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the shuffle mode.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_shuffle_mode_e {
-  /// < Shuffle Off
-  static const int BT_AVRCP_SHUFFLE_MODE_OFF = 1;
-
-  /// < All tracks shuffle
-  static const int BT_AVRCP_SHUFFLE_MODE_ALL_TRACK = 2;
-
-  /// < Group shuffle
-  static const int BT_AVRCP_SHUFFLE_MODE_GROUP = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the scan mode.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_scan_mode_e {
-  /// < Scan Off
-  static const int BT_AVRCP_SCAN_MODE_OFF = 1;
-
-  /// < All tracks scan
-  static const int BT_AVRCP_SCAN_MODE_ALL_TRACK = 2;
-
-  /// < Group scan
-  static const int BT_AVRCP_SCAN_MODE_GROUP = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the player state.
-/// @since_tizen 3.0
-abstract class bt_avrcp_player_state_e {
-  /// < Stopped
-  static const int BT_AVRCP_PLAYER_STATE_STOPPED = 0;
-
-  /// < Playing
-  static const int BT_AVRCP_PLAYER_STATE_PLAYING = 1;
-
-  /// < Paused
-  static const int BT_AVRCP_PLAYER_STATE_PAUSED = 2;
-
-  /// < Seek Forward
-  static const int BT_AVRCP_PLAYER_STATE_FORWARD_SEEK = 3;
-
-  /// < Seek Rewind
-  static const int BT_AVRCP_PLAYER_STATE_REWIND_SEEK = 4;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
 /// @brief  Called when the equalizer state is changed by the remote control device.
@@ -11484,37 +12137,6 @@ typedef Dartbt_avrcp_track_info_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief Structure of Track metadata information.
-/// @since_tizen 3.0
-///
-/// @see #bt_class_s
-final class bt_avrcp_metadata_attributes_info_s extends ffi.Struct {
-  /// < Title
-  external ffi.Pointer<ffi.Char> title;
-
-  /// < Artist
-  external ffi.Pointer<ffi.Char> artist;
-
-  /// < Album name
-  external ffi.Pointer<ffi.Char> album;
-
-  /// < Album Genre
-  external ffi.Pointer<ffi.Char> genre;
-
-  /// < The total number of tracks
-  @ffi.UnsignedInt()
-  external int total_tracks;
-
-  /// < Track number
-  @ffi.UnsignedInt()
-  external int number;
-
-  /// < Duration
-  @ffi.UnsignedInt()
-  external int duration;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
 /// @brief  Called when the connection state is changed.
 /// @since_tizen 3.0
 /// @param[in] connected  The state to be changed. true means connected state, Otherwise, false.
@@ -11530,32 +12152,6 @@ typedef bt_avrcp_control_connection_state_changed_cbFunction
 typedef Dartbt_avrcp_control_connection_state_changed_cbFunction
     = void Function(bool connected, ffi.Pointer<ffi.Char> remote_address,
         ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumeration for the player control commands.
-/// @since_tizen 3.0
-abstract class bt_avrcp_player_command_e {
-  /// < Play
-  static const int BT_AVRCP_CONTROL_PLAY = 1;
-
-  /// < Pause
-  static const int BT_AVRCP_CONTROL_PAUSE = 2;
-
-  /// < Stop
-  static const int BT_AVRCP_CONTROL_STOP = 3;
-
-  /// < Next Track
-  static const int BT_AVRCP_CONTROL_NEXT = 4;
-
-  /// < Previous track
-  static const int BT_AVRCP_CONTROL_PREVIOUS = 5;
-
-  /// < Fast Forward
-  static const int BT_AVRCP_CONTROL_FAST_FORWARD = 6;
-
-  /// < Rewind
-  static const int BT_AVRCP_CONTROL_REWIND = 7;
-}
 
 /// @deprecated Deprecated since 5.0.
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
@@ -11587,19 +12183,6 @@ typedef Dartbt_hdp_connected_cbFunction = void Function(
     int type,
     int channel,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @deprecated Deprecated since 5.0.
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
-/// @brief  Enumerations for the data channel type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-/// @remarks Deprecated, because of no usecase and supported devices.
-abstract class bt_hdp_channel_type_e {
-  /// < Reliable Data Channel
-  static const int BT_HDP_CHANNEL_TYPE_RELIABLE = 1;
-
-  /// < Streaming Data Channel
-  static const int BT_HDP_CHANNEL_TYPE_STREAMING = 2;
-}
 
 /// @deprecated Deprecated since 5.0.
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
@@ -11653,54 +12236,6 @@ typedef Dartbt_hdp_data_received_cbFunction = void Function(int channel,
 /// @since_tizen 2.3.1
 typedef bt_gatt_h = ffi.Pointer<ffi.Void>;
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the integer type for GATT handle's value.
-/// @since_tizen 2.3.1
-abstract class bt_data_type_int_e {
-  /// < 8 bit signed int type
-  static const int BT_DATA_TYPE_SINT8 = 0;
-
-  /// < 16 bit signed int type
-  static const int BT_DATA_TYPE_SINT16 = 1;
-
-  /// < 32 bit signed int type
-  static const int BT_DATA_TYPE_SINT32 = 2;
-
-  /// < 8 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT8 = 3;
-
-  /// < 16 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT16 = 4;
-
-  /// < 32 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT32 = 5;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the float type for GATT handle's value.
-/// @since_tizen 2.3.1
-abstract class bt_data_type_float_e {
-  /// < 32 bit float type
-  static const int BT_DATA_TYPE_FLOAT = 0;
-
-  /// < 16 bit float type
-  static const int BT_DATA_TYPE_SFLOAT = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the GATT handle's type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_type_e {
-  /// < GATT service type
-  static const int BT_GATT_TYPE_SERVICE = 1;
-
-  /// < GATT characteristic type
-  static const int BT_GATT_TYPE_CHARACTERISTIC = 2;
-
-  /// < GATT descriptor type
-  static const int BT_GATT_TYPE_DESCRIPTOR = 3;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief The handle of a GATT client which is associated with a remote device.
 /// @since_tizen 2.3.1
@@ -11725,17 +12260,6 @@ typedef bt_gatt_foreach_cbFunction = ffi.Bool Function(ffi.Int total,
     ffi.Int index, bt_gatt_h gatt_handle, ffi.Pointer<ffi.Void> user_data);
 typedef Dartbt_gatt_foreach_cbFunction = bool Function(int total, int index,
     bt_gatt_h gatt_handle, ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the write type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_write_type_e {
-  /// < Write without response type
-  static const int BT_GATT_WRITE_TYPE_WRITE_NO_RESPONSE = 0;
-
-  /// < Write type
-  static const int BT_GATT_WRITE_TYPE_WRITE = 1;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief  Called when the client request(e.g. read / write) has been completed.
@@ -11776,24 +12300,6 @@ typedef Dartbt_gatt_client_att_mtu_changed_cbFunction = void Function(
     bt_gatt_client_h client,
     ffi.Pointer<bt_gatt_client_att_mtu_info_s> mtu_info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
-/// @brief Attribute protocol MTU change information structure.
-/// @since_tizen 4.0
-///
-/// @see bt_gatt_client_att_mtu_changed_cb()
-final class bt_gatt_client_att_mtu_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < MTU value
-  @ffi.UnsignedInt()
-  external int mtu;
-
-  /// < Request status
-  @ffi.UnsignedInt()
-  external int status;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief  Called when a value of a watched characteristic's GATT handle has been changed.
@@ -11840,20 +12346,6 @@ typedef Dartbt_gatt_client_service_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Char> service_uuid,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
-/// @brief  Enumerations of gatt server's service changing mode.
-/// @since_tizen 3.0
-abstract class bt_gatt_client_service_change_type_e {
-  /// < Service added
-  static const int BT_GATT_CLIENT_SERVICE_ADDED = 0;
-
-  /// < Service removed
-  static const int BT_GATT_CLIENT_SERVICE_REMOVED = 1;
-
-  /// < Resync is required (Since 6.5)
-  static const int BT_GATT_CLIENT_SERVICE_RESYNC = 2;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
 /// @brief Called when the connection state is changed.
 ///
@@ -11882,17 +12374,6 @@ typedef Dartbt_gatt_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<ffi.Char> remote_address,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the service type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_service_type_e {
-  /// < GATT primary service type
-  static const int BT_GATT_SERVICE_TYPE_PRIMARY = 1;
-
-  /// < GATT secondary service type
-  static const int BT_GATT_SERVICE_TYPE_SECONDARY = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
 /// @brief The handle of a GATT server.
@@ -12009,17 +12490,6 @@ typedef Dartbt_gatt_server_write_value_requested_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
-/// @brief  Enumerations of the remote device request types for attributes.
-/// @since_tizen 3.0
-abstract class bt_gatt_att_request_type_e {
-  /// < Read Requested
-  static const int BT_GATT_REQUEST_TYPE_READ = 0;
-
-  /// < Write Requested
-  static const int BT_GATT_REQUEST_TYPE_WRITE = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
 /// @brief  Called when the sending notification / indication is done.
 /// @since_tizen 3.0
 ///
@@ -12089,39 +12559,6 @@ typedef Dartbt_pbap_connection_state_changed_cbFunction = void Function(
 
 /// @WEARABLE_ONLY
 /// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of address book location for PBAP.
-/// @since_tizen 3.0
-abstract class bt_pbap_address_book_source_e {
-  /// < Request for Addressbook from remote device
-  static const int BT_PBAP_SOURCE_DEVICE = 0;
-
-  /// < Request for address book from SIM
-  static const int BT_PBAP_SOURCE_SIM = 1;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of folder type.
-/// @since_tizen 3.0
-abstract class bt_pbap_folder_type_e {
-  /// < Request for address book
-  static const int BT_PBAP_FOLDER_PHONE_BOOK = 0;
-
-  /// < Request for incoming calls
-  static const int BT_PBAP_FOLDER_INCOMING = 1;
-
-  /// < Request for outgoing calls
-  static const int BT_PBAP_FOLDER_OUTGOING = 2;
-
-  /// < Request for missed calls
-  static const int BT_PBAP_FOLDER_MISSED = 3;
-
-  /// < Request for combined calls
-  static const int BT_PBAP_FOLDER_COMBINED = 4;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
 /// @brief  Called when PBAP Phonebook size calculation completes.
 /// @details The following error codes can be delivered: \n
 /// #BT_ERROR_NONE \n
@@ -12147,33 +12584,6 @@ typedef Dartbt_pbap_phone_book_size_cbFunction = void Function(
     ffi.Pointer<ffi.Char> remote_address,
     int size,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of vCard Formats.
-/// @since_tizen 3.0
-abstract class bt_pbap_vcard_format_e {
-  /// < vCard format 2.1 (default)
-  static const int BT_PBAP_VCARD_FORMAT_VCARD21 = 0;
-
-  /// < vCard format 3.0
-  static const int BT_PBAP_VCARD_FORMAT_VCARD30 = 1;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of sorting orders.
-/// @since_tizen 3.0
-abstract class bt_pbap_sort_order_e {
-  /// < Filter order indexed (default)
-  static const int BT_PBAP_ORDER_INDEXED = 0;
-
-  /// < Filter order alphanumeric
-  static const int BT_PBAP_ORDER_ALPHANUMERIC = 1;
-
-  /// < Filter order phonetic
-  static const int BT_PBAP_ORDER_PHONETIC = 2;
-}
 
 /// @WEARABLE_ONLY
 /// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
@@ -12235,49 +12645,7 @@ typedef Dartbt_pbap_list_vcards_cbFunction = void Function(
     int count,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief The structure type containing vCard information.
-/// @since_tizen 3.0
-///
-/// @see bt_pbap_client_pull_vcard()
-final class bt_pbap_vcard_info_s extends ffi.Struct {
-  /// < The vcard index, used as a parameter for bt_pbap_client_pull_vcard()
-  @ffi.Int()
-  external int index;
-
-  /// < The contact name of the vCard
-  external ffi.Pointer<ffi.Char> contact_name;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of phone book search fields.
-/// @since_tizen 3.0
-abstract class bt_pbap_search_field_e {
-  /// < Request for search by name (default)
-  static const int BT_PBAP_SEARCH_NAME = 0;
-
-  /// < Request for search by phone number
-  static const int BT_PBAP_SEARCH_NUMBER = 1;
-
-  /// < Request for search by sound
-  static const int BT_PBAP_SEARCH_SOUND = 2;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief The handle of a Bluetooth LE scan filter.
 /// @since_tizen 4.0
 typedef bt_scan_filter_h = ffi.Pointer<ffi.Void>;
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief Enumeration for the scan filter type.
-/// @since_tizen 4.0
-/// @see bt_adapter_le_scan_filter_set_type()
-abstract class bt_adapter_le_scan_filter_type_e {
-  /// < iBeacon filter type
-  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_IBEACON = 0;
-
-  /// < Proximity UUID filter type
-  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_PROXIMITY_UUID = 1;
-}

--- a/lib/src/bindings/6.5/generated_bindings_capi_system_info.dart
+++ b/lib/src/bindings/6.5/generated_bindings_capi_system_info.dart
@@ -369,6 +369,38 @@ class Tizen65CapiSystemInfo {
           int Function(ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Int32>)>();
 }
 
+/// @brief Enumeration for system information error codes.
+abstract class system_info_error_e {
+  /// < Successful
+  static const int SYSTEM_INFO_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int SYSTEM_INFO_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int SYSTEM_INFO_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < An input/output error occurred when reading value from system
+  static const int SYSTEM_INFO_ERROR_IO_ERROR = -5;
+
+  /// < No permission to use the API
+  static const int SYSTEM_INFO_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Not supported parameter (Since 3.0)
+  static const int SYSTEM_INFO_ERROR_NOT_SUPPORTED = -1073741822;
+}
+
+/// @internal
+/// @brief It is not decided if it should be opened to public.
+abstract class system_info_type_e {
+  static const int SYSTEM_INFO_TYPE_MIN = 0;
+  static const int SYSTEM_INFO_BOOL = 0;
+  static const int SYSTEM_INFO_INT = 1;
+  static const int SYSTEM_INFO_DOUBLE = 2;
+  static const int SYSTEM_INFO_STRING = 3;
+  static const int SYSTEM_INFO_TYPE_MAX = 4;
+}
+
 /// @internal
 /// @brief Enumeration for system information key.
 abstract class system_info_key_e {
@@ -416,15 +448,4 @@ abstract class system_info_key_e {
 
   /// < @internal Indicates whether the device supports tethering
   static const int SYSTEM_INFO_KEY_TETHERING_SUPPORTED = 14;
-}
-
-/// @internal
-/// @brief It is not decided if it should be opened to public.
-abstract class system_info_type_e {
-  static const int SYSTEM_INFO_TYPE_MIN = 0;
-  static const int SYSTEM_INFO_BOOL = 0;
-  static const int SYSTEM_INFO_INT = 1;
-  static const int SYSTEM_INFO_DOUBLE = 2;
-  static const int SYSTEM_INFO_STRING = 3;
-  static const int SYSTEM_INFO_TYPE_MAX = 4;
 }

--- a/lib/src/bindings/6.5/generated_bindings_mv_barcode_detector.dart
+++ b/lib/src/bindings/6.5/generated_bindings_mv_barcode_detector.dart
@@ -81,6 +81,123 @@ class Tizen65MvBarcodeDetector {
           ffi.Pointer<ffi.Void>)>();
 }
 
+/// @brief Enumeration for supported barcode types.
+/// @details QR codes (versions 1 to 40) and set of 1D barcodes are supported
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+/// @remarks #MV_BARCODE_UNDEFINED is deprecated. Use #MV_BARCODE_UNKNOWN instead
+abstract class mv_barcode_type_e {
+  /// < 2D barcode - Quick Response code
+  static const int MV_BARCODE_QR = 0;
+
+  /// < 1D barcode - Universal Product Code with 12-digit
+  static const int MV_BARCODE_UPC_A = 1;
+
+  /// < 1D barcode - Universal Product Code with 6-digit
+  static const int MV_BARCODE_UPC_E = 2;
+
+  /// < 1D barcode - International Article Number with 8-digit
+  static const int MV_BARCODE_EAN_8 = 3;
+
+  /// < 1D barcode - International Article Number with 13-digit
+  static const int MV_BARCODE_EAN_13 = 4;
+
+  /// < 1D barcode - Code 128
+  static const int MV_BARCODE_CODE128 = 5;
+
+  /// < 1D barcode - Code 39
+  static const int MV_BARCODE_CODE39 = 6;
+
+  /// < 1D barcode - Interleaved Two of Five
+  static const int MV_BARCODE_I2_5 = 7;
+
+  /// < @deprecated Undefined (Deprecated since 6.0)
+  static const int MV_BARCODE_UNDEFINED = 8;
+
+  /// < 1D barcode - International Article Number with 2-digit(add-on) (since 6.0)
+  static const int MV_BARCODE_EAN_2 = 9;
+
+  /// < 1D barcode - International Article Number with 5-digit(add-on) (since 6.0)
+  static const int MV_BARCODE_EAN_5 = 10;
+
+  /// < 1D barcode - Code 93 (since 6.0)
+  static const int MV_BARCODE_CODE93 = 11;
+
+  /// < 1D barcode - CODABAR (since 6.0)
+  static const int MV_BARCODE_CODABAR = 12;
+
+  /// < 1D barcode - GS1 DATABAR (since 6.0)
+  static const int MV_BARCODE_DATABAR = 13;
+
+  /// < 1D barcode - GS1 DATABAR EXPAND(since 6.0)
+  static const int MV_BARCODE_DATABAR_EXPAND = 14;
+
+  /// < Unknown (since 6.0)
+  static const int MV_BARCODE_UNKNOWN = 100;
+}
+
+/// @brief Enumeration for supported QR code error correction level.
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+/// @remarks This is unavailable for 1D barcodes
+abstract class mv_barcode_qr_ecc_e {
+  /// < Recovery up to  7% losses
+  static const int MV_BARCODE_QR_ECC_LOW = 0;
+
+  /// < Recovery up to 15% losses
+  static const int MV_BARCODE_QR_ECC_MEDIUM = 1;
+
+  /// < Recovery up to 25% losses
+  static const int MV_BARCODE_QR_ECC_QUARTILE = 2;
+
+  /// < Recovery up to 30% losses
+  static const int MV_BARCODE_QR_ECC_HIGH = 3;
+
+  /// < Unavailable
+  static const int MV_BARCODE_QR_ECC_UNAVAILABLE = 4;
+}
+
+/// @brief Enumeration for supported QR code encoding mode.
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+/// @remarks This is unavailable for 1D barcodes
+abstract class mv_barcode_qr_mode_e {
+  /// < Numeric digits
+  static const int MV_BARCODE_QR_MODE_NUMERIC = 0;
+
+  /// < Alphanumeric characters
+  static const int MV_BARCODE_QR_MODE_ALPHANUMERIC = 1;
+
+  /// < Raw 8-bit bytes
+  static const int MV_BARCODE_QR_MODE_BYTE = 2;
+
+  /// < UTF-8 character encoding
+  static const int MV_BARCODE_QR_MODE_UTF8 = 3;
+
+  /// < Unavailable
+  static const int MV_BARCODE_QR_MODE_UNAVAILABLE = 4;
+}
+
+/// @brief Enumeration for supported image formats for the barcode generating.
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+abstract class mv_barcode_image_format_e {
+  /// < Unavailable image format
+  static const int MV_BARCODE_IMAGE_FORMAT_UNAVAILABLE = -1;
+
+  /// < BMP image format
+  static const int MV_BARCODE_IMAGE_FORMAT_BMP = 0;
+
+  /// < JPEG image format
+  static const int MV_BARCODE_IMAGE_FORMAT_JPG = 1;
+
+  /// < PNG image format
+  static const int MV_BARCODE_IMAGE_FORMAT_PNG = 2;
+
+  /// < The number of supported image format
+  static const int MV_BARCODE_IMAGE_FORMAT_NUM = 3;
+}
+
 /// @brief Enumeration to target attribute
 ///
 /// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
@@ -150,61 +267,6 @@ typedef Dartmv_barcode_detected_cbFunction = void Function(
     ffi.Pointer<ffi.Int32> types,
     int number_of_barcodes,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for supported barcode types.
-/// @details QR codes (versions 1 to 40) and set of 1D barcodes are supported
-///
-/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
-/// @remarks #MV_BARCODE_UNDEFINED is deprecated. Use #MV_BARCODE_UNKNOWN instead
-abstract class mv_barcode_type_e {
-  /// < 2D barcode - Quick Response code
-  static const int MV_BARCODE_QR = 0;
-
-  /// < 1D barcode - Universal Product Code with 12-digit
-  static const int MV_BARCODE_UPC_A = 1;
-
-  /// < 1D barcode - Universal Product Code with 6-digit
-  static const int MV_BARCODE_UPC_E = 2;
-
-  /// < 1D barcode - International Article Number with 8-digit
-  static const int MV_BARCODE_EAN_8 = 3;
-
-  /// < 1D barcode - International Article Number with 13-digit
-  static const int MV_BARCODE_EAN_13 = 4;
-
-  /// < 1D barcode - Code 128
-  static const int MV_BARCODE_CODE128 = 5;
-
-  /// < 1D barcode - Code 39
-  static const int MV_BARCODE_CODE39 = 6;
-
-  /// < 1D barcode - Interleaved Two of Five
-  static const int MV_BARCODE_I2_5 = 7;
-
-  /// < @deprecated Undefined (Deprecated since 6.0)
-  static const int MV_BARCODE_UNDEFINED = 8;
-
-  /// < 1D barcode - International Article Number with 2-digit(add-on) (since 6.0)
-  static const int MV_BARCODE_EAN_2 = 9;
-
-  /// < 1D barcode - International Article Number with 5-digit(add-on) (since 6.0)
-  static const int MV_BARCODE_EAN_5 = 10;
-
-  /// < 1D barcode - Code 93 (since 6.0)
-  static const int MV_BARCODE_CODE93 = 11;
-
-  /// < 1D barcode - CODABAR (since 6.0)
-  static const int MV_BARCODE_CODABAR = 12;
-
-  /// < 1D barcode - GS1 DATABAR (since 6.0)
-  static const int MV_BARCODE_DATABAR = 13;
-
-  /// < 1D barcode - GS1 DATABAR EXPAND(since 6.0)
-  static const int MV_BARCODE_DATABAR_EXPAND = 14;
-
-  /// < Unknown (since 6.0)
-  static const int MV_BARCODE_UNKNOWN = 100;
-}
 
 const String MV_BARCODE_DETECT_ATTR_TARGET = 'MV_BARCODE_DETECT_ATTR_TARGET';
 

--- a/lib/src/bindings/6.5/generated_bindings_mv_barcode_generator.dart
+++ b/lib/src/bindings/6.5/generated_bindings_mv_barcode_generator.dart
@@ -259,7 +259,7 @@ abstract class _mv_barcode_type_e {
 ///
 /// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
 /// @remarks This is unavailable for 1D barcodes
-abstract class mv_barcode_qr_mode_e {
+abstract class _mv_barcode_qr_mode_e {
   /// < Numeric digits
   static const int MV_BARCODE_QR_MODE_NUMERIC = 0;
 
@@ -280,7 +280,7 @@ abstract class mv_barcode_qr_mode_e {
 ///
 /// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
 /// @remarks This is unavailable for 1D barcodes
-abstract class mv_barcode_qr_ecc_e {
+abstract class _mv_barcode_qr_ecc_e {
   /// < Recovery up to  7% losses
   static const int MV_BARCODE_QR_ECC_LOW = 0;
 
@@ -300,7 +300,7 @@ abstract class mv_barcode_qr_ecc_e {
 /// @brief Enumeration for supported image formats for the barcode generating.
 ///
 /// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
-abstract class mv_barcode_image_format_e {
+abstract class _mv_barcode_image_format_e {
   /// < Unavailable image format
   static const int MV_BARCODE_IMAGE_FORMAT_UNAVAILABLE = -1;
 

--- a/lib/src/bindings/6.5/generated_bindings_mv_face.dart
+++ b/lib/src/bindings/6.5/generated_bindings_mv_face.dart
@@ -1100,6 +1100,53 @@ class Tizen65MvFace {
               ffi.Pointer<ffi.Char>, ffi.Pointer<mv_face_tracking_model_h>)>();
 }
 
+/// @brief Enumeration for eyes state type.
+///
+/// @since_tizen 3.0
+///
+/// @see mv_face_eye_condition_recognize()
+abstract class mv_face_eye_condition_e {
+  /// < Eyes are open
+  static const int MV_FACE_EYES_OPEN = 0;
+
+  /// < Eyes are closed
+  static const int MV_FACE_EYES_CLOSED = 1;
+
+  /// < The eyes condition wasn't determined
+  static const int MV_FACE_EYES_NOT_FOUND = 2;
+}
+
+/// @brief Enumeration for expression types can be determined for faces.
+///
+/// @since_tizen 3.0
+///
+/// @see mv_face_facial_expression_recognize()
+abstract class mv_face_facial_expression_e {
+  /// < Unknown face expression
+  static const int MV_FACE_UNKNOWN = 0;
+
+  /// < Face expression is neutral
+  static const int MV_FACE_NEUTRAL = 1;
+
+  /// < Face expression is smiling
+  static const int MV_FACE_SMILE = 2;
+
+  /// < Face expression is sadness
+  static const int MV_FACE_SADNESS = 3;
+
+  /// < Face expression is surprise
+  static const int MV_FACE_SURPRISE = 4;
+
+  /// < Face expression is anger
+  static const int MV_FACE_ANGER = 5;
+
+  /// < Face expression is fear
+  static const int MV_FACE_FEAR = 6;
+
+  /// < Face expression is disgust
+  static const int MV_FACE_DISGUST = 7;
+}
+
 /// @brief Called when faces are detected for the @a source.
 /// @details This type callback can be invoked each time when
 /// mv_face_detect() is called to process the results of face
@@ -1311,22 +1358,6 @@ typedef Dartmv_face_eye_condition_recognized_cbFunction = void Function(
     int eye_condition,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for eyes state type.
-///
-/// @since_tizen 3.0
-///
-/// @see mv_face_eye_condition_recognize()
-abstract class mv_face_eye_condition_e {
-  /// < Eyes are open
-  static const int MV_FACE_EYES_OPEN = 0;
-
-  /// < Eyes are closed
-  static const int MV_FACE_EYES_CLOSED = 1;
-
-  /// < The eyes condition wasn't determined
-  static const int MV_FACE_EYES_NOT_FOUND = 2;
-}
-
 /// @brief Called when facial expression is recognized.
 /// @details This type callback can be invoked each time when
 /// mv_face_facial_expression_recognize() is called for @a face_location to
@@ -1362,37 +1393,6 @@ typedef Dartmv_face_facial_expression_recognized_cbFunction = void Function(
     mv_common.mv_rectangle_s face_location,
     int facial_expression,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for expression types can be determined for faces.
-///
-/// @since_tizen 3.0
-///
-/// @see mv_face_facial_expression_recognize()
-abstract class mv_face_facial_expression_e {
-  /// < Unknown face expression
-  static const int MV_FACE_UNKNOWN = 0;
-
-  /// < Face expression is neutral
-  static const int MV_FACE_NEUTRAL = 1;
-
-  /// < Face expression is smiling
-  static const int MV_FACE_SMILE = 2;
-
-  /// < Face expression is sadness
-  static const int MV_FACE_SADNESS = 3;
-
-  /// < Face expression is surprise
-  static const int MV_FACE_SURPRISE = 4;
-
-  /// < Face expression is anger
-  static const int MV_FACE_ANGER = 5;
-
-  /// < Face expression is fear
-  static const int MV_FACE_FEAR = 6;
-
-  /// < Face expression is disgust
-  static const int MV_FACE_DISGUST = 7;
-}
 
 const String MV_FACE_DETECTION_MODEL_FILE_PATH =
     'MV_FACE_DETECTION_MODEL_FILE_PATH';

--- a/lib/src/bindings/6.5/generated_bindings_mv_inference.dart
+++ b/lib/src/bindings/6.5/generated_bindings_mv_inference.dart
@@ -821,6 +821,179 @@ class Tizen65MvInference {
           ffi.Pointer<ffi.Float>)>();
 }
 
+/// @brief Enumeration for inference backend.
+/// #MV_INFERENCE_BACKEND_OPENCV An open source computer vision and machine learning
+/// software library.
+/// (https://opencv.org/about/)
+/// #MV_INFERENCE_BACKEND_TFLITE Google-introduced open source inference engine for embedded systems,
+/// which runs Tensorflow Lite model.
+/// (https://www.tensorflow.org/lite/guide/get_started)
+/// #MV_INFERENCE_BACKEND_ARMNN ARM-introduced open source inference engine for CPUs, GPUs and NPUs, which
+/// enables efficient translation of existing neural network frameworks
+/// such as TensorFlow, TensorFlow Lite and Caffes, allowing them to
+/// run efficiently without modification on Embedded hardware.
+/// (https://developer.arm.com/ip-products/processors/machine-learning/arm-nn)
+/// #MV_INFERENCE_BACKEND_MLAPI Samsung-introduced open source ML single API framework of NNStreamer, which
+/// runs various NN models via tensor filters of NNStreamer.
+/// (https://github.com/nnstreamer/nnstreamer)
+/// #MV_INFERENCE_BACKEND_ONE Samsung-introduced open source inference engine called On-device Neural Engine, which
+/// performs inference of a given NN model on various devices such as CPU, GPU, DSP and NPU.
+/// (https://github.com/Samsung/ONE)
+///
+/// @since_tizen 5.5
+///
+/// @see mv_inference_prepare()
+abstract class mv_inference_backend_type_e {
+  /// < None
+  static const int MV_INFERENCE_BACKEND_NONE = -1;
+
+  /// < OpenCV
+  static const int MV_INFERENCE_BACKEND_OPENCV = 0;
+
+  /// < TensorFlow-Lite
+  static const int MV_INFERENCE_BACKEND_TFLITE = 1;
+
+  /// < ARMNN (Since 6.0)
+  static const int MV_INFERENCE_BACKEND_ARMNN = 2;
+
+  /// < ML Single API of NNStreamer (Since 6.0)
+  static const int MV_INFERENCE_BACKEND_MLAPI = 3;
+
+  /// < On-device Neural Engine (Since 6.0)
+  static const int MV_INFERENCE_BACKEND_ONE = 4;
+
+  /// < Backend MAX
+  static const int MV_INFERENCE_BACKEND_MAX = 5;
+}
+
+/// @deprecated Deprecated since 6.0. Use #mv_inference_target_device_e instead.
+/// @brief Enumeration for inference target.
+///
+/// @since_tizen 5.5
+abstract class mv_inference_target_type_e {
+  /// < None
+  static const int MV_INFERENCE_TARGET_NONE = -1;
+
+  /// < CPU
+  static const int MV_INFERENCE_TARGET_CPU = 0;
+
+  /// < GPU
+  static const int MV_INFERENCE_TARGET_GPU = 1;
+
+  /// < CUSTOM
+  static const int MV_INFERENCE_TARGET_CUSTOM = 2;
+
+  /// < Target MAX
+  static const int MV_INFERENCE_TARGET_MAX = 3;
+}
+
+/// @brief Enumeration for inference target.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_target_device_e {
+  /// < None
+  static const int MV_INFERENCE_TARGET_DEVICE_NONE = 0;
+
+  /// < CPU
+  static const int MV_INFERENCE_TARGET_DEVICE_CPU = 1;
+
+  /// < GPU
+  static const int MV_INFERENCE_TARGET_DEVICE_GPU = 2;
+
+  /// < CUSTOM
+  static const int MV_INFERENCE_TARGET_DEVICE_CUSTOM = 4;
+
+  /// < Target MAX
+  static const int MV_INFERENCE_TARGET_DEVICE_MAX = 8;
+}
+
+/// @brief Enumeration for input data type.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_data_type_e {
+  /// < Data type of a given pre-trained model is float.
+  static const int MV_INFERENCE_DATA_FLOAT32 = 0;
+
+  /// < Data type of a given pre-trained model is unsigned char.
+  static const int MV_INFERENCE_DATA_UINT8 = 1;
+}
+
+/// @brief Enumeration for human pose landmark.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_human_pose_landmark_e {
+  /// < Head of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_HEAD = 1;
+
+  /// < Neck of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_NECK = 2;
+
+  /// < Thorax of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_THORAX = 3;
+
+  /// < Right shoulder of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_SHOULDER = 4;
+
+  /// < Right elbow of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_ELBOW = 5;
+
+  /// < Right wrist of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_WRIST = 6;
+
+  /// < Left shoulder of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_SHOULDER = 7;
+
+  /// < Left elbow of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_ELBOW = 8;
+
+  /// < Left wrist of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_WRIST = 9;
+
+  /// < Pelvis of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_PELVIS = 10;
+
+  /// < Right hip of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_HIP = 11;
+
+  /// < Right knee of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_KNEE = 12;
+
+  /// < Right ankle of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_ANKLE = 13;
+
+  /// < Left hip of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_HIP = 14;
+
+  /// < Left knee of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_KNEE = 15;
+
+  /// < Left ankle of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_ANKLE = 16;
+}
+
+/// @brief Enumeration for human body parts.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_human_body_part_e {
+  /// < HEAD, NECK, and THORAX
+  static const int MV_INFERENCE_HUMAN_BODY_PART_HEAD = 1;
+
+  /// < RIGHT SHOULDER, ELBOW, and WRIST
+  static const int MV_INFERENCE_HUMAN_BODY_PART_ARM_RIGHT = 2;
+
+  /// < LEFT SHOULDER, ELBOW, and WRIST
+  static const int MV_INFERENCE_HUMAN_BODY_PART_ARM_LEFT = 4;
+
+  /// < THORAX, PELVIS, RIGHT HIP, and LEFT HIP
+  static const int MV_INFERENCE_HUMAN_BODY_PART_BODY = 8;
+
+  /// < RIGHT HIP, KNEE, and ANKLE
+  static const int MV_INFERENCE_HUMAN_BODY_PART_LEG_RIGHT = 16;
+
+  /// < LEFT HIP, KNEE, and ANKLE
+  static const int MV_INFERENCE_HUMAN_BODY_PART_LEG_LEFT = 32;
+}
+
 /// @brief The inference handle.
 /// @details Contains information about location of
 /// detected landmarks for one or more poses.

--- a/lib/src/bindings/6.5/generated_bindings_tbm.dart
+++ b/lib/src/bindings/6.5/generated_bindings_tbm.dart
@@ -449,6 +449,8 @@ class Tizen65Tbm {
       _tbm_surface_get_formatPtr.asFunction<int Function(tbm_surface_h)>();
 }
 
+final class _tbm_surface extends ffi.Opaque {}
+
 /// @brief Enumeration for tbm_surface error type.
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
 abstract class tbm_surface_error_e {
@@ -544,11 +546,127 @@ typedef tbm_surface_plane_s = _tbm_surface_plane;
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
 typedef tbm_surface_h = ffi.Pointer<_tbm_surface>;
 
-final class _tbm_surface extends ffi.Opaque {}
-
 /// @brief Definition for the TBM surface information struct.
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
 typedef tbm_surface_info_s = _tbm_surface_info;
+
+const int TBM_FORMAT_C8 = 538982467;
+
+const int TBM_FORMAT_RGB332 = 943867730;
+
+const int TBM_FORMAT_BGR233 = 944916290;
+
+const int TBM_FORMAT_XRGB4444 = 842093144;
+
+const int TBM_FORMAT_XBGR4444 = 842089048;
+
+const int TBM_FORMAT_RGBX4444 = 842094674;
+
+const int TBM_FORMAT_BGRX4444 = 842094658;
+
+const int TBM_FORMAT_ARGB4444 = 842093121;
+
+const int TBM_FORMAT_ABGR4444 = 842089025;
+
+const int TBM_FORMAT_RGBA4444 = 842088786;
+
+const int TBM_FORMAT_BGRA4444 = 842088770;
+
+const int TBM_FORMAT_XRGB1555 = 892424792;
+
+const int TBM_FORMAT_XBGR1555 = 892420696;
+
+const int TBM_FORMAT_RGBX5551 = 892426322;
+
+const int TBM_FORMAT_BGRX5551 = 892426306;
+
+const int TBM_FORMAT_ARGB1555 = 892424769;
+
+const int TBM_FORMAT_ABGR1555 = 892420673;
+
+const int TBM_FORMAT_RGBA5551 = 892420434;
+
+const int TBM_FORMAT_BGRA5551 = 892420418;
+
+const int TBM_FORMAT_RGB565 = 909199186;
+
+const int TBM_FORMAT_BGR565 = 909199170;
+
+const int TBM_FORMAT_RGB888 = 875710290;
+
+const int TBM_FORMAT_BGR888 = 875710274;
+
+const int TBM_FORMAT_XRGB8888 = 875713112;
+
+const int TBM_FORMAT_XBGR8888 = 875709016;
+
+const int TBM_FORMAT_RGBX8888 = 875714642;
+
+const int TBM_FORMAT_BGRX8888 = 875714626;
+
+const int TBM_FORMAT_ARGB8888 = 875713089;
+
+const int TBM_FORMAT_ABGR8888 = 875708993;
+
+const int TBM_FORMAT_RGBA8888 = 875708754;
+
+const int TBM_FORMAT_BGRA8888 = 875708738;
+
+const int TBM_FORMAT_XRGB2101010 = 808669784;
+
+const int TBM_FORMAT_XBGR2101010 = 808665688;
+
+const int TBM_FORMAT_RGBX1010102 = 808671314;
+
+const int TBM_FORMAT_BGRX1010102 = 808671298;
+
+const int TBM_FORMAT_ARGB2101010 = 808669761;
+
+const int TBM_FORMAT_ABGR2101010 = 808665665;
+
+const int TBM_FORMAT_RGBA1010102 = 808665426;
+
+const int TBM_FORMAT_BGRA1010102 = 808665410;
+
+const int TBM_FORMAT_YUYV = 1448695129;
+
+const int TBM_FORMAT_YVYU = 1431918169;
+
+const int TBM_FORMAT_UYVY = 1498831189;
+
+const int TBM_FORMAT_VYUY = 1498765654;
+
+const int TBM_FORMAT_AYUV = 1448433985;
+
+const int TBM_FORMAT_NV12 = 842094158;
+
+const int TBM_FORMAT_NV21 = 825382478;
+
+const int TBM_FORMAT_NV16 = 909203022;
+
+const int TBM_FORMAT_NV61 = 825644622;
+
+const int TBM_FORMAT_YUV410 = 961959257;
+
+const int TBM_FORMAT_YVU410 = 961893977;
+
+const int TBM_FORMAT_YUV411 = 825316697;
+
+const int TBM_FORMAT_YVU411 = 825316953;
+
+const int TBM_FORMAT_YUV420 = 842093913;
+
+const int TBM_FORMAT_YVU420 = 842094169;
+
+const int TBM_FORMAT_YUV422 = 909202777;
+
+const int TBM_FORMAT_YVU422 = 909203033;
+
+const int TBM_FORMAT_YUV444 = 875713881;
+
+const int TBM_FORMAT_YVU444 = 875714137;
+
+const int TBM_FORMAT_NV12MT = 842091860;
 
 const int TBM_SURF_PLANE_MAX = 4;
 

--- a/lib/src/bindings/7.0/generated_bindings_capi_base_common.dart
+++ b/lib/src/bindings/7.0/generated_bindings_capi_base_common.dart
@@ -386,6 +386,8 @@ abstract class tizen_error_e {
   static const int TIZEN_ERROR_END_OF_COLLECTION = -1073741819;
 }
 
+const int NULL = 0;
+
 const int TIZEN_ERROR_MAX_PLATFORM_ERROR = 0;
 
 const int TIZEN_ERROR_MIN_PLATFORM_ERROR = -1073741824;

--- a/lib/src/bindings/7.0/generated_bindings_capi_geofence_manager.dart
+++ b/lib/src/bindings/7.0/generated_bindings_capi_geofence_manager.dart
@@ -1223,71 +1223,6 @@ class Tizen70CapiGeofenceManager {
       .asFunction<int Function(geofence_status_h, ffi.Pointer<ffi.Int>)>();
 }
 
-/// @brief The geofence manager handle.
-/// @since_tizen 2.4
-typedef geofence_manager_h = ffi.Pointer<geofence_manager_s>;
-
-final class geofence_manager_s extends ffi.Opaque {}
-
-/// @brief The geofence handle.
-/// @since_tizen 2.4
-typedef geofence_h = ffi.Pointer<geofence_s>;
-
-final class geofence_s extends ffi.Opaque {}
-
-/// @brief Called when a device enters or exits the given geofence.
-/// @since_tizen 2.4
-/// @param[in] geofence_id The specified geofence ID
-/// @param[in] state The geofence state
-/// @param[in] user_data The user data passed from callback registration function
-/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_state_changed_cb().
-/// @see geofence_state_e
-/// @see geofence_manager_start()
-/// @see geofence_manager_set_geofence_state_changed_cb()
-typedef geofence_state_changed_cb
-    = ffi.Pointer<ffi.NativeFunction<geofence_state_changed_cbFunction>>;
-typedef geofence_state_changed_cbFunction = ffi.Void Function(
-    ffi.Int geofence_id, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
-typedef Dartgeofence_state_changed_cbFunction = void Function(
-    int geofence_id, int state, ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the state of geofence manager.
-/// @since_tizen 2.4
-abstract class geofence_state_e {
-  /// < Uncertain state of geofence
-  static const int GEOFENCE_STATE_UNCERTAIN = 0;
-
-  /// < Geofence In state
-  static const int GEOFENCE_STATE_IN = 1;
-
-  /// < Geofence Out state
-  static const int GEOFENCE_STATE_OUT = 2;
-}
-
-/// @brief Called when the some event occurs in geofence and place such as add, update, etc..
-/// @details The events of public geofence is also received if there are public geofences.
-/// @since_tizen 2.4
-/// @remarks The value of place_id or geofence_id is -1 when the place ID or geofence ID is not assigned.
-/// @param[in] place_id The place ID
-/// @param[in] geofence_id The specified geofence ID
-/// @param[in] error The error code for the particular action
-/// @param[in] manage The result code for the particular place and geofence management
-/// @param[in] user_data The user data passed from callback registration function
-/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_event_cb()
-/// @see geofence_manage_e
-/// @see geofence_manager_start()
-/// @see geofence_manager_set_geofence_event_cb()
-typedef geofence_event_cb
-    = ffi.Pointer<ffi.NativeFunction<geofence_event_cbFunction>>;
-typedef geofence_event_cbFunction = ffi.Void Function(
-    ffi.Int place_id,
-    ffi.Int geofence_id,
-    ffi.Int32 error,
-    ffi.Int32 manage,
-    ffi.Pointer<ffi.Void> user_data);
-typedef Dartgeofence_event_cbFunction = void Function(int place_id,
-    int geofence_id, int error, int manage, ffi.Pointer<ffi.Void> user_data);
-
 /// @brief Enumeration for Geofence manager of error code.
 /// @since_tizen 2.4
 abstract class geofence_manager_error_e {
@@ -1334,57 +1269,18 @@ abstract class geofence_manager_error_e {
   static const int GEOFENCE_MANAGER_ERROR_GEOFENCE_ACCESS_DENIED = -46202871;
 }
 
-/// @brief Enumeration for geofence management events.
+/// @brief Enumeration for the state of geofence manager.
 /// @since_tizen 2.4
-abstract class geofence_manage_e {
-  /// < Geofence is added
-  static const int GEOFENCE_MANAGE_FENCE_ADDED = 0;
+abstract class geofence_state_e {
+  /// < Uncertain state of geofence
+  static const int GEOFENCE_STATE_UNCERTAIN = 0;
 
-  /// < Geofence is removed
-  static const int GEOFENCE_MANAGE_FENCE_REMOVED = 1;
+  /// < Geofence In state
+  static const int GEOFENCE_STATE_IN = 1;
 
-  /// < Geofencing is started
-  static const int GEOFENCE_MANAGE_FENCE_STARTED = 2;
-
-  /// < Geofencing is stopped
-  static const int GEOFENCE_MANAGE_FENCE_STOPPED = 3;
-
-  /// < Place is added
-  static const int GEOFENCE_MANAGE_PLACE_ADDED = 16;
-
-  /// < Place is removed
-  static const int GEOFENCE_MANAGE_PLACE_REMOVED = 17;
-
-  /// < Place is updated
-  static const int GEOFENCE_MANAGE_PLACE_UPDATED = 18;
-
-  /// < Setting for geofencing is enabled
-  static const int GEOFENCE_MANAGE_SETTING_ENABLED = 32;
-
-  /// < Setting for geofencing is disabled
-  static const int GEOFENCE_MANAGE_SETTING_DISABLED = 33;
+  /// < Geofence Out state
+  static const int GEOFENCE_STATE_OUT = 2;
 }
-
-/// @brief Called when a proximity state of device is changed.
-/// @since_tizen 3.0
-/// @param[in] geofence_id The specified geofence ID
-/// @param[in] state The proximity state
-/// @param[in] provider The proximity provider
-/// @param[in] user_data The user data passed from callback registration function
-/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_proximity_state_changed_cb().
-/// @see geofence_proximity_state_e
-/// @see geofence_proximity_provider_e
-/// @see geofence_manager_start()
-/// @see geofence_manager_set_geofence_proximity_state_changed_cb()
-typedef geofence_proximity_state_changed_cb = ffi
-    .Pointer<ffi.NativeFunction<geofence_proximity_state_changed_cbFunction>>;
-typedef geofence_proximity_state_changed_cbFunction = ffi.Void Function(
-    ffi.Int geofence_id,
-    ffi.Int32 state,
-    ffi.Int32 provider,
-    ffi.Pointer<ffi.Void> user_data);
-typedef Dartgeofence_proximity_state_changed_cbFunction = void Function(
-    int geofence_id, int state, int provider, ffi.Pointer<ffi.Void> user_data);
 
 /// @brief Enumeration for the state of proximity.
 /// @since_tizen 3.0
@@ -1420,6 +1316,125 @@ abstract class geofence_proximity_provider_e {
   /// < Proximity is specified by Sensor
   static const int GEOFENCE_PROXIMITY_PROVIDER_SENSOR = 4;
 }
+
+/// @brief Enumeration for geofence type.
+/// @since_tizen 2.4
+abstract class geofence_type_e {
+  /// < Geofence is specified by geospatial coordinate
+  static const int GEOFENCE_TYPE_GEOPOINT = 1;
+
+  /// < Geofence is specified by Wi-Fi access point
+  static const int GEOFENCE_TYPE_WIFI = 2;
+
+  /// < Geofence is specified by Bluetooth device
+  static const int GEOFENCE_TYPE_BT = 3;
+}
+
+/// @brief Enumeration for geofence management events.
+/// @since_tizen 2.4
+abstract class geofence_manage_e {
+  /// < Geofence is added
+  static const int GEOFENCE_MANAGE_FENCE_ADDED = 0;
+
+  /// < Geofence is removed
+  static const int GEOFENCE_MANAGE_FENCE_REMOVED = 1;
+
+  /// < Geofencing is started
+  static const int GEOFENCE_MANAGE_FENCE_STARTED = 2;
+
+  /// < Geofencing is stopped
+  static const int GEOFENCE_MANAGE_FENCE_STOPPED = 3;
+
+  /// < Place is added
+  static const int GEOFENCE_MANAGE_PLACE_ADDED = 16;
+
+  /// < Place is removed
+  static const int GEOFENCE_MANAGE_PLACE_REMOVED = 17;
+
+  /// < Place is updated
+  static const int GEOFENCE_MANAGE_PLACE_UPDATED = 18;
+
+  /// < Setting for geofencing is enabled
+  static const int GEOFENCE_MANAGE_SETTING_ENABLED = 32;
+
+  /// < Setting for geofencing is disabled
+  static const int GEOFENCE_MANAGE_SETTING_DISABLED = 33;
+}
+
+final class geofence_manager_s extends ffi.Opaque {}
+
+final class geofence_s extends ffi.Opaque {}
+
+final class geofence_status_s extends ffi.Opaque {}
+
+/// @brief The geofence manager handle.
+/// @since_tizen 2.4
+typedef geofence_manager_h = ffi.Pointer<geofence_manager_s>;
+
+/// @brief The geofence handle.
+/// @since_tizen 2.4
+typedef geofence_h = ffi.Pointer<geofence_s>;
+
+/// @brief Called when a device enters or exits the given geofence.
+/// @since_tizen 2.4
+/// @param[in] geofence_id The specified geofence ID
+/// @param[in] state The geofence state
+/// @param[in] user_data The user data passed from callback registration function
+/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_state_changed_cb().
+/// @see geofence_state_e
+/// @see geofence_manager_start()
+/// @see geofence_manager_set_geofence_state_changed_cb()
+typedef geofence_state_changed_cb
+    = ffi.Pointer<ffi.NativeFunction<geofence_state_changed_cbFunction>>;
+typedef geofence_state_changed_cbFunction = ffi.Void Function(
+    ffi.Int geofence_id, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
+typedef Dartgeofence_state_changed_cbFunction = void Function(
+    int geofence_id, int state, ffi.Pointer<ffi.Void> user_data);
+
+/// @brief Called when the some event occurs in geofence and place such as add, update, etc..
+/// @details The events of public geofence is also received if there are public geofences.
+/// @since_tizen 2.4
+/// @remarks The value of place_id or geofence_id is -1 when the place ID or geofence ID is not assigned.
+/// @param[in] place_id The place ID
+/// @param[in] geofence_id The specified geofence ID
+/// @param[in] error The error code for the particular action
+/// @param[in] manage The result code for the particular place and geofence management
+/// @param[in] user_data The user data passed from callback registration function
+/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_event_cb()
+/// @see geofence_manage_e
+/// @see geofence_manager_start()
+/// @see geofence_manager_set_geofence_event_cb()
+typedef geofence_event_cb
+    = ffi.Pointer<ffi.NativeFunction<geofence_event_cbFunction>>;
+typedef geofence_event_cbFunction = ffi.Void Function(
+    ffi.Int place_id,
+    ffi.Int geofence_id,
+    ffi.Int32 error,
+    ffi.Int32 manage,
+    ffi.Pointer<ffi.Void> user_data);
+typedef Dartgeofence_event_cbFunction = void Function(int place_id,
+    int geofence_id, int error, int manage, ffi.Pointer<ffi.Void> user_data);
+
+/// @brief Called when a proximity state of device is changed.
+/// @since_tizen 3.0
+/// @param[in] geofence_id The specified geofence ID
+/// @param[in] state The proximity state
+/// @param[in] provider The proximity provider
+/// @param[in] user_data The user data passed from callback registration function
+/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_proximity_state_changed_cb().
+/// @see geofence_proximity_state_e
+/// @see geofence_proximity_provider_e
+/// @see geofence_manager_start()
+/// @see geofence_manager_set_geofence_proximity_state_changed_cb()
+typedef geofence_proximity_state_changed_cb = ffi
+    .Pointer<ffi.NativeFunction<geofence_proximity_state_changed_cbFunction>>;
+typedef geofence_proximity_state_changed_cbFunction = ffi.Void Function(
+    ffi.Int geofence_id,
+    ffi.Int32 state,
+    ffi.Int32 provider,
+    ffi.Pointer<ffi.Void> user_data);
+typedef Dartgeofence_proximity_state_changed_cbFunction = void Function(
+    int geofence_id, int state, int provider, ffi.Pointer<ffi.Void> user_data);
 
 /// @brief Called when the fence list is requested.
 /// @since_tizen 2.4
@@ -1476,21 +1491,6 @@ typedef Dartgeofence_manager_place_cbFunction = bool Function(
     int place_cnt,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for geofence type.
-/// @since_tizen 2.4
-abstract class geofence_type_e {
-  /// < Geofence is specified by geospatial coordinate
-  static const int GEOFENCE_TYPE_GEOPOINT = 1;
-
-  /// < Geofence is specified by Wi-Fi access point
-  static const int GEOFENCE_TYPE_WIFI = 2;
-
-  /// < Geofence is specified by Bluetooth device
-  static const int GEOFENCE_TYPE_BT = 3;
-}
-
 /// @brief The geofence status handle.
 /// @since_tizen 2.4
 typedef geofence_status_h = ffi.Pointer<geofence_status_s>;
-
-final class geofence_status_s extends ffi.Opaque {}

--- a/lib/src/bindings/7.0/generated_bindings_capi_media_controller.dart
+++ b/lib/src/bindings/7.0/generated_bindings_capi_media_controller.dart
@@ -6781,6 +6781,461 @@ class Tizen70CapiMediaController {
       .asFunction<int Function(mc_server_h, ffi.Pointer<ffi.Char>)>();
 }
 
+/// @brief Enumeration for the media controller error.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_error_e {
+  /// < Successful
+  static const int MEDIA_CONTROLLER_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int MEDIA_CONTROLLER_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int MEDIA_CONTROLLER_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Invalid Operation
+  static const int MEDIA_CONTROLLER_ERROR_INVALID_OPERATION = -38;
+
+  /// < No space left on device
+  static const int MEDIA_CONTROLLER_ERROR_FILE_NO_SPACE_ON_DEVICE = -28;
+
+  /// < Permission denied
+  static const int MEDIA_CONTROLLER_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Limited by server application (since 5.5)
+  static const int MEDIA_CONTROLLER_ERROR_ABILITY_LIMITED_BY_SERVER_APP =
+      -50462719;
+}
+
+/// @brief Enumeration for the media controller server state.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_server_state_e {
+  /// < None state
+  static const int MC_SERVER_STATE_NONE = 0;
+
+  /// < Activate state
+  static const int MC_SERVER_STATE_ACTIVATE = 1;
+
+  /// < Deactivate state
+  static const int MC_SERVER_STATE_DEACTIVATE = 2;
+}
+
+/// @brief Enumeration for the media meta info.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_meta_e {
+  /// < Title
+  static const int MC_META_MEDIA_TITLE = 0;
+
+  /// < Artist
+  static const int MC_META_MEDIA_ARTIST = 1;
+
+  /// < Album
+  static const int MC_META_MEDIA_ALBUM = 2;
+
+  /// < Author
+  static const int MC_META_MEDIA_AUTHOR = 3;
+
+  /// < Genre
+  static const int MC_META_MEDIA_GENRE = 4;
+
+  /// < Duration
+  static const int MC_META_MEDIA_DURATION = 5;
+
+  /// < Date
+  static const int MC_META_MEDIA_DATE = 6;
+
+  /// < Copyright
+  static const int MC_META_MEDIA_COPYRIGHT = 7;
+
+  /// < Description
+  static const int MC_META_MEDIA_DESCRIPTION = 8;
+
+  /// < Track Number
+  static const int MC_META_MEDIA_TRACK_NUM = 9;
+
+  /// < Picture. Album Art
+  static const int MC_META_MEDIA_PICTURE = 10;
+
+  /// < Season (Since 5.5)
+  static const int MC_META_MEDIA_SEASON = 11;
+
+  /// < Episode (Since 5.5)
+  static const int MC_META_MEDIA_EPISODE = 12;
+
+  /// < Content resolution (Since 5.5)
+  static const int MC_META_MEDIA_RESOLUTION = 13;
+}
+
+/// @brief Enumeration for the media playback state.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_playback_states_e {
+  /// < None
+  static const int MC_PLAYBACK_STATE_NONE = 0;
+
+  /// < Playing
+  static const int MC_PLAYBACK_STATE_PLAYING = 1;
+
+  /// < Paused
+  static const int MC_PLAYBACK_STATE_PAUSED = 2;
+
+  /// < Stopped
+  static const int MC_PLAYBACK_STATE_STOPPED = 3;
+
+  /// < Moving to the next item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_MOVING_TO_NEXT = 8;
+
+  /// < Moving to the previous item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_MOVING_TO_PREVIOUS = 9;
+
+  /// < Fast forwarding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_FAST_FORWARDING = 10;
+
+  /// < Rewinding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_REWINDING = 11;
+
+  /// < Connecting (Since 6.0)
+  static const int MC_PLAYBACK_STATE_CONNECTING = 12;
+
+  /// < Buffering (Since 6.0)
+  static const int MC_PLAYBACK_STATE_BUFFERING = 13;
+
+  /// < Error (Since 6.0)
+  static const int MC_PLAYBACK_STATE_ERROR = 14;
+}
+
+/// @brief Enumeration for the media playback action.
+/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
+abstract class mc_playback_action_e {
+  /// < Play
+  static const int MC_PLAYBACK_ACTION_PLAY = 0;
+
+  /// < Pause
+  static const int MC_PLAYBACK_ACTION_PAUSE = 1;
+
+  /// < Stop
+  static const int MC_PLAYBACK_ACTION_STOP = 2;
+
+  /// < Next item
+  static const int MC_PLAYBACK_ACTION_NEXT = 3;
+
+  /// < Previous item
+  static const int MC_PLAYBACK_ACTION_PREV = 4;
+
+  /// < Fast forward
+  static const int MC_PLAYBACK_ACTION_FAST_FORWARD = 5;
+
+  /// < Rewind
+  static const int MC_PLAYBACK_ACTION_REWIND = 6;
+
+  /// < Play/Pause toggle
+  static const int MC_PLAYBACK_ACTION_TOGGLE_PLAY_PAUSE = 7;
+}
+
+/// @brief Enumeration for the shuffle mode.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_shuffle_mode_e {
+  /// < Shuffle mode on
+  static const int MC_SHUFFLE_MODE_ON = 0;
+
+  /// < Shuffle mode off
+  static const int MC_SHUFFLE_MODE_OFF = 1;
+}
+
+/// @brief Enumeration for the repeat mode.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_repeat_mode_e {
+  /// < Repeat mode on for all media
+  static const int MC_REPEAT_MODE_ON = 0;
+
+  /// < Repeat mode off
+  static const int MC_REPEAT_MODE_OFF = 1;
+
+  /// < Repeat mode on for one media (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_REPEAT_MODE_ONE_MEDIA = 2;
+}
+
+/// @brief Enumeration for the subscription type.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_subscription_type_e {
+  /// < Server state
+  static const int MC_SUBSCRIPTION_TYPE_SERVER_STATE = 0;
+
+  /// < Playback
+  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK = 1;
+
+  /// < Metadata
+  static const int MC_SUBSCRIPTION_TYPE_METADATA = 2;
+
+  /// < Shuffle mode
+  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_MODE = 3;
+
+  /// < Repeat mode
+  static const int MC_SUBSCRIPTION_TYPE_REPEAT_MODE = 4;
+
+  /// < Playlist (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_SUBSCRIPTION_TYPE_PLAYLIST = 5;
+
+  /// < Playback ability (Since 5.0)
+  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK_ABILITY = 6;
+
+  /// < Shuffle ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
+  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_ABILITY = 7;
+
+  /// < Repeat ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
+  static const int MC_SUBSCRIPTION_TYPE_REPEAT_ABILITY = 8;
+
+  /// < Ability support (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT = 9;
+
+  /// < Display mode ability (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_MODE_ABILITY = 10;
+
+  /// < Display rotation ability (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_ROTATION_ABILITY = 11;
+}
+
+/// @brief Enumeration for the playlist update mode.
+/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
+abstract class mc_playlist_update_mode_e {
+  /// < Create or Update playlist
+  static const int MC_PLAYLIST_UPDATED = 0;
+
+  /// < Remove playlist
+  static const int MC_PLAYLIST_REMOVED = 1;
+}
+
+/// @brief Enumeration for the content type of the content.
+/// @since_tizen 5.0
+abstract class mc_content_type_e {
+  /// < Image content type
+  static const int MC_CONTENT_TYPE_IMAGE = 0;
+
+  /// < Video content type
+  static const int MC_CONTENT_TYPE_VIDEO = 1;
+
+  /// < Music content type
+  static const int MC_CONTENT_TYPE_MUSIC = 2;
+
+  /// < Other content type
+  static const int MC_CONTENT_TYPE_OTHER = 3;
+
+  /// < Not decided
+  static const int MC_CONTENT_TYPE_UNDECIDED = 4;
+}
+
+/// @brief Enumeration for the content age rating of the content.
+/// @since_tizen 5.0
+abstract class mc_content_age_rating_e {
+  /// < Suitable for all ages
+  static const int MC_CONTENT_RATING_ALL = 0;
+
+  /// < Suitable for ages 1 and up
+  static const int MC_CONTENT_RATING_1_PLUS = 1;
+
+  /// < Suitable for ages 2 and up
+  static const int MC_CONTENT_RATING_2_PLUS = 2;
+
+  /// < Suitable for ages 3 and up
+  static const int MC_CONTENT_RATING_3_PLUS = 3;
+
+  /// < Suitable for ages 4 and up
+  static const int MC_CONTENT_RATING_4_PLUS = 4;
+
+  /// < Suitable for ages 5 and up
+  static const int MC_CONTENT_RATING_5_PLUS = 5;
+
+  /// < Suitable for ages 6 and up
+  static const int MC_CONTENT_RATING_6_PLUS = 6;
+
+  /// < Suitable for ages 7 and up
+  static const int MC_CONTENT_RATING_7_PLUS = 7;
+
+  /// < Suitable for ages 8 and up
+  static const int MC_CONTENT_RATING_8_PLUS = 8;
+
+  /// < Suitable for ages 9 and up
+  static const int MC_CONTENT_RATING_9_PLUS = 9;
+
+  /// < Suitable for ages 10 and up
+  static const int MC_CONTENT_RATING_10_PLUS = 10;
+
+  /// < Suitable for ages 11 and up
+  static const int MC_CONTENT_RATING_11_PLUS = 11;
+
+  /// < Suitable for ages 12 and up
+  static const int MC_CONTENT_RATING_12_PLUS = 12;
+
+  /// < Suitable for ages 13 and up
+  static const int MC_CONTENT_RATING_13_PLUS = 13;
+
+  /// < Suitable for ages 14 and up
+  static const int MC_CONTENT_RATING_14_PLUS = 14;
+
+  /// < Suitable for ages 15 and up
+  static const int MC_CONTENT_RATING_15_PLUS = 15;
+
+  /// < Suitable for ages 16 and up
+  static const int MC_CONTENT_RATING_16_PLUS = 16;
+
+  /// < Suitable for ages 17 and up
+  static const int MC_CONTENT_RATING_17_PLUS = 17;
+
+  /// < Suitable for ages 18 and up
+  static const int MC_CONTENT_RATING_18_PLUS = 18;
+
+  /// < Suitable for ages 19 and up
+  static const int MC_CONTENT_RATING_19_PLUS = 19;
+}
+
+/// @brief Enumeration for the support of the ability.
+/// @since_tizen 5.0
+abstract class mc_ability_support_e {
+  /// < Supported
+  static const int MC_ABILITY_SUPPORTED_YES = 0;
+
+  /// < Not supported
+  static const int MC_ABILITY_SUPPORTED_NO = 1;
+
+  /// < Not decided
+  static const int MC_ABILITY_SUPPORTED_UNDECIDED = 2;
+}
+
+/// @brief Enumeration for the ability.
+/// @since_tizen 5.5
+abstract class mc_ability_e {
+  /// < Shuffle
+  static const int MC_ABILITY_SHUFFLE = 0;
+
+  /// < Repeat
+  static const int MC_ABILITY_REPEAT = 1;
+
+  /// < Playback Position
+  static const int MC_ABILITY_PLAYBACK_POSITION = 2;
+
+  /// < Playlist
+  static const int MC_ABILITY_PLAYLIST = 3;
+
+  /// < Custom command from a client
+  static const int MC_ABILITY_CLIENT_CUSTOM = 4;
+
+  /// < Search
+  static const int MC_ABILITY_SEARCH = 5;
+
+  /// < Subtitles display
+  static const int MC_ABILITY_SUBTITLES = 6;
+
+  /// < 360 content mode display
+  static const int MC_ABILITY_360_MODE = 7;
+}
+
+/// @brief Enumeration for the search category.
+/// @since_tizen 5.0
+abstract class mc_search_category_e {
+  /// < No search category
+  static const int MC_SEARCH_NO_CATEGORY = 0;
+
+  /// < Search by content title
+  static const int MC_SEARCH_TITLE = 1;
+
+  /// < Search by content artist
+  static const int MC_SEARCH_ARTIST = 2;
+
+  /// < Search by content album
+  static const int MC_SEARCH_ALBUM = 3;
+
+  /// < Search by content genre
+  static const int MC_SEARCH_GENRE = 4;
+
+  /// < Search by Time Place Occasion
+  static const int MC_SEARCH_TPO = 5;
+}
+
+/// @brief Enumeration for the display mode.
+/// @since_tizen 5.5
+abstract class mc_display_mode_e {
+  /// < Letter box
+  static const int MC_DISPLAY_MODE_LETTER_BOX = 1;
+
+  /// < Origin size
+  static const int MC_DISPLAY_MODE_ORIGIN_SIZE = 2;
+
+  /// < Full-screen
+  static const int MC_DISPLAY_MODE_FULL_SCREEN = 4;
+
+  /// < Cropped full-screen
+  static const int MC_DISPLAY_MODE_CROPPED_FULL = 8;
+}
+
+/// @brief Enumeration for the display rotation.
+/// @since_tizen 5.5
+abstract class mc_display_rotation_e {
+  /// < Display is not rotated
+  static const int MC_DISPLAY_ROTATION_NONE = 1;
+
+  /// < Display is rotated 90 degrees
+  static const int MC_DISPLAY_ROTATION_90 = 2;
+
+  /// < Display is rotated 180 degrees
+  static const int MC_DISPLAY_ROTATION_180 = 4;
+
+  /// < Display is rotated 270 degrees
+  static const int MC_DISPLAY_ROTATION_270 = 8;
+}
+
+/// @brief The result codes of the reply for the command or the event.
+/// @since_tizen 6.0
+///
+/// @see mc_cmd_reply_received_cb()
+/// @see mc_client_send_event_reply()
+/// @see mc_server_event_reply_received_cb()
+/// @see mc_server_send_cmd_reply()
+abstract class mc_result_code_e {
+  /// < The command or the event has been successfully completed.
+  static const int MC_RESULT_CODE_SUCCESS = 0;
+
+  /// < The command or the event had already been completed.
+  static const int MC_RESULT_CODE_ALREADY_DONE = 200;
+
+  /// < The command or the event is aborted by some external event (e.g. aborted play command by incoming call).
+  static const int MC_RESULT_CODE_ABORTED = 300;
+
+  /// < The command or the event is denied due to application policy (e.g. cannot rewind in recording).
+  static const int MC_RESULT_CODE_DENIED = 301;
+
+  /// < The command or the event is not supported.
+  static const int MC_RESULT_CODE_NOT_SUPPORTED = 302;
+
+  /// < The command or the event is out of supported range or the limit is reached.
+  static const int MC_RESULT_CODE_INVALID = 303;
+
+  /// < Timeout has occurred.
+  static const int MC_RESULT_CODE_TIMEOUT = 400;
+
+  /// < The application has failed.
+  static const int MC_RESULT_CODE_APP_FAILED = 401;
+
+  /// < The command or the event has failed because the application has no media.
+  static const int MC_RESULT_CODE_NO_MEDIA = 402;
+
+  /// < The command or the event has failed because there is no audio output device.
+  static const int MC_RESULT_CODE_NO_AUDIO_OUTPUT_DEVICE = 403;
+
+  /// < The command or the event has failed because there is no peer.
+  static const int MC_RESULT_CODE_NO_PEER = 404;
+
+  /// < The network has failed.
+  static const int MC_RESULT_CODE_NETWORK_FAILED = 500;
+
+  /// < The application needs to have an account to which it's logged in.
+  static const int MC_RESULT_CODE_NO_ACCOUNT = 600;
+
+  /// < The application could not log in.
+  static const int MC_RESULT_CODE_LOGIN_FAILED = 601;
+
+  /// < Unknown error.
+  static const int MC_RESULT_CODE_UNKNOWN = 2147483647;
+}
+
 /// @brief The structure type for the media controller playlist handle.
 /// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
 typedef mc_playlist_h = ffi.Pointer<ffi.Void>;
@@ -6848,141 +7303,13 @@ typedef mc_playlist_cbFunction = ffi.Bool Function(
 typedef Dartmc_playlist_cbFunction = bool Function(
     mc_playlist_h playlist, ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the media meta info.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_meta_e {
-  /// < Title
-  static const int MC_META_MEDIA_TITLE = 0;
-
-  /// < Artist
-  static const int MC_META_MEDIA_ARTIST = 1;
-
-  /// < Album
-  static const int MC_META_MEDIA_ALBUM = 2;
-
-  /// < Author
-  static const int MC_META_MEDIA_AUTHOR = 3;
-
-  /// < Genre
-  static const int MC_META_MEDIA_GENRE = 4;
-
-  /// < Duration
-  static const int MC_META_MEDIA_DURATION = 5;
-
-  /// < Date
-  static const int MC_META_MEDIA_DATE = 6;
-
-  /// < Copyright
-  static const int MC_META_MEDIA_COPYRIGHT = 7;
-
-  /// < Description
-  static const int MC_META_MEDIA_DESCRIPTION = 8;
-
-  /// < Track Number
-  static const int MC_META_MEDIA_TRACK_NUM = 9;
-
-  /// < Picture. Album Art
-  static const int MC_META_MEDIA_PICTURE = 10;
-
-  /// < Season (Since 5.5)
-  static const int MC_META_MEDIA_SEASON = 11;
-
-  /// < Episode (Since 5.5)
-  static const int MC_META_MEDIA_EPISODE = 12;
-
-  /// < Content resolution (Since 5.5)
-  static const int MC_META_MEDIA_RESOLUTION = 13;
-}
-
 /// @brief The structure type for the media controller ability handle.
 /// @since_tizen 5.0
 typedef mc_playback_ability_h = ffi.Pointer<ffi.Void>;
 
-/// @brief Enumeration for the media playback action.
-/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
-abstract class mc_playback_action_e {
-  /// < Play
-  static const int MC_PLAYBACK_ACTION_PLAY = 0;
-
-  /// < Pause
-  static const int MC_PLAYBACK_ACTION_PAUSE = 1;
-
-  /// < Stop
-  static const int MC_PLAYBACK_ACTION_STOP = 2;
-
-  /// < Next item
-  static const int MC_PLAYBACK_ACTION_NEXT = 3;
-
-  /// < Previous item
-  static const int MC_PLAYBACK_ACTION_PREV = 4;
-
-  /// < Fast forward
-  static const int MC_PLAYBACK_ACTION_FAST_FORWARD = 5;
-
-  /// < Rewind
-  static const int MC_PLAYBACK_ACTION_REWIND = 6;
-
-  /// < Play/Pause toggle
-  static const int MC_PLAYBACK_ACTION_TOGGLE_PLAY_PAUSE = 7;
-}
-
-/// @brief Enumeration for the support of the ability.
-/// @since_tizen 5.0
-abstract class mc_ability_support_e {
-  /// < Supported
-  static const int MC_ABILITY_SUPPORTED_YES = 0;
-
-  /// < Not supported
-  static const int MC_ABILITY_SUPPORTED_NO = 1;
-
-  /// < Not decided
-  static const int MC_ABILITY_SUPPORTED_UNDECIDED = 2;
-}
-
 /// @brief The structure type for the media controller search handle.
 /// @since_tizen 5.0
 typedef mc_search_h = ffi.Pointer<ffi.Void>;
-
-/// @brief Enumeration for the content type of the content.
-/// @since_tizen 5.0
-abstract class mc_content_type_e {
-  /// < Image content type
-  static const int MC_CONTENT_TYPE_IMAGE = 0;
-
-  /// < Video content type
-  static const int MC_CONTENT_TYPE_VIDEO = 1;
-
-  /// < Music content type
-  static const int MC_CONTENT_TYPE_MUSIC = 2;
-
-  /// < Other content type
-  static const int MC_CONTENT_TYPE_OTHER = 3;
-
-  /// < Not decided
-  static const int MC_CONTENT_TYPE_UNDECIDED = 4;
-}
-
-/// @brief Enumeration for the search category.
-/// @since_tizen 5.0
-abstract class mc_search_category_e {
-  /// < No search category
-  static const int MC_SEARCH_NO_CATEGORY = 0;
-
-  /// < Search by content title
-  static const int MC_SEARCH_TITLE = 1;
-
-  /// < Search by content artist
-  static const int MC_SEARCH_ARTIST = 2;
-
-  /// < Search by content album
-  static const int MC_SEARCH_ALBUM = 3;
-
-  /// < Search by content genre
-  static const int MC_SEARCH_GENRE = 4;
-
-  /// < Search by Time Place Occasion
-  static const int MC_SEARCH_TPO = 5;
-}
 
 /// @brief Called for every search condition information in the obtained list of search.
 /// @details Iterates over a search list.
@@ -7047,19 +7374,6 @@ typedef Dartmc_server_state_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the media controller server state.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_server_state_e {
-  /// < None state
-  static const int MC_SERVER_STATE_NONE = 0;
-
-  /// < Activate state
-  static const int MC_SERVER_STATE_ACTIVATE = 1;
-
-  /// < Deactivate state
-  static const int MC_SERVER_STATE_DEACTIVATE = 2;
-}
 
 /// @brief Called when the playback information of the media controller server is updated.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
@@ -7146,16 +7460,6 @@ typedef Dartmc_shuffle_mode_updated_cbFunction = void Function(
     int mode,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the shuffle mode.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_shuffle_mode_e {
-  /// < Shuffle mode on
-  static const int MC_SHUFFLE_MODE_ON = 0;
-
-  /// < Shuffle mode off
-  static const int MC_SHUFFLE_MODE_OFF = 1;
-}
-
 /// @brief Called when the repeat mode of the media controller server is updated.
 /// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
 ///
@@ -7180,19 +7484,6 @@ typedef Dartmc_repeat_mode_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int mode,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the repeat mode.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_repeat_mode_e {
-  /// < Repeat mode on for all media
-  static const int MC_REPEAT_MODE_ON = 0;
-
-  /// < Repeat mode off
-  static const int MC_REPEAT_MODE_OFF = 1;
-
-  /// < Repeat mode on for one media (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_REPEAT_MODE_ONE_MEDIA = 2;
-}
 
 /// @brief Called when the playback ability support of the media controller server is updated.
 /// @since_tizen 5.0
@@ -7299,34 +7590,6 @@ typedef Dartmc_ability_support_updated_cbFunction = void Function(
     int support,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the ability.
-/// @since_tizen 5.5
-abstract class mc_ability_e {
-  /// < Shuffle
-  static const int MC_ABILITY_SHUFFLE = 0;
-
-  /// < Repeat
-  static const int MC_ABILITY_REPEAT = 1;
-
-  /// < Playback Position
-  static const int MC_ABILITY_PLAYBACK_POSITION = 2;
-
-  /// < Playlist
-  static const int MC_ABILITY_PLAYLIST = 3;
-
-  /// < Custom command from a client
-  static const int MC_ABILITY_CLIENT_CUSTOM = 4;
-
-  /// < Search
-  static const int MC_ABILITY_SEARCH = 5;
-
-  /// < Subtitles display
-  static const int MC_ABILITY_SUBTITLES = 6;
-
-  /// < 360 content mode display
-  static const int MC_ABILITY_360_MODE = 7;
-}
-
 /// @brief Called when a media controller server's supported items for an ability is updated.
 /// @since_tizen 5.5
 ///
@@ -7416,16 +7679,6 @@ typedef Dartmc_playlist_updated_cbFunction = void Function(
     mc_playlist_h playlist,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the playlist update mode.
-/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
-abstract class mc_playlist_update_mode_e {
-  /// < Create or Update playlist
-  static const int MC_PLAYLIST_UPDATED = 0;
-
-  /// < Remove playlist
-  static const int MC_PLAYLIST_REMOVED = 1;
-}
-
 /// @brief Called when the status of a media controller server's boolean attribute (subtitles or 360 mode) is updated.
 /// @since_tizen 5.5
 ///
@@ -7473,22 +7726,6 @@ typedef Dartmc_display_mode_updated_cbFunction = void Function(
     int mode,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the display mode.
-/// @since_tizen 5.5
-abstract class mc_display_mode_e {
-  /// < Letter box
-  static const int MC_DISPLAY_MODE_LETTER_BOX = 1;
-
-  /// < Origin size
-  static const int MC_DISPLAY_MODE_ORIGIN_SIZE = 2;
-
-  /// < Full-screen
-  static const int MC_DISPLAY_MODE_FULL_SCREEN = 4;
-
-  /// < Cropped full-screen
-  static const int MC_DISPLAY_MODE_CROPPED_FULL = 8;
-}
-
 /// @brief Called when a media controller server's display rotation is updated.
 /// @since_tizen 5.5
 ///
@@ -7511,22 +7748,6 @@ typedef Dartmc_display_rotation_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int rotation,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the display rotation.
-/// @since_tizen 5.5
-abstract class mc_display_rotation_e {
-  /// < Display is not rotated
-  static const int MC_DISPLAY_ROTATION_NONE = 1;
-
-  /// < Display is rotated 90 degrees
-  static const int MC_DISPLAY_ROTATION_90 = 2;
-
-  /// < Display is rotated 180 degrees
-  static const int MC_DISPLAY_ROTATION_180 = 4;
-
-  /// < Display is rotated 270 degrees
-  static const int MC_DISPLAY_ROTATION_270 = 8;
-}
 
 /// @brief Called when receiving custom event of media controller servers.
 /// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
@@ -7563,46 +7784,6 @@ typedef Dartmc_client_custom_event_received_cbFunction = void Function(
     ffi.Pointer<bundle.bundle> data,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the subscription type.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_subscription_type_e {
-  /// < Server state
-  static const int MC_SUBSCRIPTION_TYPE_SERVER_STATE = 0;
-
-  /// < Playback
-  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK = 1;
-
-  /// < Metadata
-  static const int MC_SUBSCRIPTION_TYPE_METADATA = 2;
-
-  /// < Shuffle mode
-  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_MODE = 3;
-
-  /// < Repeat mode
-  static const int MC_SUBSCRIPTION_TYPE_REPEAT_MODE = 4;
-
-  /// < Playlist (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_SUBSCRIPTION_TYPE_PLAYLIST = 5;
-
-  /// < Playback ability (Since 5.0)
-  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK_ABILITY = 6;
-
-  /// < Shuffle ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
-  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_ABILITY = 7;
-
-  /// < Repeat ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
-  static const int MC_SUBSCRIPTION_TYPE_REPEAT_ABILITY = 8;
-
-  /// < Ability support (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT = 9;
-
-  /// < Display mode ability (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_MODE_ABILITY = 10;
-
-  /// < Display rotation ability (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_ROTATION_ABILITY = 11;
-}
-
 /// @brief Called when requesting the list of subscribed servers.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
 ///
@@ -7625,107 +7806,6 @@ typedef mc_subscribed_server_cbFunction = ffi.Bool Function(
     ffi.Pointer<ffi.Char> server_name, ffi.Pointer<ffi.Void> user_data);
 typedef Dartmc_subscribed_server_cbFunction = bool Function(
     ffi.Pointer<ffi.Char> server_name, ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the media playback state.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_playback_states_e {
-  /// < None
-  static const int MC_PLAYBACK_STATE_NONE = 0;
-
-  /// < Playing
-  static const int MC_PLAYBACK_STATE_PLAYING = 1;
-
-  /// < Paused
-  static const int MC_PLAYBACK_STATE_PAUSED = 2;
-
-  /// < Stopped
-  static const int MC_PLAYBACK_STATE_STOPPED = 3;
-
-  /// < Moving to the next item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_MOVING_TO_NEXT = 8;
-
-  /// < Moving to the previous item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_MOVING_TO_PREVIOUS = 9;
-
-  /// < Fast forwarding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_FAST_FORWARDING = 10;
-
-  /// < Rewinding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_REWINDING = 11;
-
-  /// < Connecting (Since 6.0)
-  static const int MC_PLAYBACK_STATE_CONNECTING = 12;
-
-  /// < Buffering (Since 6.0)
-  static const int MC_PLAYBACK_STATE_BUFFERING = 13;
-
-  /// < Error (Since 6.0)
-  static const int MC_PLAYBACK_STATE_ERROR = 14;
-}
-
-/// @brief Enumeration for the content age rating of the content.
-/// @since_tizen 5.0
-abstract class mc_content_age_rating_e {
-  /// < Suitable for all ages
-  static const int MC_CONTENT_RATING_ALL = 0;
-
-  /// < Suitable for ages 1 and up
-  static const int MC_CONTENT_RATING_1_PLUS = 1;
-
-  /// < Suitable for ages 2 and up
-  static const int MC_CONTENT_RATING_2_PLUS = 2;
-
-  /// < Suitable for ages 3 and up
-  static const int MC_CONTENT_RATING_3_PLUS = 3;
-
-  /// < Suitable for ages 4 and up
-  static const int MC_CONTENT_RATING_4_PLUS = 4;
-
-  /// < Suitable for ages 5 and up
-  static const int MC_CONTENT_RATING_5_PLUS = 5;
-
-  /// < Suitable for ages 6 and up
-  static const int MC_CONTENT_RATING_6_PLUS = 6;
-
-  /// < Suitable for ages 7 and up
-  static const int MC_CONTENT_RATING_7_PLUS = 7;
-
-  /// < Suitable for ages 8 and up
-  static const int MC_CONTENT_RATING_8_PLUS = 8;
-
-  /// < Suitable for ages 9 and up
-  static const int MC_CONTENT_RATING_9_PLUS = 9;
-
-  /// < Suitable for ages 10 and up
-  static const int MC_CONTENT_RATING_10_PLUS = 10;
-
-  /// < Suitable for ages 11 and up
-  static const int MC_CONTENT_RATING_11_PLUS = 11;
-
-  /// < Suitable for ages 12 and up
-  static const int MC_CONTENT_RATING_12_PLUS = 12;
-
-  /// < Suitable for ages 13 and up
-  static const int MC_CONTENT_RATING_13_PLUS = 13;
-
-  /// < Suitable for ages 14 and up
-  static const int MC_CONTENT_RATING_14_PLUS = 14;
-
-  /// < Suitable for ages 15 and up
-  static const int MC_CONTENT_RATING_15_PLUS = 15;
-
-  /// < Suitable for ages 16 and up
-  static const int MC_CONTENT_RATING_16_PLUS = 16;
-
-  /// < Suitable for ages 17 and up
-  static const int MC_CONTENT_RATING_17_PLUS = 17;
-
-  /// < Suitable for ages 18 and up
-  static const int MC_CONTENT_RATING_18_PLUS = 18;
-
-  /// < Suitable for ages 19 and up
-  static const int MC_CONTENT_RATING_19_PLUS = 19;
-}
 
 /// @brief Called when requesting the list of created servers.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
@@ -8131,3 +8211,5 @@ typedef Dartmc_server_search_cmd_received_cbFunction = void Function(
     ffi.Pointer<ffi.Char> request_id,
     mc_search_h search,
     ffi.Pointer<ffi.Void> user_data);
+
+const int MEDIA_CONTROLLER_ERROR_CLASS = -50462720;

--- a/lib/src/bindings/7.0/generated_bindings_capi_media_metadata_editor.dart
+++ b/lib/src/bindings/7.0/generated_bindings_capi_media_metadata_editor.dart
@@ -368,9 +368,34 @@ class Tizen70CapiMediaMetadataEditor {
 }
 
 /// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
-/// @brief The handle of media metadata.
+/// @brief The enumerations of media metadata error.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-typedef metadata_editor_h = ffi.Pointer<ffi.Void>;
+abstract class metadata_editor_error_e {
+  /// < Successful
+  static const int METADATA_EDITOR_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int METADATA_EDITOR_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int METADATA_EDITOR_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < File not exist
+  static const int METADATA_EDITOR_ERROR_FILE_EXISTS = -17;
+
+  /// < Permission denied
+  static const int METADATA_EDITOR_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Unsupported type
+  static const int METADATA_EDITOR_ERROR_NOT_SUPPORTED = -1073741822;
+
+  /// < Invalid internal operation
+  static const int METADATA_EDITOR_ERROR_OPERATION_FAILED = -27000831;
+
+  /// < Update not possible (Since 6.0)
+  static const int METADATA_EDITOR_ERROR_METADATA_UPDATE_NOT_POSSIBLE =
+      -27000830;
+}
 
 /// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
 /// @brief The enumerations of attribute.
@@ -415,3 +440,10 @@ abstract class metadata_editor_attr_e {
   /// < Unsynchronized lyric
   static const int METADATA_EDITOR_ATTR_UNSYNCLYRICS = 12;
 }
+
+/// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
+/// @brief The handle of media metadata.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+typedef metadata_editor_h = ffi.Pointer<ffi.Void>;
+
+const int METADATA_EDITOR_ERROR_CLASS = -27000832;

--- a/lib/src/bindings/7.0/generated_bindings_capi_media_metadata_extractor.dart
+++ b/lib/src/bindings/7.0/generated_bindings_capi_media_metadata_extractor.dart
@@ -384,11 +384,27 @@ class Tizen70CapiMediaMetadataExtractor {
 }
 
 /// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
-/// @brief The metadata extractor handle.
+/// @brief Enumeration for metadata extractor error.
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
-typedef metadata_extractor_h = ffi.Pointer<metadata_extractor_s>;
+abstract class metadata_extractor_error_e {
+  /// < Successful
+  static const int METADATA_EXTRACTOR_ERROR_NONE = 0;
 
-final class metadata_extractor_s extends ffi.Opaque {}
+  /// < Invalid parameter
+  static const int METADATA_EXTRACTOR_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int METADATA_EXTRACTOR_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < File does not exist
+  static const int METADATA_EXTRACTOR_ERROR_FILE_EXISTS = -17;
+
+  /// < Permission denied
+  static const int METADATA_EXTRACTOR_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Invalid internal operation
+  static const int METADATA_EXTRACTOR_ERROR_OPERATION_FAILED = -26411007;
+}
 
 /// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
 /// @brief Enumeration for attribute.
@@ -499,3 +515,12 @@ abstract class metadata_extractor_attr_e {
   /// < Flag indicating if the video is a spherical video (Since 3.0)
   static const int METADATA_360 = 34;
 }
+
+final class metadata_extractor_s extends ffi.Opaque {}
+
+/// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
+/// @brief The metadata extractor handle.
+/// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
+typedef metadata_extractor_h = ffi.Pointer<metadata_extractor_s>;
+
+const int METADATA_EXTRACTOR_ERROR_CLASS = -26411008;

--- a/lib/src/bindings/7.0/generated_bindings_capi_media_screen_mirroring.dart
+++ b/lib/src/bindings/7.0/generated_bindings_capi_media_screen_mirroring.dart
@@ -880,29 +880,6 @@ class Tizen70CapiMediaScreenMirroring {
           int Function(scmirroring_sink_h, ffi.Pointer<ffi.Int32>)>();
 }
 
-/// @brief	The handle to the screen mirroring sink.
-/// @since_tizen 2.4
-typedef scmirroring_sink_h = ffi.Pointer<ffi.Void>;
-
-/// @brief Called when each status is changed.
-/// @since_tizen 2.4
-///
-/// @details This callback is called for state and error of screen mirroring sink
-///
-/// @param[in] error     The error code
-/// @param[in] state     The screen mirroring sink state
-/// @param[in] user_data The user data passed from the scmirroring_sink_set_state_cb() function
-///
-/// @pre scmirroring_sink_create()
-///
-/// @see scmirroring_sink_create()
-typedef scmirroring_sink_state_cb
-    = ffi.Pointer<ffi.NativeFunction<scmirroring_sink_state_cbFunction>>;
-typedef scmirroring_sink_state_cbFunction = ffi.Void Function(
-    ffi.Int32 error, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
-typedef Dartscmirroring_sink_state_cbFunction = void Function(
-    int error, int state, ffi.Pointer<ffi.Void> user_data);
-
 /// @brief Enumeration for screen mirroring error.
 /// @since_tizen 2.4
 abstract class scmirroring_error_e {
@@ -957,6 +934,41 @@ abstract class scmirroring_sink_state_e {
   static const int SCMIRRORING_SINK_STATE_MAX = 7;
 }
 
+/// @brief Enumeration for screen mirroring resolution.
+/// @since_tizen 2.4
+abstract class scmirroring_resolution_e {
+  static const int SCMIRRORING_RESOLUTION_UNKNOWN = 0;
+
+  /// < W-1920, H-1080, 30 fps
+  static const int SCMIRRORING_RESOLUTION_1920x1080_P30 = 1;
+
+  /// < W-1280, H-720, 30 fps
+  static const int SCMIRRORING_RESOLUTION_1280x720_P30 = 2;
+
+  /// < W-960, H-540, 30 fps
+  static const int SCMIRRORING_RESOLUTION_960x540_P30 = 4;
+
+  /// < W-864, H-480, 30 fps
+  static const int SCMIRRORING_RESOLUTION_864x480_P30 = 8;
+
+  /// < W-720, H-480, 30 fps
+  static const int SCMIRRORING_RESOLUTION_720x480_P60 = 16;
+
+  /// < W-640, H-480, 60 fps
+  static const int SCMIRRORING_RESOLUTION_640x480_P60 = 32;
+
+  /// < W-640, H-360, 30 fps
+  static const int SCMIRRORING_RESOLUTION_640x360_P30 = 64;
+  static const int SCMIRRORING_RESOLUTION_MAX = 128;
+}
+
+/// @brief Ability to send to multisink.
+/// @since_tizen 3.0
+abstract class scmirroring_multisink_e {
+  static const int SCMIRRORING_MULTISINK_DISABLE = 0;
+  static const int SCMIRRORING_MULTISINK_ENABLE = 1;
+}
+
 /// @brief Enumeration for screen mirroring display surface type.
 /// @since_tizen 2.4
 abstract class scmirroring_display_type_e {
@@ -966,16 +978,6 @@ abstract class scmirroring_display_type_e {
   /// < Use Evas pixmap surface to display streaming multimedia data
   static const int SCMIRRORING_DISPLAY_TYPE_EVAS = 1;
   static const int SCMIRRORING_DISPLAY_TYPE_MAX = 2;
-}
-
-/// @brief Enumeration for screen mirroring video codec.
-/// @since_tizen 2.4
-abstract class scmirroring_video_codec_e {
-  /// < Screen mirroring is not negotiated yet
-  static const int SCMIRRORING_VIDEO_CODEC_NONE = 0;
-
-  /// < H.264 codec for video
-  static const int SCMIRRORING_VIDEO_CODEC_H264 = 1;
 }
 
 /// @brief Enumeration for screen mirroring audio codec.
@@ -993,3 +995,56 @@ abstract class scmirroring_audio_codec_e {
   /// < LPCM codec for audio
   static const int SCMIRRORING_AUDIO_CODEC_LPCM = 3;
 }
+
+/// @brief Enumeration for screen mirroring video codec.
+/// @since_tizen 2.4
+abstract class scmirroring_video_codec_e {
+  /// < Screen mirroring is not negotiated yet
+  static const int SCMIRRORING_VIDEO_CODEC_NONE = 0;
+
+  /// < H.264 codec for video
+  static const int SCMIRRORING_VIDEO_CODEC_H264 = 1;
+}
+
+/// @brief Enumeration for screen mirroring direct streaming mode.
+/// @since_tizen 3.0
+abstract class scmirroring_direct_streaming_e {
+  /// < Disable screen mirroring direct streaming mode
+  static const int SCMIRRORING_DIRECT_STREAMING_DISABLED = 0;
+
+  /// < Enable direct streaming for files
+  static const int SCMIRRORING_DIRECT_STREAMING_ENABLED = 1;
+}
+
+/// @brief Enumeration for screen mirroring AV streaming transport.
+/// @since_tizen 3.0
+abstract class scmirroring_av_transport_e {
+  /// < UDP transport for AV streaming data
+  static const int SCMIRRORING_AV_TRANSPORT_UDP = 0;
+
+  /// < TCP transport for AV streaming data
+  static const int SCMIRRORING_AV_TRANSPORT_TCP = 1;
+}
+
+/// @brief	The handle to the screen mirroring sink.
+/// @since_tizen 2.4
+typedef scmirroring_sink_h = ffi.Pointer<ffi.Void>;
+
+/// @brief Called when each status is changed.
+/// @since_tizen 2.4
+///
+/// @details This callback is called for state and error of screen mirroring sink
+///
+/// @param[in] error     The error code
+/// @param[in] state     The screen mirroring sink state
+/// @param[in] user_data The user data passed from the scmirroring_sink_set_state_cb() function
+///
+/// @pre scmirroring_sink_create()
+///
+/// @see scmirroring_sink_create()
+typedef scmirroring_sink_state_cb
+    = ffi.Pointer<ffi.NativeFunction<scmirroring_sink_state_cbFunction>>;
+typedef scmirroring_sink_state_cbFunction = ffi.Void Function(
+    ffi.Int32 error, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
+typedef Dartscmirroring_sink_state_cbFunction = void Function(
+    int error, int state, ffi.Pointer<ffi.Void> user_data);

--- a/lib/src/bindings/7.0/generated_bindings_capi_media_sound_pool.dart
+++ b/lib/src/bindings/7.0/generated_bindings_capi_media_sound_pool.dart
@@ -865,10 +865,52 @@ class Tizen70CapiMediaSoundPool {
       .asFunction<int Function(sound_pool_h, int, ffi.Pointer<ffi.Int32>)>();
 }
 
-/// @brief Sound pool handle type.
+/// @brief Enumeration for Tizen Sound Pool error.
 ///
 /// @since_tizen 4.0
-typedef sound_pool_h = ffi.Pointer<ffi.Void>;
+abstract class sound_pool_error_e {
+  static const int SOUND_POOL_ERROR_NONE = 0;
+  static const int SOUND_POOL_ERROR_KEY_NOT_AVAILABLE = -126;
+  static const int SOUND_POOL_ERROR_OUT_OF_MEMORY = -12;
+  static const int SOUND_POOL_ERROR_INVALID_PARAMETER = -22;
+  static const int SOUND_POOL_ERROR_INVALID_OPERATION = -38;
+  static const int SOUND_POOL_ERROR_NOT_PERMITTED = -1;
+  static const int SOUND_POOL_ERROR_NO_SUCH_FILE = -2;
+}
+
+/// @brief Enumeration of sound pool stream state.
+///
+/// @since_tizen 4.0
+abstract class sound_pool_stream_state_e {
+  /// < Stream state isn't determined
+  static const int SOUND_POOL_STREAM_STATE_NONE = 0;
+
+  /// < Stream state is playing
+  static const int SOUND_POOL_STREAM_STATE_PLAYING = 1;
+
+  /// < Stream state is paused
+  static const int SOUND_POOL_STREAM_STATE_PAUSED = 2;
+
+  /// < Stream state is stopped
+  static const int SOUND_POOL_STREAM_STATE_STOPPED = 3;
+
+  /// < Stream state is finished
+  static const int SOUND_POOL_STREAM_STATE_FINISHED = 4;
+
+  /// < Stream state is suspended
+  static const int SOUND_POOL_STREAM_STATE_SUSPENDED = 5;
+}
+
+/// @brief Enumeration of sound pool stream priority policy.
+///
+/// @since_tizen 4.0
+abstract class sound_pool_stream_priority_policy_e {
+  /// < Stream priority policy is mute
+  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_MUTE = 0;
+
+  /// < Stream priority policy is suspended
+  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_SUSPENDED = 1;
+}
 
 /// @brief Enumeration of sound pool state.
 ///
@@ -880,6 +922,11 @@ abstract class sound_pool_state_e {
   /// < Sound pool inactive state: streams can't be played
   static const int SOUND_POOL_STATE_INACTIVE = 1;
 }
+
+/// @brief Sound pool handle type.
+///
+/// @since_tizen 4.0
+typedef sound_pool_h = ffi.Pointer<ffi.Void>;
 
 /// @brief Called when the sound pool state is changed.
 ///
@@ -910,17 +957,6 @@ typedef Dartsound_pool_state_changed_cbFunction = void Function(
     int prev_state,
     int cur_state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration of sound pool stream priority policy.
-///
-/// @since_tizen 4.0
-abstract class sound_pool_stream_priority_policy_e {
-  /// < Stream priority policy is mute
-  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_MUTE = 0;
-
-  /// < Stream priority policy is suspended
-  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_SUSPENDED = 1;
-}
 
 /// @brief Called when the sound pool stream state is changed.
 ///
@@ -954,26 +990,3 @@ typedef Dartsound_pool_stream_state_changed_cbFunction = void Function(
     int prev_state,
     int cur_state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration of sound pool stream state.
-///
-/// @since_tizen 4.0
-abstract class sound_pool_stream_state_e {
-  /// < Stream state isn't determined
-  static const int SOUND_POOL_STREAM_STATE_NONE = 0;
-
-  /// < Stream state is playing
-  static const int SOUND_POOL_STREAM_STATE_PLAYING = 1;
-
-  /// < Stream state is paused
-  static const int SOUND_POOL_STREAM_STATE_PAUSED = 2;
-
-  /// < Stream state is stopped
-  static const int SOUND_POOL_STREAM_STATE_STOPPED = 3;
-
-  /// < Stream state is finished
-  static const int SOUND_POOL_STREAM_STATE_FINISHED = 4;
-
-  /// < Stream state is suspended
-  static const int SOUND_POOL_STREAM_STATE_SUSPENDED = 5;
-}

--- a/lib/src/bindings/7.0/generated_bindings_capi_media_thumbnail_util.dart
+++ b/lib/src/bindings/7.0/generated_bindings_capi_media_thumbnail_util.dart
@@ -380,12 +380,38 @@ class Tizen70CapiMediaThumbnailUtil {
 }
 
 /// @ingroup CAPI_MEDIA_THUMBNAIL_UTIL_MODULE
+/// @brief Enumeration for a thumbnail util error.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class thumbnail_util_error_e {
+  /// < Successful
+  static const int THUMBNAIL_UTIL_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int THUMBNAIL_UTIL_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int THUMBNAIL_UTIL_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Invalid Operation
+  static const int THUMBNAIL_UTIL_ERROR_INVALID_OPERATION = -38;
+
+  /// < No space left on device
+  static const int THUMBNAIL_UTIL_ERROR_FILE_NO_SPACE_ON_DEVICE = -28;
+
+  /// < Permission denied
+  static const int THUMBNAIL_UTIL_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Unsupported Content (Since 4.0)
+  static const int THUMBNAIL_UTIL_ERROR_UNSUPPORTED_CONTENT = -49872895;
+}
+
+final class thumbnail_s extends ffi.Opaque {}
+
+/// @ingroup CAPI_MEDIA_THUMBNAIL_UTIL_MODULE
 /// @deprecated Deprecated since 5.0.
 /// @brief The structure type for the thumbnail info handle.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
 typedef thumbnail_h = ffi.Pointer<thumbnail_s>;
-
-final class thumbnail_s extends ffi.Opaque {}
 
 /// @ingroup CAPI_MEDIA_THUMBNAIL_UTIL_MODULE
 /// @deprecated Deprecated since 5.0.
@@ -431,28 +457,4 @@ typedef Dartthumbnail_extracted_cbFunction = void Function(
     int thumb_size,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_MEDIA_THUMBNAIL_UTIL_MODULE
-/// @brief Enumeration for a thumbnail util error.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class thumbnail_util_error_e {
-  /// < Successful
-  static const int THUMBNAIL_UTIL_ERROR_NONE = 0;
-
-  /// < Invalid parameter
-  static const int THUMBNAIL_UTIL_ERROR_INVALID_PARAMETER = -22;
-
-  /// < Out of memory
-  static const int THUMBNAIL_UTIL_ERROR_OUT_OF_MEMORY = -12;
-
-  /// < Invalid Operation
-  static const int THUMBNAIL_UTIL_ERROR_INVALID_OPERATION = -38;
-
-  /// < No space left on device
-  static const int THUMBNAIL_UTIL_ERROR_FILE_NO_SPACE_ON_DEVICE = -28;
-
-  /// < Permission denied
-  static const int THUMBNAIL_UTIL_ERROR_PERMISSION_DENIED = -13;
-
-  /// < Unsupported Content (Since 4.0)
-  static const int THUMBNAIL_UTIL_ERROR_UNSUPPORTED_CONTENT = -49872895;
-}
+const int THUMBNAIL_UTIL_ERROR_CLASS = -49872896;

--- a/lib/src/bindings/7.0/generated_bindings_capi_network_bluetooth.dart
+++ b/lib/src/bindings/7.0/generated_bindings_capi_network_bluetooth.dart
@@ -10162,6 +10162,185 @@ class Tizen70CapiNetworkBluetooth {
       _bt_socket_reject_l2cap_channelPtr.asFunction<int Function(int)>();
 }
 
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of PBAP fields.
+/// @since_tizen 3.0
+abstract class bt_pbap_field_e {
+  /// < All field
+  static const int BT_PBAP_FIELD_ALL = -1;
+
+  /// < vCard Version
+  static const int BT_PBAP_FIELD_VERSION = 1;
+
+  /// < Formatted Name
+  static const int BT_PBAP_FIELD_FN = 2;
+
+  /// < Structured Presentation of Name
+  static const int BT_PBAP_FIELD_N = 4;
+
+  /// < Associated Image or Photo
+  static const int BT_PBAP_FIELD_PHOTO = 8;
+
+  /// < Birthday
+  static const int BT_PBAP_FIELD_BDAY = 16;
+
+  /// < Delivery Address
+  static const int BT_PBAP_FIELD_ADR = 32;
+
+  /// < Delivery
+  static const int BT_PBAP_FIELD_LABEL = 64;
+
+  /// < Telephone Number
+  static const int BT_PBAP_FIELD_TEL = 128;
+
+  /// < Electronic Mail Address
+  static const int BT_PBAP_FIELD_EMAIL = 256;
+
+  /// < Electronic Mail
+  static const int BT_PBAP_FIELD_MAILER = 512;
+
+  /// < Time Zone
+  static const int BT_PBAP_FIELD_TZ = 1024;
+
+  /// < Geographic Position
+  static const int BT_PBAP_FIELD_GEO = 2048;
+
+  /// < Job
+  static const int BT_PBAP_FIELD_TITLE = 4096;
+
+  /// < Role within the Organization
+  static const int BT_PBAP_FIELD_ROLE = 8192;
+
+  /// < Organization Logo
+  static const int BT_PBAP_FIELD_LOGO = 16384;
+
+  /// < vCard of Person Representing
+  static const int BT_PBAP_FIELD_AGENT = 32768;
+
+  /// < Name of Organization
+  static const int BT_PBAP_FIELD_ORG = 65536;
+
+  /// < Comments
+  static const int BT_PBAP_FIELD_NOTE = 131072;
+
+  /// < Revision
+  static const int BT_PBAP_FIELD_REV = 262144;
+
+  /// < Pronunciation of Name
+  static const int BT_PBAP_FIELD_SOUND = 524288;
+
+  /// < Uniform Resource Locator
+  static const int BT_PBAP_FIELD_URL = 1048576;
+
+  /// < Unique ID
+  static const int BT_PBAP_FIELD_UID = 2097152;
+
+  /// < Public Encryption Key
+  static const int BT_PBAP_FIELD_KEY = 4194304;
+
+  /// < Nickname
+  static const int BT_PBAP_FIELD_NICKNAME = 8388608;
+
+  /// < Categories
+  static const int BT_PBAP_FIELD_CATEGORIES = 16777216;
+
+  /// < Product ID
+  static const int BT_PBAP_FIELD_PROID = 33554432;
+
+  /// < Class information
+  static const int BT_PBAP_FIELD_CLASS = 67108864;
+
+  /// < String used for sorting operations
+  static const int BT_PBAP_FIELD_SORT_STRING = 134217728;
+
+  /// < Time stamp
+  static const int BT_PBAP_FIELD_X_IRMC_CALL_DATETIME = 268435456;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_MODULE
+/// @brief Enumerations of Bluetooth error codes.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_error_e {
+  /// < Successful
+  static const int BT_ERROR_NONE = 0;
+
+  /// < Operation cancelled
+  static const int BT_ERROR_CANCELLED = -125;
+
+  /// < Invalid parameter
+  static const int BT_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int BT_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Device or resource busy
+  static const int BT_ERROR_RESOURCE_BUSY = -16;
+
+  /// < Timeout error
+  static const int BT_ERROR_TIMED_OUT = -1073741823;
+
+  /// < Operation now in progress
+  static const int BT_ERROR_NOW_IN_PROGRESS = -115;
+
+  /// < BT is Not Supported
+  static const int BT_ERROR_NOT_SUPPORTED = -1073741822;
+
+  /// < Permission denied
+  static const int BT_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Quota exceeded
+  static const int BT_ERROR_QUOTA_EXCEEDED = -122;
+
+  /// < No data available
+  static const int BT_ERROR_NO_DATA = -61;
+
+  /// < Device policy restriction (Since 3.0)
+  static const int BT_ERROR_DEVICE_POLICY_RESTRICTION = -1073741820;
+
+  /// < Local adapter not initialized
+  static const int BT_ERROR_NOT_INITIALIZED = -29359871;
+
+  /// < Local adapter not enabled
+  static const int BT_ERROR_NOT_ENABLED = -29359870;
+
+  /// < Operation already done
+  static const int BT_ERROR_ALREADY_DONE = -29359869;
+
+  /// < Operation failed
+  static const int BT_ERROR_OPERATION_FAILED = -29359868;
+
+  /// < Operation not in progress
+  static const int BT_ERROR_NOT_IN_PROGRESS = -29359867;
+
+  /// < Remote device not bonded
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_BONDED = -29359866;
+
+  /// < Authentication rejected
+  static const int BT_ERROR_AUTH_REJECTED = -29359865;
+
+  /// < Authentication failed
+  static const int BT_ERROR_AUTH_FAILED = -29359864;
+
+  /// < Remote device not found
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_FOUND = -29359863;
+
+  /// < Service search failed
+  static const int BT_ERROR_SERVICE_SEARCH_FAILED = -29359862;
+
+  /// < Remote device is not connected
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_CONNECTED = -29359861;
+
+  /// < Resource temporarily unavailable
+  static const int BT_ERROR_AGAIN = -29359860;
+
+  /// < Service Not Found
+  static const int BT_ERROR_SERVICE_NOT_FOUND = -29359859;
+
+  /// < Authorization rejected (Since 5.0)
+  static const int BT_ERROR_AUTHORIZATION_REJECTED = -29359858;
+}
+
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
 /// @brief  Enumerations of the Bluetooth adapter state.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
@@ -10186,6 +10365,178 @@ abstract class bt_adapter_visibility_mode_e {
   /// < Discoverable mode with time limit. After specific period,
   /// it is changed to #BT_ADAPTER_VISIBILITY_MODE_NON_DISCOVERABLE.
   static const int BT_ADAPTER_VISIBILITY_MODE_LIMITED_DISCOVERABLE = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief Enumerations of the discovery state of Bluetooth device.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_device_discovery_state_e {
+  /// < Device discovery is started
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_STARTED = 0;
+
+  /// < Device discovery is finished
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_FINISHED = 1;
+
+  /// < The remote Bluetooth device is found
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_FOUND = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising state.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_le_advertising_state_e {
+  /// < Bluetooth advertising is stopped
+  static const int BT_ADAPTER_LE_ADVERTISING_STOPPED = 0;
+
+  /// < Bluetooth advertising is started
+  static const int BT_ADAPTER_LE_ADVERTISING_STARTED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising mode.
+/// @since_tizen 2.3.1
+abstract class bt_adapter_le_advertising_mode_e {
+  /// < Balanced advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_BALANCED = 0;
+
+  /// < Low latency advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_LATENCY = 1;
+
+  /// < Low energy advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_ENERGY = 2;
+
+  /// < Custom mode to set advertising parameters
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_CUSTOM = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising filter policy.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_le_advertising_filter_policy_e {
+  /// < White list is not in use
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_DEFAULT = 0;
+
+  /// < Allow the scan
+  /// request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_SCAN_WL = 1;
+
+  /// < Allow the connection
+  /// request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_CONN_WL = 2;
+
+  /// < Allow the
+  /// scan and connection request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_SCAN_CONN_WL = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth LE packet type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_le_packet_type_e {
+  /// < Advertising packet
+  static const int BT_ADAPTER_LE_PACKET_ADVERTISING = 0;
+
+  /// < Scan response packet
+  static const int BT_ADAPTER_LE_PACKET_SCAN_RESPONSE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth le scan mode.
+/// @since_tizen 3.0
+abstract class bt_adapter_le_scan_mode_e {
+  /// < Balanced mode of power consumption and connection latency
+  static const int BT_ADAPTER_LE_SCAN_MODE_BALANCED = 0;
+
+  /// < Low connection latency but high power consumption
+  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_LATENCY = 1;
+
+  /// < Low power consumption but high connection latency
+  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_ENERGY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device disconnect reason.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_disconnect_reason_e {
+  /// < Disconnected by unknown reason
+  static const int BT_DEVICE_DISCONNECT_REASON_UNKNOWN = 0;
+
+  /// < Disconnected by timeout
+  static const int BT_DEVICE_DISCONNECT_REASON_TIMEOUT = 1;
+
+  /// < Disconnected by local host
+  static const int BT_DEVICE_DISCONNECT_REASON_LOCAL_HOST = 2;
+
+  /// < Disconnected by remote
+  static const int BT_DEVICE_DISCONNECT_REASON_REMOTE = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of connection link type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_connection_link_type_e {
+  /// < BR/EDR link
+  static const int BT_DEVICE_CONNECTION_LINK_BREDR = 0;
+
+  /// < LE link
+  static const int BT_DEVICE_CONNECTION_LINK_LE = 1;
+
+  /// < The connection type default
+  static const int BT_DEVICE_CONNECTION_LINK_DEFAULT = 255;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device authorization state.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_authorization_e {
+  /// < The remote Bluetooth device is authorized
+  static const int BT_DEVICE_AUTHORIZED = 0;
+
+  /// < The remote Bluetooth device is unauthorized
+  static const int BT_DEVICE_UNAUTHORIZED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of Bluetooth profile.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_profile_e {
+  /// < RFCOMM Profile
+  static const int BT_PROFILE_RFCOMM = 1;
+
+  /// < Advanced Audio Distribution Profile Source role
+  static const int BT_PROFILE_A2DP = 2;
+
+  /// < Headset Profile
+  static const int BT_PROFILE_HSP = 4;
+
+  /// < Human Interface Device Profile
+  static const int BT_PROFILE_HID = 8;
+
+  /// < Network Access Point Profile
+  static const int BT_PROFILE_NAP = 16;
+
+  /// < Audio Gateway Profile
+  static const int BT_PROFILE_AG = 32;
+
+  /// < Generic Attribute Profile
+  static const int BT_PROFILE_GATT = 64;
+
+  /// < NAP server Profile
+  static const int BT_PROFILE_NAP_SERVER = 128;
+
+  /// < Advanced Audio Distribution Profile Sink role
+  static const int BT_PROFILE_A2DP_SINK = 256;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device address type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_address_type_e {
+  /// < Public address
+  static const int BT_DEVICE_PUBLIC_ADDRESS = 0;
+
+  /// < Random address
+  static const int BT_DEVICE_RANDOM_ADDRESS = 1;
 }
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
@@ -10271,88 +10622,36 @@ abstract class bt_service_class_t {
   static const int BT_SC_MAX = 16777216;
 }
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief  Called when you get bonded devices repeatedly.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @param[in] device_info The bonded device information
-/// @param[in] user_data The user data passed from the foreach function
-/// @return @c true to continue with the next iteration of the loop,
-/// \n @c false to break out of the loop.
-/// @pre bt_adapter_foreach_bonded_device() will invoke this function.
-///
-/// @see bt_adapter_foreach_bonded_device()
-typedef bt_adapter_bonded_device_cb
-    = ffi.Pointer<ffi.NativeFunction<bt_adapter_bonded_device_cbFunction>>;
-typedef bt_adapter_bonded_device_cbFunction = ffi.Bool Function(
-    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
-typedef Dartbt_adapter_bonded_device_cbFunction = bool Function(
-    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Device information structure used for identifying pear device.
+/// @brief  Enumerations of major service class.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see #bt_class_s
-/// @see bt_device_bond_created_cb()
-final class bt_device_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
+abstract class bt_major_service_class_e {
+  /// < Limited discoverable mode
+  static const int BT_MAJOR_SERVICE_CLASS_LIMITED_DISCOVERABLE_MODE = 8192;
 
-  /// < The name of remote device
-  external ffi.Pointer<ffi.Char> remote_name;
+  /// < Positioning class
+  static const int BT_MAJOR_SERVICE_CLASS_POSITIONING = 65536;
 
-  /// < The Bluetooth classes
-  external bt_class_s bt_class;
+  /// < Networking class
+  static const int BT_MAJOR_SERVICE_CLASS_NETWORKING = 131072;
 
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+  /// < Rendering class
+  static const int BT_MAJOR_SERVICE_CLASS_RENDERING = 262144;
 
-  /// < The number of services
-  @ffi.Int()
-  external int service_count;
+  /// < Capturing class
+  static const int BT_MAJOR_SERVICE_CLASS_CAPTURING = 524288;
 
-  /// < The bonding state
-  @ffi.Bool()
-  external bool is_bonded;
+  /// < Object transferring class
+  static const int BT_MAJOR_SERVICE_CLASS_OBJECT_TRANSFER = 1048576;
 
-  /// < The connection state
-  @ffi.Bool()
-  external bool is_connected;
+  /// < Audio class
+  static const int BT_MAJOR_SERVICE_CLASS_AUDIO = 2097152;
 
-  /// < The authorization state
-  @ffi.Bool()
-  external bool is_authorized;
+  /// < Telephony class
+  static const int BT_MAJOR_SERVICE_CLASS_TELEPHONY = 4194304;
 
-  /// < manufacturer specific data length
-  @ffi.Int()
-  external int manufacturer_data_len;
-
-  /// < manufacturer specific data
-  external ffi.Pointer<ffi.Char> manufacturer_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Class structure of device and service.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see #bt_device_info_s
-/// @see #bt_adapter_device_discovery_info_s
-/// @see bt_device_bond_created_cb()
-/// @see bt_adapter_device_discovery_state_changed_cb()
-final class bt_class_s extends ffi.Struct {
-  /// < Major device class.
-  @ffi.Int32()
-  external int major_device_class;
-
-  /// < Minor device class.
-  @ffi.Int32()
-  external int minor_device_class;
-
-  /// < Major service class mask.
-  /// This value can be a combination of #bt_major_service_class_e like #BT_MAJOR_SERVICE_CLASS_RENDERING | #BT_MAJOR_SERVICE_CLASS_AUDIO
-  @ffi.Int()
-  external int major_service_class_mask;
+  /// < Information class
+  static const int BT_MAJOR_SERVICE_CLASS_INFORMATION = 8388608;
 }
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
@@ -10653,6 +10952,998 @@ abstract class bt_minor_device_class_e {
   static const int BT_MINOR_DEVICE_CLASS_HEALTH_ANKLE_PROSTHESIS = 52;
 }
 
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief  Enumerations of gap appearance type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_appearance_type_e {
+  /// < Unknown appearance type
+  static const int BT_APPEARANCE_TYPE_UNKNOWN = 0;
+
+  /// < Generic Phone type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_PHONE = 64;
+
+  /// < Generic Computer type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_COMPUTER = 128;
+
+  /// < Generic Watch type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_WATCH = 192;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief  Enumerations of the Bluetooth device's LE connection mode.
+/// @since_tizen 3.0
+abstract class bt_device_le_connection_mode_e {
+  /// < Balanced mode of power consumption and connection latency
+  static const int BT_DEVICE_LE_CONNECTION_MODE_BALANCED = 0;
+
+  /// < Low connection latency but high power consumption
+  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_LATENCY = 1;
+
+  /// < Low power consumption but high connection latency
+  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_ENERGY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief  Enumerations of connected Bluetooth device event role.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_socket_role_e {
+  /// < Unknown role
+  static const int BT_SOCKET_UNKNOWN = 0;
+
+  /// < Server role
+  static const int BT_SOCKET_SERVER = 1;
+
+  /// < Client role
+  static const int BT_SOCKET_CLIENT = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief  Enumerations of Bluetooth socket connection state.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_socket_connection_state_e {
+  /// < RFCOMM is connected
+  static const int BT_SOCKET_CONNECTED = 0;
+
+  /// < RFCOMM is disconnected
+  static const int BT_SOCKET_DISCONNECTED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
+/// @brief  Enumerations for the types of profiles related with audio.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_audio_profile_type_e {
+  /// < All supported profiles related with audio (Both Host and Device role)
+  static const int BT_AUDIO_PROFILE_TYPE_ALL = 0;
+
+  /// < local device AG and remote device HF Client (Host role, ex: mobile)
+  static const int BT_AUDIO_PROFILE_TYPE_HSP_HFP = 1;
+
+  /// < A2DP Source Connection, remote device is A2DP Sink (Host role, ex: mobile)
+  static const int BT_AUDIO_PROFILE_TYPE_A2DP = 2;
+
+  /// < local device HF Client and remote device AG (Device role, ex: headset)
+  static const int BT_AUDIO_PROFILE_TYPE_AG = 3;
+
+  /// < A2DP Sink Connection, remote device is A2DP Source (Device role, ex: headset)
+  static const int BT_AUDIO_PROFILE_TYPE_A2DP_SINK = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_AG_MODULE
+/// @brief  Enumerations for the call handling event.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_ag_call_handling_event_e {
+  /// < Request to answer an incoming call
+  static const int BT_AG_CALL_HANDLING_EVENT_ANSWER = 0;
+
+  /// < Request to release a call
+  static const int BT_AG_CALL_HANDLING_EVENT_RELEASE = 1;
+
+  /// < Request to reject an incoming call
+  static const int BT_AG_CALL_HANDLING_EVENT_REJECT = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_AG_MODULE
+/// @brief  Enumerations for the multi call handling event.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_ag_multi_call_handling_event_e {
+  /// < Request to release held calls
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_RELEASE_HELD_CALLS = 0;
+
+  /// < Request to release active calls
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_RELEASE_ACTIVE_CALLS = 1;
+
+  /// < Request to put active calls into hold state and activate another (held or waiting) call
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_ACTIVATE_HELD_CALL = 2;
+
+  /// < Request to add a held call to the conversation
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_MERGE_CALLS = 3;
+
+  /// < Request to let a user who has two calls to connect these two calls together and release its connections to both other parties
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_EXPLICIT_CALL_TRANSFER = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the equalizer state.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_equalizer_state_e {
+  /// < Equalizer Off
+  static const int BT_AVRCP_EQUALIZER_STATE_OFF = 1;
+
+  /// < Equalizer On
+  static const int BT_AVRCP_EQUALIZER_STATE_ON = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the repeat mode.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_repeat_mode_e {
+  /// < Repeat Off
+  static const int BT_AVRCP_REPEAT_MODE_OFF = 1;
+
+  /// < Single track repeat
+  static const int BT_AVRCP_REPEAT_MODE_SINGLE_TRACK = 2;
+
+  /// < All track repeat
+  static const int BT_AVRCP_REPEAT_MODE_ALL_TRACK = 3;
+
+  /// < Group repeat
+  static const int BT_AVRCP_REPEAT_MODE_GROUP = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the shuffle mode.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_shuffle_mode_e {
+  /// < Shuffle Off
+  static const int BT_AVRCP_SHUFFLE_MODE_OFF = 1;
+
+  /// < All tracks shuffle
+  static const int BT_AVRCP_SHUFFLE_MODE_ALL_TRACK = 2;
+
+  /// < Group shuffle
+  static const int BT_AVRCP_SHUFFLE_MODE_GROUP = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the scan mode.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_scan_mode_e {
+  /// < Scan Off
+  static const int BT_AVRCP_SCAN_MODE_OFF = 1;
+
+  /// < All tracks scan
+  static const int BT_AVRCP_SCAN_MODE_ALL_TRACK = 2;
+
+  /// < Group scan
+  static const int BT_AVRCP_SCAN_MODE_GROUP = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the player state.
+/// @since_tizen 3.0
+abstract class bt_avrcp_player_state_e {
+  /// < Stopped
+  static const int BT_AVRCP_PLAYER_STATE_STOPPED = 0;
+
+  /// < Playing
+  static const int BT_AVRCP_PLAYER_STATE_PLAYING = 1;
+
+  /// < Paused
+  static const int BT_AVRCP_PLAYER_STATE_PAUSED = 2;
+
+  /// < Seek Forward
+  static const int BT_AVRCP_PLAYER_STATE_FORWARD_SEEK = 3;
+
+  /// < Seek Rewind
+  static const int BT_AVRCP_PLAYER_STATE_REWIND_SEEK = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumeration for the player control commands.
+/// @since_tizen 3.0
+abstract class bt_avrcp_player_command_e {
+  /// < Play
+  static const int BT_AVRCP_CONTROL_PLAY = 1;
+
+  /// < Pause
+  static const int BT_AVRCP_CONTROL_PAUSE = 2;
+
+  /// < Stop
+  static const int BT_AVRCP_CONTROL_STOP = 3;
+
+  /// < Next Track
+  static const int BT_AVRCP_CONTROL_NEXT = 4;
+
+  /// < Previous track
+  static const int BT_AVRCP_CONTROL_PREVIOUS = 5;
+
+  /// < Fast Forward
+  static const int BT_AVRCP_CONTROL_FAST_FORWARD = 6;
+
+  /// < Rewind
+  static const int BT_AVRCP_CONTROL_REWIND = 7;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief Structure of Track metadata information.
+/// @since_tizen 3.0
+///
+/// @see #bt_class_s
+final class bt_avrcp_metadata_attributes_info_s extends ffi.Struct {
+  /// < Title
+  external ffi.Pointer<ffi.Char> title;
+
+  /// < Artist
+  external ffi.Pointer<ffi.Char> artist;
+
+  /// < Album name
+  external ffi.Pointer<ffi.Char> album;
+
+  /// < Album Genre
+  external ffi.Pointer<ffi.Char> genre;
+
+  /// < The total number of tracks
+  @ffi.UnsignedInt()
+  external int total_tracks;
+
+  /// < Track number
+  @ffi.UnsignedInt()
+  external int number;
+
+  /// < Duration
+  @ffi.UnsignedInt()
+  external int duration;
+}
+
+/// @deprecated Deprecated since 5.0.
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
+/// @brief  Enumerations for the data channel type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+/// @remarks Deprecated, because of no usecase and supported devices.
+abstract class bt_hdp_channel_type_e {
+  /// < Reliable Data Channel
+  static const int BT_HDP_CHANNEL_TYPE_RELIABLE = 1;
+
+  /// < Streaming Data Channel
+  static const int BT_HDP_CHANNEL_TYPE_STREAMING = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the integer type for GATT handle's value.
+/// @since_tizen 2.3.1
+abstract class bt_data_type_int_e {
+  /// < 8 bit signed int type
+  static const int BT_DATA_TYPE_SINT8 = 0;
+
+  /// < 16 bit signed int type
+  static const int BT_DATA_TYPE_SINT16 = 1;
+
+  /// < 32 bit signed int type
+  static const int BT_DATA_TYPE_SINT32 = 2;
+
+  /// < 8 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT8 = 3;
+
+  /// < 16 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT16 = 4;
+
+  /// < 32 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT32 = 5;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the float type for GATT handle's value.
+/// @since_tizen 2.3.1
+abstract class bt_data_type_float_e {
+  /// < 32 bit float type
+  static const int BT_DATA_TYPE_FLOAT = 0;
+
+  /// < 16 bit float type
+  static const int BT_DATA_TYPE_SFLOAT = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the write type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_write_type_e {
+  /// < Write without response type
+  static const int BT_GATT_WRITE_TYPE_WRITE_NO_RESPONSE = 0;
+
+  /// < Write type
+  static const int BT_GATT_WRITE_TYPE_WRITE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the GATT handle's type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_type_e {
+  /// < GATT service type
+  static const int BT_GATT_TYPE_SERVICE = 1;
+
+  /// < GATT characteristic type
+  static const int BT_GATT_TYPE_CHARACTERISTIC = 2;
+
+  /// < GATT descriptor type
+  static const int BT_GATT_TYPE_DESCRIPTOR = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the service type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_service_type_e {
+  /// < GATT primary service type
+  static const int BT_GATT_SERVICE_TYPE_PRIMARY = 1;
+
+  /// < GATT secondary service type
+  static const int BT_GATT_SERVICE_TYPE_SECONDARY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the characteristic's property.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_property_e {
+  /// < Broadcast property
+  static const int BT_GATT_PROPERTY_BROADCAST = 1;
+
+  /// < Read property
+  static const int BT_GATT_PROPERTY_READ = 2;
+
+  /// < Write without response property
+  static const int BT_GATT_PROPERTY_WRITE_WITHOUT_RESPONSE = 4;
+
+  /// < Write property
+  static const int BT_GATT_PROPERTY_WRITE = 8;
+
+  /// < Notify property
+  static const int BT_GATT_PROPERTY_NOTIFY = 16;
+
+  /// < Indicate property
+  static const int BT_GATT_PROPERTY_INDICATE = 32;
+
+  /// < Authenticated signed writes property
+  static const int BT_GATT_PROPERTY_AUTHENTICATED_SIGNED_WRITES = 64;
+
+  /// < Extended properties
+  static const int BT_GATT_PROPERTY_EXTENDED_PROPERTIES = 128;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
+/// @brief  Enumerations of gatt server's service changing mode.
+/// @since_tizen 3.0
+abstract class bt_gatt_client_service_change_type_e {
+  /// < Service added
+  static const int BT_GATT_CLIENT_SERVICE_ADDED = 0;
+
+  /// < Service removed
+  static const int BT_GATT_CLIENT_SERVICE_REMOVED = 1;
+
+  /// < Resync is required (Since 6.5)
+  static const int BT_GATT_CLIENT_SERVICE_RESYNC = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the attribute's permission.
+/// @since_tizen 3.0
+abstract class bt_gatt_permission_e {
+  /// < Readable permission
+  static const int BT_GATT_PERMISSION_READ = 1;
+
+  /// < Writable permission
+  static const int BT_GATT_PERMISSION_WRITE = 2;
+
+  /// < Readable permission required encryption
+  static const int BT_GATT_PERMISSION_ENCRYPT_READ = 4;
+
+  /// < Writable permission required encryption
+  static const int BT_GATT_PERMISSION_ENCRYPT_WRITE = 8;
+
+  /// < Readable permission required encryption and authentication
+  static const int BT_GATT_PERMISSION_ENCRYPT_AUTHENTICATED_READ = 16;
+
+  /// < Writable permission required encryption and authentication
+  static const int BT_GATT_PERMISSION_ENCRYPT_AUTHENTICATED_WRITE = 32;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
+/// @brief  Enumerations of the remote device request types for attributes.
+/// @since_tizen 3.0
+abstract class bt_gatt_att_request_type_e {
+  /// < Read Requested
+  static const int BT_GATT_REQUEST_TYPE_READ = 0;
+
+  /// < Write Requested
+  static const int BT_GATT_REQUEST_TYPE_WRITE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PAN_PANU_MODULE
+/// @brief  Enumerations for the types of PAN (Personal Area Networking) service.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_panu_service_type_e {
+  /// < Network Access Point
+  static const int BT_PANU_SERVICE_TYPE_NAP = 0;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of address book location for PBAP.
+/// @since_tizen 3.0
+abstract class bt_pbap_address_book_source_e {
+  /// < Request for Addressbook from remote device
+  static const int BT_PBAP_SOURCE_DEVICE = 0;
+
+  /// < Request for address book from SIM
+  static const int BT_PBAP_SOURCE_SIM = 1;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of folder type.
+/// @since_tizen 3.0
+abstract class bt_pbap_folder_type_e {
+  /// < Request for address book
+  static const int BT_PBAP_FOLDER_PHONE_BOOK = 0;
+
+  /// < Request for incoming calls
+  static const int BT_PBAP_FOLDER_INCOMING = 1;
+
+  /// < Request for outgoing calls
+  static const int BT_PBAP_FOLDER_OUTGOING = 2;
+
+  /// < Request for missed calls
+  static const int BT_PBAP_FOLDER_MISSED = 3;
+
+  /// < Request for combined calls
+  static const int BT_PBAP_FOLDER_COMBINED = 4;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of phone book search fields.
+/// @since_tizen 3.0
+abstract class bt_pbap_search_field_e {
+  /// < Request for search by name (default)
+  static const int BT_PBAP_SEARCH_NAME = 0;
+
+  /// < Request for search by phone number
+  static const int BT_PBAP_SEARCH_NUMBER = 1;
+
+  /// < Request for search by sound
+  static const int BT_PBAP_SEARCH_SOUND = 2;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of vCard Formats.
+/// @since_tizen 3.0
+abstract class bt_pbap_vcard_format_e {
+  /// < vCard format 2.1 (default)
+  static const int BT_PBAP_VCARD_FORMAT_VCARD21 = 0;
+
+  /// < vCard format 3.0
+  static const int BT_PBAP_VCARD_FORMAT_VCARD30 = 1;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of sorting orders.
+/// @since_tizen 3.0
+abstract class bt_pbap_sort_order_e {
+  /// < Filter order indexed (default)
+  static const int BT_PBAP_ORDER_INDEXED = 0;
+
+  /// < Filter order alphanumeric
+  static const int BT_PBAP_ORDER_ALPHANUMERIC = 1;
+
+  /// < Filter order phonetic
+  static const int BT_PBAP_ORDER_PHONETIC = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Class structure of device and service.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see #bt_device_info_s
+/// @see #bt_adapter_device_discovery_info_s
+/// @see bt_device_bond_created_cb()
+/// @see bt_adapter_device_discovery_state_changed_cb()
+final class bt_class_s extends ffi.Struct {
+  /// < Major device class.
+  @ffi.Int32()
+  external int major_device_class;
+
+  /// < Minor device class.
+  @ffi.Int32()
+  external int minor_device_class;
+
+  /// < Major service class mask.
+  /// This value can be a combination of #bt_major_service_class_e like #BT_MAJOR_SERVICE_CLASS_RENDERING | #BT_MAJOR_SERVICE_CLASS_AUDIO
+  @ffi.Int()
+  external int major_service_class_mask;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief Structure of device discovery information.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see #bt_class_s
+/// @see bt_adapter_device_discovery_state_changed_cb()
+final class bt_adapter_device_discovery_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The name of remote device
+  external ffi.Pointer<ffi.Char> remote_name;
+
+  /// < The Bluetooth classes
+  external bt_class_s bt_class;
+
+  /// < The strength indicator of received signal
+  @ffi.Int()
+  external int rssi;
+
+  /// < The bonding state
+  @ffi.Bool()
+  external bool is_bonded;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services
+  @ffi.Int()
+  external int service_count;
+
+  /// < The Bluetooth appearance
+  @ffi.Int32()
+  external int appearance;
+
+  /// < manufacturer specific data length
+  @ffi.Int()
+  external int manufacturer_data_len;
+
+  /// < manufacturer specific data
+  external ffi.Pointer<ffi.Char> manufacturer_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief Structure of le scan result information.
+/// @since_tizen 2.3.1
+///
+/// @see bt_adapter_le_start_scan()
+final class bt_adapter_le_device_scan_result_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The address type of remote device
+  @ffi.Int32()
+  external int address_type;
+
+  /// < The strength indicator of received signal
+  @ffi.Int()
+  external int rssi;
+
+  /// < advertising indication data length
+  @ffi.Int()
+  external int adv_data_len;
+
+  /// < advertising indication data
+  external ffi.Pointer<ffi.Char> adv_data;
+
+  /// < scan response data length
+  @ffi.Int()
+  external int scan_data_len;
+
+  /// < scan response data
+  external ffi.Pointer<ffi.Char> scan_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief The structure for LE iBeacon scan result information.
+/// @since_tizen 4.0
+///
+/// @see bt_adapter_le_start_scan()
+final class bt_adapter_le_ibeacon_scan_result_info_s extends ffi.Struct {
+  /// < Company ID
+  @ffi.Int()
+  external int company_id;
+
+  /// < iBeacon type
+  @ffi.Int()
+  external int ibeacon_type;
+
+  /// < UUID
+  external ffi.Pointer<ffi.Char> uuid;
+
+  /// < Major ID
+  @ffi.Int()
+  external int major_id;
+
+  /// < Minor ID
+  @ffi.Int()
+  external int minor_id;
+
+  /// < Measured power
+  @ffi.Int()
+  external int measured_power;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief LE service data structure.
+/// @since_tizen 2.3.1
+///
+/// @see bt_adapter_le_get_scan_result_service_data()
+final class bt_adapter_le_service_data_s extends ffi.Struct {
+  /// < 16 bit UUID of the service data
+  external ffi.Pointer<ffi.Char> service_uuid;
+
+  /// < Service data
+  external ffi.Pointer<ffi.Char> service_data;
+
+  /// < Service data length
+  @ffi.Int()
+  external int service_data_len;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Device information structure used for identifying pear device.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see #bt_class_s
+/// @see bt_device_bond_created_cb()
+final class bt_device_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The name of remote device
+  external ffi.Pointer<ffi.Char> remote_name;
+
+  /// < The Bluetooth classes
+  external bt_class_s bt_class;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services
+  @ffi.Int()
+  external int service_count;
+
+  /// < The bonding state
+  @ffi.Bool()
+  external bool is_bonded;
+
+  /// < The connection state
+  @ffi.Bool()
+  external bool is_connected;
+
+  /// < The authorization state
+  @ffi.Bool()
+  external bool is_authorized;
+
+  /// < manufacturer specific data length
+  @ffi.Int()
+  external int manufacturer_data_len;
+
+  /// < manufacturer specific data
+  external ffi.Pointer<ffi.Char> manufacturer_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Service Discovery Protocol (SDP) data structure.
+///
+/// @details This protocol is used for discovering available services or pear device,
+/// and finding one to connect with.
+///
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+/// @see bt_device_service_searched_cb()
+final class bt_device_sdp_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services.
+  @ffi.Int()
+  external int service_count;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Device connection information structure.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see bt_device_connection_state_changed_cb()
+final class bt_device_connection_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < Link type
+  @ffi.Int32()
+  external int link;
+
+  /// < Disconnection reason
+  @ffi.Int32()
+  external int disconn_reason;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief Rfcomm connection data used for exchanging data between Bluetooth devices.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see bt_socket_connection_state_changed_cb()
+final class bt_socket_connection_s extends ffi.Struct {
+  /// < The file descriptor of connected socket
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The file descriptor of the server socket or -1 for client connection
+  @ffi.Int()
+  external int server_fd;
+
+  /// < The local device role in this connection
+  @ffi.Int32()
+  external int local_role;
+
+  /// < The remote device address
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The service UUId
+  external ffi.Pointer<ffi.Char> service_uuid;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief Structure of RFCOMM received data.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @remarks User can use standard linux functions for reading/writing \n
+/// data from/to sockets.
+///
+/// @see bt_socket_data_received_cb()
+final class bt_socket_received_data_s extends ffi.Struct {
+  /// < The socket fd
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The length of the received data
+  @ffi.Int()
+  external int data_size;
+
+  /// < The received data
+  external ffi.Pointer<ffi.Char> data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
+/// @brief Attribute protocol MTU change information structure.
+/// @since_tizen 4.0
+///
+/// @see bt_gatt_client_att_mtu_changed_cb()
+final class bt_gatt_client_att_mtu_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < MTU value
+  @ffi.UnsignedInt()
+  external int mtu;
+
+  /// < Request status
+  @ffi.UnsignedInt()
+  external int status;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID mouse's button.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_mouse_button_e {
+  /// <The mouse's none value
+  static const int BT_HID_MOUSE_BUTTON_NONE = 0;
+
+  /// <The mouse's left button value
+  static const int BT_HID_MOUSE_BUTTON_LEFT = 1;
+
+  /// <The mouse's right button value
+  static const int BT_HID_MOUSE_BUTTON_RIGHT = 2;
+
+  /// <The mouse's middle button value
+  static const int BT_HID_MOUSE_BUTTON_MIDDLE = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing the HID mouse event information.
+/// @since_tizen @if WEARABLE 3.0 @endif
+///
+/// @see bt_hid_device_send_mouse_event()
+final class bt_hid_mouse_data_s extends ffi.Struct {
+  /// < The button values, we can combine key's values when we pressed multiple mouse buttons
+  @ffi.Int()
+  external int buttons;
+
+  /// < The location's x value, -128 ~127
+  @ffi.Int()
+  external int axis_x;
+
+  /// < The location's y value, -128 ~127
+  @ffi.Int()
+  external int axis_y;
+
+  /// < The padding value, -128 ~127
+  @ffi.Int()
+  external int padding;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing the HID keyboard event information.
+/// @details If you want to know more detail values, refer to http://www.usb.org/developers/hidpage/ and see "HID Usage Tables"
+/// @since_tizen @if WEARABLE 3.0 @endif
+///
+/// @see bt_hid_device_send_key_event()
+final class bt_hid_key_data_s extends ffi.Struct {
+  /// < The modifier keys : such as shift, alt
+  @ffi.UnsignedChar()
+  external int modifier;
+
+  /// < The key value - currently pressed keys : Max 8 at once
+  @ffi.Array.multi([8])
+  external ffi.Array<ffi.UnsignedChar> key;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID header type.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_header_type_e {
+  /// < The Bluetooth HID header type: Handshake
+  static const int BT_HID_HEADER_HANDSHAKE = 0;
+
+  /// < The Bluetooth HID header type: HID control
+  static const int BT_HID_HEADER_HID_CONTROL = 1;
+
+  /// < The Bluetooth HID header type: Get report
+  static const int BT_HID_HEADER_GET_REPORT = 2;
+
+  /// < The Bluetooth HID header type: Set report
+  static const int BT_HID_HEADER_SET_REPORT = 3;
+
+  /// < The Bluetooth HID header type: Get protocol
+  static const int BT_HID_HEADER_GET_PROTOCOL = 4;
+
+  /// < The Bluetooth HID header type: Set protocol
+  static const int BT_HID_HEADER_SET_PROTOCOL = 5;
+
+  /// < The Bluetooth HID header type: Data
+  static const int BT_HID_HEADER_DATA = 6;
+
+  /// < The Bluetooth HID header type: Unknown
+  static const int BT_HID_HEADER_UNKNOWN = 7;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID parameter type.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_param_type_e {
+  /// < Parameter type: Input
+  static const int BT_HID_PARAM_DATA_RTYPE_INPUT = 0;
+
+  /// < Parameter type: Output
+  static const int BT_HID_PARAM_DATA_RTYPE_OUTPUT = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID handshake type.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_handshake_type_e {
+  /// < Handshake error code none
+  static const int BT_HID_HANDSHAKE_SUCCESSFUL = 0;
+
+  /// < Handshake error code Not Ready
+  static const int BT_HID_HANDSHAKE_NOT_READY = 1;
+
+  /// < Handshake error code send invalid report id
+  static const int BT_HID_HANDSHAKE_ERR_INVALID_REPORT_ID = 2;
+
+  /// < Handshake error code request unsupported request
+  static const int BT_HID_HANDSHAKE_ERR_UNSUPPORTED_REQUEST = 3;
+
+  /// < Handshake error code received invalid parameter
+  static const int BT_HID_HANDSHAKE_ERR_INVALID_PARAMETER = 4;
+
+  /// < unknown error
+  static const int BT_HID_HANDSHAKE_ERR_UNKNOWN = 14;
+
+  /// < Fatal error
+  static const int BT_HID_HANDSHAKE_ERR_FATAL = 15;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing data received from the HID Host.
+/// @since_tizen @if WEARABLE 3.0 @endif
+final class bt_hid_device_received_data_s extends ffi.Struct {
+  /// < The remote device's address
+  external ffi.Pointer<ffi.Char> address;
+
+  /// < The header type
+  @ffi.Int32()
+  external int header_type;
+
+  /// < The parameter type
+  @ffi.Int32()
+  external int param_type;
+
+  /// < The length of the received data
+  @ffi.Int()
+  external int data_size;
+
+  /// < The received data
+  external ffi.Pointer<ffi.Char> data;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief The structure type containing vCard information.
+/// @since_tizen 3.0
+///
+/// @see bt_pbap_client_pull_vcard()
+final class bt_pbap_vcard_info_s extends ffi.Struct {
+  /// < The vcard index, used as a parameter for bt_pbap_client_pull_vcard()
+  @ffi.Int()
+  external int index;
+
+  /// < The contact name of the vCard
+  external ffi.Pointer<ffi.Char> contact_name;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief Enumeration for the scan filter type.
+/// @since_tizen 4.0
+/// @see bt_adapter_le_scan_filter_set_type()
+abstract class bt_adapter_le_scan_filter_type_e {
+  /// < iBeacon filter type
+  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_IBEACON = 0;
+
+  /// < Proximity UUID filter type
+  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_PROXIMITY_UUID = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief L2CAP CoC connection data used for exchanging data between Bluetooth devices.
+/// @since_tizen 7.0
+///
+/// @see bt_socket_l2cap_channel_connection_state_changed_cb()
+final class bt_socket_l2cap_le_connection_s extends ffi.Struct {
+  /// < The file descriptor of connected socket
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The file descriptor of the server socket or -1 for client connection
+  @ffi.Int()
+  external int server_fd;
+
+  /// < The local device role in this connection
+  @ffi.Int32()
+  external int local_role;
+
+  /// < The remote device address
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The psm of the connected socket
+  @ffi.Int()
+  external int psm;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief  Called when you get bonded devices repeatedly.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @param[in] device_info The bonded device information
+/// @param[in] user_data The user data passed from the foreach function
+/// @return @c true to continue with the next iteration of the loop,
+/// \n @c false to break out of the loop.
+/// @pre bt_adapter_foreach_bonded_device() will invoke this function.
+///
+/// @see bt_adapter_foreach_bonded_device()
+typedef bt_adapter_bonded_device_cb
+    = ffi.Pointer<ffi.NativeFunction<bt_adapter_bonded_device_cbFunction>>;
+typedef bt_adapter_bonded_device_cbFunction = ffi.Bool Function(
+    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
+typedef Dartbt_adapter_bonded_device_cbFunction = bool Function(
+    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
+
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
 /// @brief  Called when the Bluetooth adapter state changes.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
@@ -10760,80 +12051,6 @@ typedef Dartbt_adapter_device_discovery_state_changed_cbFunction
         ffi.Pointer<bt_adapter_device_discovery_info_s> discovery_info,
         ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief Enumerations of the discovery state of Bluetooth device.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_adapter_device_discovery_state_e {
-  /// < Device discovery is started
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_STARTED = 0;
-
-  /// < Device discovery is finished
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_FINISHED = 1;
-
-  /// < The remote Bluetooth device is found
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_FOUND = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief Structure of device discovery information.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see #bt_class_s
-/// @see bt_adapter_device_discovery_state_changed_cb()
-final class bt_adapter_device_discovery_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The name of remote device
-  external ffi.Pointer<ffi.Char> remote_name;
-
-  /// < The Bluetooth classes
-  external bt_class_s bt_class;
-
-  /// < The strength indicator of received signal
-  @ffi.Int()
-  external int rssi;
-
-  /// < The bonding state
-  @ffi.Bool()
-  external bool is_bonded;
-
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
-
-  /// < The number of services
-  @ffi.Int()
-  external int service_count;
-
-  /// < The Bluetooth appearance
-  @ffi.Int32()
-  external int appearance;
-
-  /// < manufacturer specific data length
-  @ffi.Int()
-  external int manufacturer_data_len;
-
-  /// < manufacturer specific data
-  external ffi.Pointer<ffi.Char> manufacturer_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief  Enumerations of gap appearance type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_appearance_type_e {
-  /// < Unknown appearance type
-  static const int BT_APPEARANCE_TYPE_UNKNOWN = 0;
-
-  /// < Generic Phone type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_PHONE = 64;
-
-  /// < Generic Computer type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_COMPUTER = 128;
-
-  /// < Generic Watch type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_WATCH = 192;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief  Called when the LE advertisement has been found.
 /// @since_tizen 2.3.1
@@ -10853,107 +12070,6 @@ typedef Dartbt_adapter_le_scan_result_cbFunction = void Function(
     int result,
     ffi.Pointer<bt_adapter_le_device_scan_result_info_s> info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief Structure of le scan result information.
-/// @since_tizen 2.3.1
-///
-/// @see bt_adapter_le_start_scan()
-final class bt_adapter_le_device_scan_result_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The address type of remote device
-  @ffi.Int32()
-  external int address_type;
-
-  /// < The strength indicator of received signal
-  @ffi.Int()
-  external int rssi;
-
-  /// < advertising indication data length
-  @ffi.Int()
-  external int adv_data_len;
-
-  /// < advertising indication data
-  external ffi.Pointer<ffi.Char> adv_data;
-
-  /// < scan response data length
-  @ffi.Int()
-  external int scan_data_len;
-
-  /// < scan response data
-  external ffi.Pointer<ffi.Char> scan_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device address type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_address_type_e {
-  /// < Public address
-  static const int BT_DEVICE_PUBLIC_ADDRESS = 0;
-
-  /// < Random address
-  static const int BT_DEVICE_RANDOM_ADDRESS = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth LE packet type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_adapter_le_packet_type_e {
-  /// < Advertising packet
-  static const int BT_ADAPTER_LE_PACKET_ADVERTISING = 0;
-
-  /// < Scan response packet
-  static const int BT_ADAPTER_LE_PACKET_SCAN_RESPONSE = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief LE service data structure.
-/// @since_tizen 2.3.1
-///
-/// @see bt_adapter_le_get_scan_result_service_data()
-final class bt_adapter_le_service_data_s extends ffi.Struct {
-  /// < 16 bit UUID of the service data
-  external ffi.Pointer<ffi.Char> service_uuid;
-
-  /// < Service data
-  external ffi.Pointer<ffi.Char> service_data;
-
-  /// < Service data length
-  @ffi.Int()
-  external int service_data_len;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief The structure for LE iBeacon scan result information.
-/// @since_tizen 4.0
-///
-/// @see bt_adapter_le_start_scan()
-final class bt_adapter_le_ibeacon_scan_result_info_s extends ffi.Struct {
-  /// < Company ID
-  @ffi.Int()
-  external int company_id;
-
-  /// < iBeacon type
-  @ffi.Int()
-  external int ibeacon_type;
-
-  /// < UUID
-  external ffi.Pointer<ffi.Char> uuid;
-
-  /// < Major ID
-  @ffi.Int()
-  external int major_id;
-
-  /// < Minor ID
-  @ffi.Int()
-  external int minor_id;
-
-  /// < Measured power
-  @ffi.Int()
-  external int measured_power;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief The handle to control Bluetooth LE advertising.
@@ -11024,59 +12140,6 @@ typedef Dartbt_adapter_le_advertising_state_changed_cbFunction = void Function(
     int adv_state,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth advertising state.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_adapter_le_advertising_state_e {
-  /// < Bluetooth advertising is stopped
-  static const int BT_ADAPTER_LE_ADVERTISING_STOPPED = 0;
-
-  /// < Bluetooth advertising is started
-  static const int BT_ADAPTER_LE_ADVERTISING_STARTED = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth advertising mode.
-/// @since_tizen 2.3.1
-abstract class bt_adapter_le_advertising_mode_e {
-  /// < Balanced advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_BALANCED = 0;
-
-  /// < Low latency advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_LATENCY = 1;
-
-  /// < Low energy advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_ENERGY = 2;
-
-  /// < Custom mode to set advertising parameters
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_CUSTOM = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth le scan mode.
-/// @since_tizen 3.0
-abstract class bt_adapter_le_scan_mode_e {
-  /// < Balanced mode of power consumption and connection latency
-  static const int BT_ADAPTER_LE_SCAN_MODE_BALANCED = 0;
-
-  /// < Low connection latency but high power consumption
-  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_LATENCY = 1;
-
-  /// < Low power consumption but high connection latency
-  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_ENERGY = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device authorization state.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_authorization_e {
-  /// < The remote Bluetooth device is authorized
-  static const int BT_DEVICE_AUTHORIZED = 0;
-
-  /// < The remote Bluetooth device is unauthorized
-  static const int BT_DEVICE_UNAUTHORIZED = 1;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief  Called when you get connected profiles repeatedly.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
@@ -11093,52 +12156,6 @@ typedef bt_device_connected_profileFunction = ffi.Bool Function(
     ffi.Int32 profile, ffi.Pointer<ffi.Void> user_data);
 typedef Dartbt_device_connected_profileFunction = bool Function(
     int profile, ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of Bluetooth profile.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_profile_e {
-  /// < RFCOMM Profile
-  static const int BT_PROFILE_RFCOMM = 1;
-
-  /// < Advanced Audio Distribution Profile Source role
-  static const int BT_PROFILE_A2DP = 2;
-
-  /// < Headset Profile
-  static const int BT_PROFILE_HSP = 4;
-
-  /// < Human Interface Device Profile
-  static const int BT_PROFILE_HID = 8;
-
-  /// < Network Access Point Profile
-  static const int BT_PROFILE_NAP = 16;
-
-  /// < Audio Gateway Profile
-  static const int BT_PROFILE_AG = 32;
-
-  /// < Generic Attribute Profile
-  static const int BT_PROFILE_GATT = 64;
-
-  /// < NAP server Profile
-  static const int BT_PROFILE_NAP_SERVER = 128;
-
-  /// < Advanced Audio Distribution Profile Sink role
-  static const int BT_PROFILE_A2DP_SINK = 256;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief  Enumerations of the Bluetooth device's LE connection mode.
-/// @since_tizen 3.0
-abstract class bt_device_le_connection_mode_e {
-  /// < Balanced mode of power consumption and connection latency
-  static const int BT_DEVICE_LE_CONNECTION_MODE_BALANCED = 0;
-
-  /// < Low connection latency but high power consumption
-  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_LATENCY = 1;
-
-  /// < Low power consumption but high connection latency
-  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_ENERGY = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief Called when the process of creating bond finishes.
@@ -11236,26 +12253,6 @@ typedef Dartbt_device_service_searched_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Service Discovery Protocol (SDP) data structure.
-///
-/// @details This protocol is used for discovering available services or pear device,
-/// and finding one to connect with.
-///
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-/// @see bt_device_service_searched_cb()
-final class bt_device_sdp_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
-
-  /// < The number of services.
-  @ffi.Int()
-  external int service_count;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief  Called when the connection state is changed.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
 ///
@@ -11274,55 +12271,6 @@ typedef Dartbt_device_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<bt_device_connection_info_s> conn_info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Device connection information structure.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see bt_device_connection_state_changed_cb()
-final class bt_device_connection_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < Link type
-  @ffi.Int32()
-  external int link;
-
-  /// < Disconnection reason
-  @ffi.Int32()
-  external int disconn_reason;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of connection link type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_connection_link_type_e {
-  /// < BR/EDR link
-  static const int BT_DEVICE_CONNECTION_LINK_BREDR = 0;
-
-  /// < LE link
-  static const int BT_DEVICE_CONNECTION_LINK_LE = 1;
-
-  /// < The connection type default
-  static const int BT_DEVICE_CONNECTION_LINK_DEFAULT = 255;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device disconnect reason.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_disconnect_reason_e {
-  /// < Disconnected by unknown reason
-  static const int BT_DEVICE_DISCONNECT_REASON_UNKNOWN = 0;
-
-  /// < Disconnected by timeout
-  static const int BT_DEVICE_DISCONNECT_REASON_TIMEOUT = 1;
-
-  /// < Disconnected by local host
-  static const int BT_DEVICE_DISCONNECT_REASON_LOCAL_HOST = 2;
-
-  /// < Disconnected by remote
-  static const int BT_DEVICE_DISCONNECT_REASON_REMOTE = 3;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief Called when you receive data.
@@ -11345,27 +12293,6 @@ typedef bt_socket_data_received_cbFunction = ffi.Void Function(
 typedef Dartbt_socket_data_received_cbFunction = void Function(
     ffi.Pointer<bt_socket_received_data_s> data,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief Structure of RFCOMM received data.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @remarks User can use standard linux functions for reading/writing \n
-/// data from/to sockets.
-///
-/// @see bt_socket_data_received_cb()
-final class bt_socket_received_data_s extends ffi.Struct {
-  /// < The socket fd
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The length of the received data
-  @ffi.Int()
-  external int data_size;
-
-  /// < The received data
-  external ffi.Pointer<ffi.Char> data;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief  Called when a RFCOMM connection is requested.
@@ -11413,56 +12340,6 @@ typedef Dartbt_socket_connection_state_changed_cbFunction = void Function(
     int connection_state,
     ffi.Pointer<bt_socket_connection_s> connection,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief  Enumerations of Bluetooth socket connection state.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_socket_connection_state_e {
-  /// < RFCOMM is connected
-  static const int BT_SOCKET_CONNECTED = 0;
-
-  /// < RFCOMM is disconnected
-  static const int BT_SOCKET_DISCONNECTED = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief Rfcomm connection data used for exchanging data between Bluetooth devices.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see bt_socket_connection_state_changed_cb()
-final class bt_socket_connection_s extends ffi.Struct {
-  /// < The file descriptor of connected socket
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The file descriptor of the server socket or -1 for client connection
-  @ffi.Int()
-  external int server_fd;
-
-  /// < The local device role in this connection
-  @ffi.Int32()
-  external int local_role;
-
-  /// < The remote device address
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The service UUId
-  external ffi.Pointer<ffi.Char> service_uuid;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief  Enumerations of connected Bluetooth device event role.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_socket_role_e {
-  /// < Unknown role
-  static const int BT_SOCKET_UNKNOWN = 0;
-
-  /// < Server role
-  static const int BT_SOCKET_SERVER = 1;
-
-  /// < Client role
-  static const int BT_SOCKET_CLIENT = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_OPP_SERVER_MODULE
 /// @brief  Called when an OPP connection is requested.
@@ -11634,45 +12511,6 @@ typedef Dartbt_hid_device_connection_state_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing the HID mouse event information.
-/// @since_tizen @if WEARABLE 3.0 @endif
-///
-/// @see bt_hid_device_send_mouse_event()
-final class bt_hid_mouse_data_s extends ffi.Struct {
-  /// < The button values, we can combine key's values when we pressed multiple mouse buttons
-  @ffi.Int()
-  external int buttons;
-
-  /// < The location's x value, -128 ~127
-  @ffi.Int()
-  external int axis_x;
-
-  /// < The location's y value, -128 ~127
-  @ffi.Int()
-  external int axis_y;
-
-  /// < The padding value, -128 ~127
-  @ffi.Int()
-  external int padding;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing the HID keyboard event information.
-/// @details If you want to know more detail values, refer to http://www.usb.org/developers/hidpage/ and see "HID Usage Tables"
-/// @since_tizen @if WEARABLE 3.0 @endif
-///
-/// @see bt_hid_device_send_key_event()
-final class bt_hid_key_data_s extends ffi.Struct {
-  /// < The modifier keys : such as shift, alt
-  @ffi.UnsignedChar()
-  external int modifier;
-
-  /// < The key value - currently pressed keys : Max 8 at once
-  @ffi.Array.multi([8])
-  external ffi.Array<ffi.UnsignedChar> key;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
 /// @brief  Called when the HID Device receives data from the HID Host.
 /// @details The following error codes can be delivered: \n
 /// #BT_ERROR_NONE \n
@@ -11690,89 +12528,6 @@ typedef bt_hid_device_data_received_cbFunction = ffi.Void Function(
 typedef Dartbt_hid_device_data_received_cbFunction = void Function(
     ffi.Pointer<bt_hid_device_received_data_s> data,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing data received from the HID Host.
-/// @since_tizen @if WEARABLE 3.0 @endif
-final class bt_hid_device_received_data_s extends ffi.Struct {
-  /// < The remote device's address
-  external ffi.Pointer<ffi.Char> address;
-
-  /// < The header type
-  @ffi.Int32()
-  external int header_type;
-
-  /// < The parameter type
-  @ffi.Int32()
-  external int param_type;
-
-  /// < The length of the received data
-  @ffi.Int()
-  external int data_size;
-
-  /// < The received data
-  external ffi.Pointer<ffi.Char> data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief Enumerations of the Bluetooth HID header type.
-/// @since_tizen @if WEARABLE 3.0 @endif
-abstract class bt_hid_header_type_e {
-  /// < The Bluetooth HID header type: Handshake
-  static const int BT_HID_HEADER_HANDSHAKE = 0;
-
-  /// < The Bluetooth HID header type: HID control
-  static const int BT_HID_HEADER_HID_CONTROL = 1;
-
-  /// < The Bluetooth HID header type: Get report
-  static const int BT_HID_HEADER_GET_REPORT = 2;
-
-  /// < The Bluetooth HID header type: Set report
-  static const int BT_HID_HEADER_SET_REPORT = 3;
-
-  /// < The Bluetooth HID header type: Get protocol
-  static const int BT_HID_HEADER_GET_PROTOCOL = 4;
-
-  /// < The Bluetooth HID header type: Set protocol
-  static const int BT_HID_HEADER_SET_PROTOCOL = 5;
-
-  /// < The Bluetooth HID header type: Data
-  static const int BT_HID_HEADER_DATA = 6;
-
-  /// < The Bluetooth HID header type: Unknown
-  static const int BT_HID_HEADER_UNKNOWN = 7;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief Enumerations of the Bluetooth HID parameter type.
-/// @since_tizen @if WEARABLE 3.0 @endif
-abstract class bt_hid_param_type_e {
-  /// < Parameter type: Input
-  static const int BT_HID_PARAM_DATA_RTYPE_INPUT = 0;
-
-  /// < Parameter type: Output
-  static const int BT_HID_PARAM_DATA_RTYPE_OUTPUT = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
-/// @brief  Enumerations for the types of profiles related with audio.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_audio_profile_type_e {
-  /// < All supported profiles related with audio (Both Host and Device role)
-  static const int BT_AUDIO_PROFILE_TYPE_ALL = 0;
-
-  /// < local device AG and remote device HF Client (Host role, ex: mobile)
-  static const int BT_AUDIO_PROFILE_TYPE_HSP_HFP = 1;
-
-  /// < A2DP Source Connection, remote device is A2DP Sink (Host role, ex: mobile)
-  static const int BT_AUDIO_PROFILE_TYPE_A2DP = 2;
-
-  /// < local device HF Client and remote device AG (Device role, ex: headset)
-  static const int BT_AUDIO_PROFILE_TYPE_AG = 3;
-
-  /// < A2DP Sink Connection, remote device is A2DP Source (Device role, ex: headset)
-  static const int BT_AUDIO_PROFILE_TYPE_A2DP_SINK = 4;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
 /// @brief  Called when the connection state is changed.
@@ -11821,82 +12576,6 @@ typedef Dartbt_avrcp_target_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<ffi.Char> remote_address,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the equalizer state.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_equalizer_state_e {
-  /// < Equalizer Off
-  static const int BT_AVRCP_EQUALIZER_STATE_OFF = 1;
-
-  /// < Equalizer On
-  static const int BT_AVRCP_EQUALIZER_STATE_ON = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the repeat mode.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_repeat_mode_e {
-  /// < Repeat Off
-  static const int BT_AVRCP_REPEAT_MODE_OFF = 1;
-
-  /// < Single track repeat
-  static const int BT_AVRCP_REPEAT_MODE_SINGLE_TRACK = 2;
-
-  /// < All track repeat
-  static const int BT_AVRCP_REPEAT_MODE_ALL_TRACK = 3;
-
-  /// < Group repeat
-  static const int BT_AVRCP_REPEAT_MODE_GROUP = 4;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the shuffle mode.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_shuffle_mode_e {
-  /// < Shuffle Off
-  static const int BT_AVRCP_SHUFFLE_MODE_OFF = 1;
-
-  /// < All tracks shuffle
-  static const int BT_AVRCP_SHUFFLE_MODE_ALL_TRACK = 2;
-
-  /// < Group shuffle
-  static const int BT_AVRCP_SHUFFLE_MODE_GROUP = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the scan mode.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_scan_mode_e {
-  /// < Scan Off
-  static const int BT_AVRCP_SCAN_MODE_OFF = 1;
-
-  /// < All tracks scan
-  static const int BT_AVRCP_SCAN_MODE_ALL_TRACK = 2;
-
-  /// < Group scan
-  static const int BT_AVRCP_SCAN_MODE_GROUP = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the player state.
-/// @since_tizen 3.0
-abstract class bt_avrcp_player_state_e {
-  /// < Stopped
-  static const int BT_AVRCP_PLAYER_STATE_STOPPED = 0;
-
-  /// < Playing
-  static const int BT_AVRCP_PLAYER_STATE_PLAYING = 1;
-
-  /// < Paused
-  static const int BT_AVRCP_PLAYER_STATE_PAUSED = 2;
-
-  /// < Seek Forward
-  static const int BT_AVRCP_PLAYER_STATE_FORWARD_SEEK = 3;
-
-  /// < Seek Rewind
-  static const int BT_AVRCP_PLAYER_STATE_REWIND_SEEK = 4;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
 /// @brief  Called when the equalizer state is changed by the remote control device.
@@ -12003,37 +12682,6 @@ typedef Dartbt_avrcp_track_info_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief Structure of Track metadata information.
-/// @since_tizen 3.0
-///
-/// @see #bt_class_s
-final class bt_avrcp_metadata_attributes_info_s extends ffi.Struct {
-  /// < Title
-  external ffi.Pointer<ffi.Char> title;
-
-  /// < Artist
-  external ffi.Pointer<ffi.Char> artist;
-
-  /// < Album name
-  external ffi.Pointer<ffi.Char> album;
-
-  /// < Album Genre
-  external ffi.Pointer<ffi.Char> genre;
-
-  /// < The total number of tracks
-  @ffi.UnsignedInt()
-  external int total_tracks;
-
-  /// < Track number
-  @ffi.UnsignedInt()
-  external int number;
-
-  /// < Duration
-  @ffi.UnsignedInt()
-  external int duration;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
 /// @brief  Called when the connection state is changed.
 /// @since_tizen 3.0
 /// @param[in] connected  The state to be changed. true means connected state, Otherwise, false.
@@ -12049,32 +12697,6 @@ typedef bt_avrcp_control_connection_state_changed_cbFunction
 typedef Dartbt_avrcp_control_connection_state_changed_cbFunction
     = void Function(bool connected, ffi.Pointer<ffi.Char> remote_address,
         ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumeration for the player control commands.
-/// @since_tizen 3.0
-abstract class bt_avrcp_player_command_e {
-  /// < Play
-  static const int BT_AVRCP_CONTROL_PLAY = 1;
-
-  /// < Pause
-  static const int BT_AVRCP_CONTROL_PAUSE = 2;
-
-  /// < Stop
-  static const int BT_AVRCP_CONTROL_STOP = 3;
-
-  /// < Next Track
-  static const int BT_AVRCP_CONTROL_NEXT = 4;
-
-  /// < Previous track
-  static const int BT_AVRCP_CONTROL_PREVIOUS = 5;
-
-  /// < Fast Forward
-  static const int BT_AVRCP_CONTROL_FAST_FORWARD = 6;
-
-  /// < Rewind
-  static const int BT_AVRCP_CONTROL_REWIND = 7;
-}
 
 /// @deprecated Deprecated since 5.0.
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
@@ -12106,19 +12728,6 @@ typedef Dartbt_hdp_connected_cbFunction = void Function(
     int type,
     int channel,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @deprecated Deprecated since 5.0.
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
-/// @brief  Enumerations for the data channel type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-/// @remarks Deprecated, because of no usecase and supported devices.
-abstract class bt_hdp_channel_type_e {
-  /// < Reliable Data Channel
-  static const int BT_HDP_CHANNEL_TYPE_RELIABLE = 1;
-
-  /// < Streaming Data Channel
-  static const int BT_HDP_CHANNEL_TYPE_STREAMING = 2;
-}
 
 /// @deprecated Deprecated since 5.0.
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
@@ -12172,54 +12781,6 @@ typedef Dartbt_hdp_data_received_cbFunction = void Function(int channel,
 /// @since_tizen 2.3.1
 typedef bt_gatt_h = ffi.Pointer<ffi.Void>;
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the integer type for GATT handle's value.
-/// @since_tizen 2.3.1
-abstract class bt_data_type_int_e {
-  /// < 8 bit signed int type
-  static const int BT_DATA_TYPE_SINT8 = 0;
-
-  /// < 16 bit signed int type
-  static const int BT_DATA_TYPE_SINT16 = 1;
-
-  /// < 32 bit signed int type
-  static const int BT_DATA_TYPE_SINT32 = 2;
-
-  /// < 8 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT8 = 3;
-
-  /// < 16 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT16 = 4;
-
-  /// < 32 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT32 = 5;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the float type for GATT handle's value.
-/// @since_tizen 2.3.1
-abstract class bt_data_type_float_e {
-  /// < 32 bit float type
-  static const int BT_DATA_TYPE_FLOAT = 0;
-
-  /// < 16 bit float type
-  static const int BT_DATA_TYPE_SFLOAT = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the GATT handle's type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_type_e {
-  /// < GATT service type
-  static const int BT_GATT_TYPE_SERVICE = 1;
-
-  /// < GATT characteristic type
-  static const int BT_GATT_TYPE_CHARACTERISTIC = 2;
-
-  /// < GATT descriptor type
-  static const int BT_GATT_TYPE_DESCRIPTOR = 3;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief The handle of a GATT client which is associated with a remote device.
 /// @since_tizen 2.3.1
@@ -12244,17 +12805,6 @@ typedef bt_gatt_foreach_cbFunction = ffi.Bool Function(ffi.Int total,
     ffi.Int index, bt_gatt_h gatt_handle, ffi.Pointer<ffi.Void> user_data);
 typedef Dartbt_gatt_foreach_cbFunction = bool Function(int total, int index,
     bt_gatt_h gatt_handle, ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the write type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_write_type_e {
-  /// < Write without response type
-  static const int BT_GATT_WRITE_TYPE_WRITE_NO_RESPONSE = 0;
-
-  /// < Write type
-  static const int BT_GATT_WRITE_TYPE_WRITE = 1;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief  Called when the client request(e.g. read / write) has been completed.
@@ -12295,24 +12845,6 @@ typedef Dartbt_gatt_client_att_mtu_changed_cbFunction = void Function(
     bt_gatt_client_h client,
     ffi.Pointer<bt_gatt_client_att_mtu_info_s> mtu_info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
-/// @brief Attribute protocol MTU change information structure.
-/// @since_tizen 4.0
-///
-/// @see bt_gatt_client_att_mtu_changed_cb()
-final class bt_gatt_client_att_mtu_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < MTU value
-  @ffi.UnsignedInt()
-  external int mtu;
-
-  /// < Request status
-  @ffi.UnsignedInt()
-  external int status;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief  Called when a value of a watched characteristic's GATT handle has been changed.
@@ -12359,20 +12891,6 @@ typedef Dartbt_gatt_client_service_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Char> service_uuid,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
-/// @brief  Enumerations of gatt server's service changing mode.
-/// @since_tizen 3.0
-abstract class bt_gatt_client_service_change_type_e {
-  /// < Service added
-  static const int BT_GATT_CLIENT_SERVICE_ADDED = 0;
-
-  /// < Service removed
-  static const int BT_GATT_CLIENT_SERVICE_REMOVED = 1;
-
-  /// < Resync is required (Since 6.5)
-  static const int BT_GATT_CLIENT_SERVICE_RESYNC = 2;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
 /// @brief Called when the connection state is changed.
 ///
@@ -12401,17 +12919,6 @@ typedef Dartbt_gatt_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<ffi.Char> remote_address,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the service type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_service_type_e {
-  /// < GATT primary service type
-  static const int BT_GATT_SERVICE_TYPE_PRIMARY = 1;
-
-  /// < GATT secondary service type
-  static const int BT_GATT_SERVICE_TYPE_SECONDARY = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
 /// @brief The handle of a GATT server.
@@ -12528,17 +13035,6 @@ typedef Dartbt_gatt_server_write_value_requested_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
-/// @brief  Enumerations of the remote device request types for attributes.
-/// @since_tizen 3.0
-abstract class bt_gatt_att_request_type_e {
-  /// < Read Requested
-  static const int BT_GATT_REQUEST_TYPE_READ = 0;
-
-  /// < Write Requested
-  static const int BT_GATT_REQUEST_TYPE_WRITE = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
 /// @brief  Called when the sending notification / indication is done.
 /// @since_tizen 3.0
 ///
@@ -12608,39 +13104,6 @@ typedef Dartbt_pbap_connection_state_changed_cbFunction = void Function(
 
 /// @WEARABLE_ONLY
 /// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of address book location for PBAP.
-/// @since_tizen 3.0
-abstract class bt_pbap_address_book_source_e {
-  /// < Request for Addressbook from remote device
-  static const int BT_PBAP_SOURCE_DEVICE = 0;
-
-  /// < Request for address book from SIM
-  static const int BT_PBAP_SOURCE_SIM = 1;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of folder type.
-/// @since_tizen 3.0
-abstract class bt_pbap_folder_type_e {
-  /// < Request for address book
-  static const int BT_PBAP_FOLDER_PHONE_BOOK = 0;
-
-  /// < Request for incoming calls
-  static const int BT_PBAP_FOLDER_INCOMING = 1;
-
-  /// < Request for outgoing calls
-  static const int BT_PBAP_FOLDER_OUTGOING = 2;
-
-  /// < Request for missed calls
-  static const int BT_PBAP_FOLDER_MISSED = 3;
-
-  /// < Request for combined calls
-  static const int BT_PBAP_FOLDER_COMBINED = 4;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
 /// @brief  Called when PBAP Phonebook size calculation completes.
 /// @details The following error codes can be delivered: \n
 /// #BT_ERROR_NONE \n
@@ -12666,33 +13129,6 @@ typedef Dartbt_pbap_phone_book_size_cbFunction = void Function(
     ffi.Pointer<ffi.Char> remote_address,
     int size,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of vCard Formats.
-/// @since_tizen 3.0
-abstract class bt_pbap_vcard_format_e {
-  /// < vCard format 2.1 (default)
-  static const int BT_PBAP_VCARD_FORMAT_VCARD21 = 0;
-
-  /// < vCard format 3.0
-  static const int BT_PBAP_VCARD_FORMAT_VCARD30 = 1;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of sorting orders.
-/// @since_tizen 3.0
-abstract class bt_pbap_sort_order_e {
-  /// < Filter order indexed (default)
-  static const int BT_PBAP_ORDER_INDEXED = 0;
-
-  /// < Filter order alphanumeric
-  static const int BT_PBAP_ORDER_ALPHANUMERIC = 1;
-
-  /// < Filter order phonetic
-  static const int BT_PBAP_ORDER_PHONETIC = 2;
-}
 
 /// @WEARABLE_ONLY
 /// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
@@ -12754,52 +13190,10 @@ typedef Dartbt_pbap_list_vcards_cbFunction = void Function(
     int count,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief The structure type containing vCard information.
-/// @since_tizen 3.0
-///
-/// @see bt_pbap_client_pull_vcard()
-final class bt_pbap_vcard_info_s extends ffi.Struct {
-  /// < The vcard index, used as a parameter for bt_pbap_client_pull_vcard()
-  @ffi.Int()
-  external int index;
-
-  /// < The contact name of the vCard
-  external ffi.Pointer<ffi.Char> contact_name;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of phone book search fields.
-/// @since_tizen 3.0
-abstract class bt_pbap_search_field_e {
-  /// < Request for search by name (default)
-  static const int BT_PBAP_SEARCH_NAME = 0;
-
-  /// < Request for search by phone number
-  static const int BT_PBAP_SEARCH_NUMBER = 1;
-
-  /// < Request for search by sound
-  static const int BT_PBAP_SEARCH_SOUND = 2;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief The handle of a Bluetooth LE scan filter.
 /// @since_tizen 4.0
 typedef bt_scan_filter_h = ffi.Pointer<ffi.Void>;
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief Enumeration for the scan filter type.
-/// @since_tizen 4.0
-/// @see bt_adapter_le_scan_filter_set_type()
-abstract class bt_adapter_le_scan_filter_type_e {
-  /// < iBeacon filter type
-  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_IBEACON = 0;
-
-  /// < Proximity UUID filter type
-  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_PROXIMITY_UUID = 1;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief  Called when the l2cap channel socket connection state changes.
@@ -12830,29 +13224,3 @@ typedef Dartbt_socket_l2cap_channel_connection_state_changed_cbFunction
         int connection_state,
         ffi.Pointer<bt_socket_l2cap_le_connection_s> connection,
         ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief L2CAP CoC connection data used for exchanging data between Bluetooth devices.
-/// @since_tizen 7.0
-///
-/// @see bt_socket_l2cap_channel_connection_state_changed_cb()
-final class bt_socket_l2cap_le_connection_s extends ffi.Struct {
-  /// < The file descriptor of connected socket
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The file descriptor of the server socket or -1 for client connection
-  @ffi.Int()
-  external int server_fd;
-
-  /// < The local device role in this connection
-  @ffi.Int32()
-  external int local_role;
-
-  /// < The remote device address
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The psm of the connected socket
-  @ffi.Int()
-  external int psm;
-}

--- a/lib/src/bindings/7.0/generated_bindings_capi_system_info.dart
+++ b/lib/src/bindings/7.0/generated_bindings_capi_system_info.dart
@@ -369,6 +369,38 @@ class Tizen70CapiSystemInfo {
           int Function(ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Int32>)>();
 }
 
+/// @brief Enumeration for system information error codes.
+abstract class system_info_error_e {
+  /// < Successful
+  static const int SYSTEM_INFO_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int SYSTEM_INFO_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int SYSTEM_INFO_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < An input/output error occurred when reading value from system
+  static const int SYSTEM_INFO_ERROR_IO_ERROR = -5;
+
+  /// < No permission to use the API
+  static const int SYSTEM_INFO_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Not supported parameter (Since 3.0)
+  static const int SYSTEM_INFO_ERROR_NOT_SUPPORTED = -1073741822;
+}
+
+/// @internal
+/// @brief It is not decided if it should be opened to public.
+abstract class system_info_type_e {
+  static const int SYSTEM_INFO_TYPE_MIN = 0;
+  static const int SYSTEM_INFO_BOOL = 0;
+  static const int SYSTEM_INFO_INT = 1;
+  static const int SYSTEM_INFO_DOUBLE = 2;
+  static const int SYSTEM_INFO_STRING = 3;
+  static const int SYSTEM_INFO_TYPE_MAX = 4;
+}
+
 /// @internal
 /// @brief Enumeration for system information key.
 abstract class system_info_key_e {
@@ -416,15 +448,4 @@ abstract class system_info_key_e {
 
   /// < @internal Indicates whether the device supports tethering
   static const int SYSTEM_INFO_KEY_TETHERING_SUPPORTED = 14;
-}
-
-/// @internal
-/// @brief It is not decided if it should be opened to public.
-abstract class system_info_type_e {
-  static const int SYSTEM_INFO_TYPE_MIN = 0;
-  static const int SYSTEM_INFO_BOOL = 0;
-  static const int SYSTEM_INFO_INT = 1;
-  static const int SYSTEM_INFO_DOUBLE = 2;
-  static const int SYSTEM_INFO_STRING = 3;
-  static const int SYSTEM_INFO_TYPE_MAX = 4;
 }

--- a/lib/src/bindings/7.0/generated_bindings_mv_barcode_detector.dart
+++ b/lib/src/bindings/7.0/generated_bindings_mv_barcode_detector.dart
@@ -81,6 +81,123 @@ class Tizen70MvBarcodeDetector {
           ffi.Pointer<ffi.Void>)>();
 }
 
+/// @brief Enumeration for supported barcode types.
+/// @details QR codes (versions 1 to 40) and set of 1D barcodes are supported
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+/// @remarks #MV_BARCODE_UNDEFINED is deprecated. Use #MV_BARCODE_UNKNOWN instead
+abstract class mv_barcode_type_e {
+  /// < 2D barcode - Quick Response code
+  static const int MV_BARCODE_QR = 0;
+
+  /// < 1D barcode - Universal Product Code with 12-digit
+  static const int MV_BARCODE_UPC_A = 1;
+
+  /// < 1D barcode - Universal Product Code with 6-digit
+  static const int MV_BARCODE_UPC_E = 2;
+
+  /// < 1D barcode - International Article Number with 8-digit
+  static const int MV_BARCODE_EAN_8 = 3;
+
+  /// < 1D barcode - International Article Number with 13-digit
+  static const int MV_BARCODE_EAN_13 = 4;
+
+  /// < 1D barcode - Code 128
+  static const int MV_BARCODE_CODE128 = 5;
+
+  /// < 1D barcode - Code 39
+  static const int MV_BARCODE_CODE39 = 6;
+
+  /// < 1D barcode - Interleaved Two of Five
+  static const int MV_BARCODE_I2_5 = 7;
+
+  /// < @deprecated Undefined (Deprecated since 6.0)
+  static const int MV_BARCODE_UNDEFINED = 8;
+
+  /// < 1D barcode - International Article Number with 2-digit(add-on) (since 6.0)
+  static const int MV_BARCODE_EAN_2 = 9;
+
+  /// < 1D barcode - International Article Number with 5-digit(add-on) (since 6.0)
+  static const int MV_BARCODE_EAN_5 = 10;
+
+  /// < 1D barcode - Code 93 (since 6.0)
+  static const int MV_BARCODE_CODE93 = 11;
+
+  /// < 1D barcode - CODABAR (since 6.0)
+  static const int MV_BARCODE_CODABAR = 12;
+
+  /// < 1D barcode - GS1 DATABAR (since 6.0)
+  static const int MV_BARCODE_DATABAR = 13;
+
+  /// < 1D barcode - GS1 DATABAR EXPAND(since 6.0)
+  static const int MV_BARCODE_DATABAR_EXPAND = 14;
+
+  /// < Unknown (since 6.0)
+  static const int MV_BARCODE_UNKNOWN = 100;
+}
+
+/// @brief Enumeration for supported QR code error correction level.
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+/// @remarks This is unavailable for 1D barcodes
+abstract class mv_barcode_qr_ecc_e {
+  /// < Recovery up to  7% losses
+  static const int MV_BARCODE_QR_ECC_LOW = 0;
+
+  /// < Recovery up to 15% losses
+  static const int MV_BARCODE_QR_ECC_MEDIUM = 1;
+
+  /// < Recovery up to 25% losses
+  static const int MV_BARCODE_QR_ECC_QUARTILE = 2;
+
+  /// < Recovery up to 30% losses
+  static const int MV_BARCODE_QR_ECC_HIGH = 3;
+
+  /// < Unavailable
+  static const int MV_BARCODE_QR_ECC_UNAVAILABLE = 4;
+}
+
+/// @brief Enumeration for supported QR code encoding mode.
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+/// @remarks This is unavailable for 1D barcodes
+abstract class mv_barcode_qr_mode_e {
+  /// < Numeric digits
+  static const int MV_BARCODE_QR_MODE_NUMERIC = 0;
+
+  /// < Alphanumeric characters
+  static const int MV_BARCODE_QR_MODE_ALPHANUMERIC = 1;
+
+  /// < Raw 8-bit bytes
+  static const int MV_BARCODE_QR_MODE_BYTE = 2;
+
+  /// < UTF-8 character encoding
+  static const int MV_BARCODE_QR_MODE_UTF8 = 3;
+
+  /// < Unavailable
+  static const int MV_BARCODE_QR_MODE_UNAVAILABLE = 4;
+}
+
+/// @brief Enumeration for supported image formats for the barcode generating.
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+abstract class mv_barcode_image_format_e {
+  /// < Unavailable image format
+  static const int MV_BARCODE_IMAGE_FORMAT_UNAVAILABLE = -1;
+
+  /// < BMP image format
+  static const int MV_BARCODE_IMAGE_FORMAT_BMP = 0;
+
+  /// < JPEG image format
+  static const int MV_BARCODE_IMAGE_FORMAT_JPG = 1;
+
+  /// < PNG image format
+  static const int MV_BARCODE_IMAGE_FORMAT_PNG = 2;
+
+  /// < The number of supported image format
+  static const int MV_BARCODE_IMAGE_FORMAT_NUM = 3;
+}
+
 /// @brief Enumeration to target attribute
 ///
 /// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
@@ -150,61 +267,6 @@ typedef Dartmv_barcode_detected_cbFunction = void Function(
     ffi.Pointer<ffi.Int32> types,
     int number_of_barcodes,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for supported barcode types.
-/// @details QR codes (versions 1 to 40) and set of 1D barcodes are supported
-///
-/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
-/// @remarks #MV_BARCODE_UNDEFINED is deprecated. Use #MV_BARCODE_UNKNOWN instead
-abstract class mv_barcode_type_e {
-  /// < 2D barcode - Quick Response code
-  static const int MV_BARCODE_QR = 0;
-
-  /// < 1D barcode - Universal Product Code with 12-digit
-  static const int MV_BARCODE_UPC_A = 1;
-
-  /// < 1D barcode - Universal Product Code with 6-digit
-  static const int MV_BARCODE_UPC_E = 2;
-
-  /// < 1D barcode - International Article Number with 8-digit
-  static const int MV_BARCODE_EAN_8 = 3;
-
-  /// < 1D barcode - International Article Number with 13-digit
-  static const int MV_BARCODE_EAN_13 = 4;
-
-  /// < 1D barcode - Code 128
-  static const int MV_BARCODE_CODE128 = 5;
-
-  /// < 1D barcode - Code 39
-  static const int MV_BARCODE_CODE39 = 6;
-
-  /// < 1D barcode - Interleaved Two of Five
-  static const int MV_BARCODE_I2_5 = 7;
-
-  /// < @deprecated Undefined (Deprecated since 6.0)
-  static const int MV_BARCODE_UNDEFINED = 8;
-
-  /// < 1D barcode - International Article Number with 2-digit(add-on) (since 6.0)
-  static const int MV_BARCODE_EAN_2 = 9;
-
-  /// < 1D barcode - International Article Number with 5-digit(add-on) (since 6.0)
-  static const int MV_BARCODE_EAN_5 = 10;
-
-  /// < 1D barcode - Code 93 (since 6.0)
-  static const int MV_BARCODE_CODE93 = 11;
-
-  /// < 1D barcode - CODABAR (since 6.0)
-  static const int MV_BARCODE_CODABAR = 12;
-
-  /// < 1D barcode - GS1 DATABAR (since 6.0)
-  static const int MV_BARCODE_DATABAR = 13;
-
-  /// < 1D barcode - GS1 DATABAR EXPAND(since 6.0)
-  static const int MV_BARCODE_DATABAR_EXPAND = 14;
-
-  /// < Unknown (since 6.0)
-  static const int MV_BARCODE_UNKNOWN = 100;
-}
 
 const String MV_BARCODE_DETECT_ATTR_TARGET = 'MV_BARCODE_DETECT_ATTR_TARGET';
 

--- a/lib/src/bindings/7.0/generated_bindings_mv_barcode_generator.dart
+++ b/lib/src/bindings/7.0/generated_bindings_mv_barcode_generator.dart
@@ -259,7 +259,7 @@ abstract class _mv_barcode_type_e {
 ///
 /// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
 /// @remarks This is unavailable for 1D barcodes
-abstract class mv_barcode_qr_mode_e {
+abstract class _mv_barcode_qr_mode_e {
   /// < Numeric digits
   static const int MV_BARCODE_QR_MODE_NUMERIC = 0;
 
@@ -280,7 +280,7 @@ abstract class mv_barcode_qr_mode_e {
 ///
 /// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
 /// @remarks This is unavailable for 1D barcodes
-abstract class mv_barcode_qr_ecc_e {
+abstract class _mv_barcode_qr_ecc_e {
   /// < Recovery up to  7% losses
   static const int MV_BARCODE_QR_ECC_LOW = 0;
 
@@ -300,7 +300,7 @@ abstract class mv_barcode_qr_ecc_e {
 /// @brief Enumeration for supported image formats for the barcode generating.
 ///
 /// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
-abstract class mv_barcode_image_format_e {
+abstract class _mv_barcode_image_format_e {
   /// < Unavailable image format
   static const int MV_BARCODE_IMAGE_FORMAT_UNAVAILABLE = -1;
 

--- a/lib/src/bindings/7.0/generated_bindings_mv_face.dart
+++ b/lib/src/bindings/7.0/generated_bindings_mv_face.dart
@@ -1100,6 +1100,53 @@ class Tizen70MvFace {
               ffi.Pointer<ffi.Char>, ffi.Pointer<mv_face_tracking_model_h>)>();
 }
 
+/// @brief Enumeration for eyes state type.
+///
+/// @since_tizen 3.0
+///
+/// @see mv_face_eye_condition_recognize()
+abstract class mv_face_eye_condition_e {
+  /// < Eyes are open
+  static const int MV_FACE_EYES_OPEN = 0;
+
+  /// < Eyes are closed
+  static const int MV_FACE_EYES_CLOSED = 1;
+
+  /// < The eyes condition wasn't determined
+  static const int MV_FACE_EYES_NOT_FOUND = 2;
+}
+
+/// @brief Enumeration for expression types can be determined for faces.
+///
+/// @since_tizen 3.0
+///
+/// @see mv_face_facial_expression_recognize()
+abstract class mv_face_facial_expression_e {
+  /// < Unknown face expression
+  static const int MV_FACE_UNKNOWN = 0;
+
+  /// < Face expression is neutral
+  static const int MV_FACE_NEUTRAL = 1;
+
+  /// < Face expression is smiling
+  static const int MV_FACE_SMILE = 2;
+
+  /// < Face expression is sadness
+  static const int MV_FACE_SADNESS = 3;
+
+  /// < Face expression is surprise
+  static const int MV_FACE_SURPRISE = 4;
+
+  /// < Face expression is anger
+  static const int MV_FACE_ANGER = 5;
+
+  /// < Face expression is fear
+  static const int MV_FACE_FEAR = 6;
+
+  /// < Face expression is disgust
+  static const int MV_FACE_DISGUST = 7;
+}
+
 /// @brief Called when faces are detected for the @a source.
 /// @details This type callback can be invoked each time when
 /// mv_face_detect() is called to process the results of face
@@ -1311,22 +1358,6 @@ typedef Dartmv_face_eye_condition_recognized_cbFunction = void Function(
     int eye_condition,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for eyes state type.
-///
-/// @since_tizen 3.0
-///
-/// @see mv_face_eye_condition_recognize()
-abstract class mv_face_eye_condition_e {
-  /// < Eyes are open
-  static const int MV_FACE_EYES_OPEN = 0;
-
-  /// < Eyes are closed
-  static const int MV_FACE_EYES_CLOSED = 1;
-
-  /// < The eyes condition wasn't determined
-  static const int MV_FACE_EYES_NOT_FOUND = 2;
-}
-
 /// @brief Called when facial expression is recognized.
 /// @details This type callback can be invoked each time when
 /// mv_face_facial_expression_recognize() is called for @a face_location to
@@ -1362,37 +1393,6 @@ typedef Dartmv_face_facial_expression_recognized_cbFunction = void Function(
     mv_common.mv_rectangle_s face_location,
     int facial_expression,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for expression types can be determined for faces.
-///
-/// @since_tizen 3.0
-///
-/// @see mv_face_facial_expression_recognize()
-abstract class mv_face_facial_expression_e {
-  /// < Unknown face expression
-  static const int MV_FACE_UNKNOWN = 0;
-
-  /// < Face expression is neutral
-  static const int MV_FACE_NEUTRAL = 1;
-
-  /// < Face expression is smiling
-  static const int MV_FACE_SMILE = 2;
-
-  /// < Face expression is sadness
-  static const int MV_FACE_SADNESS = 3;
-
-  /// < Face expression is surprise
-  static const int MV_FACE_SURPRISE = 4;
-
-  /// < Face expression is anger
-  static const int MV_FACE_ANGER = 5;
-
-  /// < Face expression is fear
-  static const int MV_FACE_FEAR = 6;
-
-  /// < Face expression is disgust
-  static const int MV_FACE_DISGUST = 7;
-}
 
 const String MV_FACE_DETECTION_MODEL_FILE_PATH =
     'MV_FACE_DETECTION_MODEL_FILE_PATH';

--- a/lib/src/bindings/7.0/generated_bindings_mv_inference.dart
+++ b/lib/src/bindings/7.0/generated_bindings_mv_inference.dart
@@ -821,6 +821,185 @@ class Tizen70MvInference {
           ffi.Pointer<ffi.Float>)>();
 }
 
+/// @brief Enumeration for inference backend.
+/// #MV_INFERENCE_BACKEND_OPENCV An open source computer vision and machine learning
+/// software library.
+/// (https://opencv.org/about/)
+/// #MV_INFERENCE_BACKEND_TFLITE Google-introduced open source inference engine for embedded systems,
+/// which runs Tensorflow Lite model.
+/// (https://www.tensorflow.org/lite/guide/get_started)
+/// #MV_INFERENCE_BACKEND_ARMNN ARM-introduced open source inference engine for CPUs, GPUs and NPUs, which
+/// enables efficient translation of existing neural network frameworks
+/// such as TensorFlow, TensorFlow Lite and Caffes, allowing them to
+/// run efficiently without modification on Embedded hardware.
+/// (https://developer.arm.com/ip-products/processors/machine-learning/arm-nn)
+/// #MV_INFERENCE_BACKEND_MLAPI Samsung-introduced open source ML single API framework of NNStreamer, which
+/// runs various NN models via tensor filters of NNStreamer. (Deprecated since 7.0)
+/// (https://github.com/nnstreamer/nnstreamer)
+/// #MV_INFERENCE_BACKEND_ONE Samsung-introduced open source inference engine called On-device Neural Engine, which
+/// performs inference of a given NN model on various devices such as CPU, GPU, DSP and NPU.
+/// (https://github.com/Samsung/ONE)
+///
+/// @since_tizen 5.5
+///
+/// @see mv_inference_prepare()
+abstract class mv_inference_backend_type_e {
+  /// < None
+  static const int MV_INFERENCE_BACKEND_NONE = -1;
+
+  /// < OpenCV
+  static const int MV_INFERENCE_BACKEND_OPENCV = 0;
+
+  /// < TensorFlow-Lite
+  static const int MV_INFERENCE_BACKEND_TFLITE = 1;
+
+  /// < ARMNN (Since 6.0)
+  static const int MV_INFERENCE_BACKEND_ARMNN = 2;
+
+  /// < @deprecated ML Single API of NNStreamer (Deprecated since 7.0)
+  static const int MV_INFERENCE_BACKEND_MLAPI = 3;
+
+  /// < On-device Neural Engine (Since 6.0)
+  static const int MV_INFERENCE_BACKEND_ONE = 4;
+
+  /// < NNTrainer (Since 7.0)
+  static const int MV_INFERENCE_BACKEND_NNTRAINER = 5;
+
+  /// < SNPE Engine (Since 7.0)
+  static const int MV_INFERENCE_BACKEND_SNPE = 6;
+
+  /// < @deprecated Backend MAX (Deprecated since 7.0)
+  static const int MV_INFERENCE_BACKEND_MAX = 7;
+}
+
+/// @deprecated Deprecated since 6.0. Use #mv_inference_target_device_e instead.
+/// @brief Enumeration for inference target.
+///
+/// @since_tizen 5.5
+abstract class mv_inference_target_type_e {
+  /// < None
+  static const int MV_INFERENCE_TARGET_NONE = -1;
+
+  /// < CPU
+  static const int MV_INFERENCE_TARGET_CPU = 0;
+
+  /// < GPU
+  static const int MV_INFERENCE_TARGET_GPU = 1;
+
+  /// < CUSTOM
+  static const int MV_INFERENCE_TARGET_CUSTOM = 2;
+
+  /// < Target MAX
+  static const int MV_INFERENCE_TARGET_MAX = 3;
+}
+
+/// @brief Enumeration for inference target.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_target_device_e {
+  /// < None
+  static const int MV_INFERENCE_TARGET_DEVICE_NONE = 0;
+
+  /// < CPU
+  static const int MV_INFERENCE_TARGET_DEVICE_CPU = 1;
+
+  /// < GPU
+  static const int MV_INFERENCE_TARGET_DEVICE_GPU = 2;
+
+  /// < CUSTOM
+  static const int MV_INFERENCE_TARGET_DEVICE_CUSTOM = 4;
+
+  /// < Target MAX
+  static const int MV_INFERENCE_TARGET_DEVICE_MAX = 8;
+}
+
+/// @brief Enumeration for input data type.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_data_type_e {
+  /// < Data type of a given pre-trained model is float.
+  static const int MV_INFERENCE_DATA_FLOAT32 = 0;
+
+  /// < Data type of a given pre-trained model is unsigned char.
+  static const int MV_INFERENCE_DATA_UINT8 = 1;
+}
+
+/// @brief Enumeration for human pose landmark.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_human_pose_landmark_e {
+  /// < Head of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_HEAD = 1;
+
+  /// < Neck of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_NECK = 2;
+
+  /// < Thorax of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_THORAX = 3;
+
+  /// < Right shoulder of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_SHOULDER = 4;
+
+  /// < Right elbow of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_ELBOW = 5;
+
+  /// < Right wrist of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_WRIST = 6;
+
+  /// < Left shoulder of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_SHOULDER = 7;
+
+  /// < Left elbow of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_ELBOW = 8;
+
+  /// < Left wrist of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_WRIST = 9;
+
+  /// < Pelvis of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_PELVIS = 10;
+
+  /// < Right hip of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_HIP = 11;
+
+  /// < Right knee of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_KNEE = 12;
+
+  /// < Right ankle of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_ANKLE = 13;
+
+  /// < Left hip of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_HIP = 14;
+
+  /// < Left knee of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_KNEE = 15;
+
+  /// < Left ankle of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_ANKLE = 16;
+}
+
+/// @brief Enumeration for human body parts.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_human_body_part_e {
+  /// < HEAD, NECK, and THORAX
+  static const int MV_INFERENCE_HUMAN_BODY_PART_HEAD = 1;
+
+  /// < RIGHT SHOULDER, ELBOW, and WRIST
+  static const int MV_INFERENCE_HUMAN_BODY_PART_ARM_RIGHT = 2;
+
+  /// < LEFT SHOULDER, ELBOW, and WRIST
+  static const int MV_INFERENCE_HUMAN_BODY_PART_ARM_LEFT = 4;
+
+  /// < THORAX, PELVIS, RIGHT HIP, and LEFT HIP
+  static const int MV_INFERENCE_HUMAN_BODY_PART_BODY = 8;
+
+  /// < RIGHT HIP, KNEE, and ANKLE
+  static const int MV_INFERENCE_HUMAN_BODY_PART_LEG_RIGHT = 16;
+
+  /// < LEFT HIP, KNEE, and ANKLE
+  static const int MV_INFERENCE_HUMAN_BODY_PART_LEG_LEFT = 32;
+}
+
 /// @brief The inference handle.
 /// @details Contains information about location of
 /// detected landmarks for one or more poses.

--- a/lib/src/bindings/7.0/generated_bindings_tbm.dart
+++ b/lib/src/bindings/7.0/generated_bindings_tbm.dart
@@ -449,6 +449,8 @@ class Tizen70Tbm {
       _tbm_surface_get_formatPtr.asFunction<int Function(tbm_surface_h)>();
 }
 
+final class _tbm_surface extends ffi.Opaque {}
+
 /// @brief Enumeration for tbm_surface error type.
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
 abstract class tbm_surface_error_e {
@@ -544,11 +546,127 @@ typedef tbm_surface_plane_s = _tbm_surface_plane;
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
 typedef tbm_surface_h = ffi.Pointer<_tbm_surface>;
 
-final class _tbm_surface extends ffi.Opaque {}
-
 /// @brief Definition for the TBM surface information struct.
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
 typedef tbm_surface_info_s = _tbm_surface_info;
+
+const int TBM_FORMAT_C8 = 538982467;
+
+const int TBM_FORMAT_RGB332 = 943867730;
+
+const int TBM_FORMAT_BGR233 = 944916290;
+
+const int TBM_FORMAT_XRGB4444 = 842093144;
+
+const int TBM_FORMAT_XBGR4444 = 842089048;
+
+const int TBM_FORMAT_RGBX4444 = 842094674;
+
+const int TBM_FORMAT_BGRX4444 = 842094658;
+
+const int TBM_FORMAT_ARGB4444 = 842093121;
+
+const int TBM_FORMAT_ABGR4444 = 842089025;
+
+const int TBM_FORMAT_RGBA4444 = 842088786;
+
+const int TBM_FORMAT_BGRA4444 = 842088770;
+
+const int TBM_FORMAT_XRGB1555 = 892424792;
+
+const int TBM_FORMAT_XBGR1555 = 892420696;
+
+const int TBM_FORMAT_RGBX5551 = 892426322;
+
+const int TBM_FORMAT_BGRX5551 = 892426306;
+
+const int TBM_FORMAT_ARGB1555 = 892424769;
+
+const int TBM_FORMAT_ABGR1555 = 892420673;
+
+const int TBM_FORMAT_RGBA5551 = 892420434;
+
+const int TBM_FORMAT_BGRA5551 = 892420418;
+
+const int TBM_FORMAT_RGB565 = 909199186;
+
+const int TBM_FORMAT_BGR565 = 909199170;
+
+const int TBM_FORMAT_RGB888 = 875710290;
+
+const int TBM_FORMAT_BGR888 = 875710274;
+
+const int TBM_FORMAT_XRGB8888 = 875713112;
+
+const int TBM_FORMAT_XBGR8888 = 875709016;
+
+const int TBM_FORMAT_RGBX8888 = 875714642;
+
+const int TBM_FORMAT_BGRX8888 = 875714626;
+
+const int TBM_FORMAT_ARGB8888 = 875713089;
+
+const int TBM_FORMAT_ABGR8888 = 875708993;
+
+const int TBM_FORMAT_RGBA8888 = 875708754;
+
+const int TBM_FORMAT_BGRA8888 = 875708738;
+
+const int TBM_FORMAT_XRGB2101010 = 808669784;
+
+const int TBM_FORMAT_XBGR2101010 = 808665688;
+
+const int TBM_FORMAT_RGBX1010102 = 808671314;
+
+const int TBM_FORMAT_BGRX1010102 = 808671298;
+
+const int TBM_FORMAT_ARGB2101010 = 808669761;
+
+const int TBM_FORMAT_ABGR2101010 = 808665665;
+
+const int TBM_FORMAT_RGBA1010102 = 808665426;
+
+const int TBM_FORMAT_BGRA1010102 = 808665410;
+
+const int TBM_FORMAT_YUYV = 1448695129;
+
+const int TBM_FORMAT_YVYU = 1431918169;
+
+const int TBM_FORMAT_UYVY = 1498831189;
+
+const int TBM_FORMAT_VYUY = 1498765654;
+
+const int TBM_FORMAT_AYUV = 1448433985;
+
+const int TBM_FORMAT_NV12 = 842094158;
+
+const int TBM_FORMAT_NV21 = 825382478;
+
+const int TBM_FORMAT_NV16 = 909203022;
+
+const int TBM_FORMAT_NV61 = 825644622;
+
+const int TBM_FORMAT_YUV410 = 961959257;
+
+const int TBM_FORMAT_YVU410 = 961893977;
+
+const int TBM_FORMAT_YUV411 = 825316697;
+
+const int TBM_FORMAT_YVU411 = 825316953;
+
+const int TBM_FORMAT_YUV420 = 842093913;
+
+const int TBM_FORMAT_YVU420 = 842094169;
+
+const int TBM_FORMAT_YUV422 = 909202777;
+
+const int TBM_FORMAT_YVU422 = 909203033;
+
+const int TBM_FORMAT_YUV444 = 875713881;
+
+const int TBM_FORMAT_YVU444 = 875714137;
+
+const int TBM_FORMAT_NV12MT = 842091860;
 
 const int TBM_SURF_PLANE_MAX = 4;
 

--- a/lib/src/bindings/8.0/generated_bindings_capi_base_common.dart
+++ b/lib/src/bindings/8.0/generated_bindings_capi_base_common.dart
@@ -386,6 +386,8 @@ abstract class tizen_error_e {
   static const int TIZEN_ERROR_END_OF_COLLECTION = -1073741819;
 }
 
+const int NULL = 0;
+
 const int TIZEN_ERROR_MAX_PLATFORM_ERROR = 0;
 
 const int TIZEN_ERROR_MIN_PLATFORM_ERROR = -1073741824;

--- a/lib/src/bindings/8.0/generated_bindings_capi_geofence_manager.dart
+++ b/lib/src/bindings/8.0/generated_bindings_capi_geofence_manager.dart
@@ -1244,76 +1244,6 @@ class Tizen80CapiGeofenceManager {
 }
 
 /// @deprecated Deprecated since 8.0.
-/// @brief The geofence manager handle.
-/// @since_tizen 2.4
-typedef geofence_manager_h = ffi.Pointer<geofence_manager_s>;
-
-final class geofence_manager_s extends ffi.Opaque {}
-
-/// @deprecated Deprecated since 8.0.
-/// @brief The geofence handle.
-/// @since_tizen 2.4
-typedef geofence_h = ffi.Pointer<geofence_s>;
-
-final class geofence_s extends ffi.Opaque {}
-
-/// @deprecated Deprecated since 8.0.
-/// @brief Called when a device enters or exits the given geofence.
-/// @since_tizen 2.4
-/// @param[in] geofence_id The specified geofence ID
-/// @param[in] state The geofence state
-/// @param[in] user_data The user data passed from callback registration function
-/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_state_changed_cb().
-/// @see geofence_state_e
-/// @see geofence_manager_start()
-/// @see geofence_manager_set_geofence_state_changed_cb()
-typedef geofence_state_changed_cb
-    = ffi.Pointer<ffi.NativeFunction<geofence_state_changed_cbFunction>>;
-typedef geofence_state_changed_cbFunction = ffi.Void Function(
-    ffi.Int geofence_id, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
-typedef Dartgeofence_state_changed_cbFunction = void Function(
-    int geofence_id, int state, ffi.Pointer<ffi.Void> user_data);
-
-/// @deprecated Deprecated since 8.0.
-/// @brief Enumeration for the state of geofence manager.
-/// @since_tizen 2.4
-abstract class geofence_state_e {
-  /// < Uncertain state of geofence
-  static const int GEOFENCE_STATE_UNCERTAIN = 0;
-
-  /// < Geofence In state
-  static const int GEOFENCE_STATE_IN = 1;
-
-  /// < Geofence Out state
-  static const int GEOFENCE_STATE_OUT = 2;
-}
-
-/// @deprecated Deprecated since 8.0.
-/// @brief Called when the some event occurs in geofence and place such as add, update, etc..
-/// @details The events of public geofence is also received if there are public geofences.
-/// @since_tizen 2.4
-/// @remarks The value of place_id or geofence_id is -1 when the place ID or geofence ID is not assigned.
-/// @param[in] place_id The place ID
-/// @param[in] geofence_id The specified geofence ID
-/// @param[in] error The error code for the particular action
-/// @param[in] manage The result code for the particular place and geofence management
-/// @param[in] user_data The user data passed from callback registration function
-/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_event_cb()
-/// @see geofence_manage_e
-/// @see geofence_manager_start()
-/// @see geofence_manager_set_geofence_event_cb()
-typedef geofence_event_cb
-    = ffi.Pointer<ffi.NativeFunction<geofence_event_cbFunction>>;
-typedef geofence_event_cbFunction = ffi.Void Function(
-    ffi.Int place_id,
-    ffi.Int geofence_id,
-    ffi.Int32 error,
-    ffi.Int32 manage,
-    ffi.Pointer<ffi.Void> user_data);
-typedef Dartgeofence_event_cbFunction = void Function(int place_id,
-    int geofence_id, int error, int manage, ffi.Pointer<ffi.Void> user_data);
-
-/// @deprecated Deprecated since 8.0.
 /// @brief Enumeration for Geofence manager of error code.
 /// @since_tizen 2.4
 abstract class geofence_manager_error_e {
@@ -1361,58 +1291,18 @@ abstract class geofence_manager_error_e {
 }
 
 /// @deprecated Deprecated since 8.0.
-/// @brief Enumeration for geofence management events.
+/// @brief Enumeration for the state of geofence manager.
 /// @since_tizen 2.4
-abstract class geofence_manage_e {
-  /// < Geofence is added
-  static const int GEOFENCE_MANAGE_FENCE_ADDED = 0;
+abstract class geofence_state_e {
+  /// < Uncertain state of geofence
+  static const int GEOFENCE_STATE_UNCERTAIN = 0;
 
-  /// < Geofence is removed
-  static const int GEOFENCE_MANAGE_FENCE_REMOVED = 1;
+  /// < Geofence In state
+  static const int GEOFENCE_STATE_IN = 1;
 
-  /// < Geofencing is started
-  static const int GEOFENCE_MANAGE_FENCE_STARTED = 2;
-
-  /// < Geofencing is stopped
-  static const int GEOFENCE_MANAGE_FENCE_STOPPED = 3;
-
-  /// < Place is added
-  static const int GEOFENCE_MANAGE_PLACE_ADDED = 16;
-
-  /// < Place is removed
-  static const int GEOFENCE_MANAGE_PLACE_REMOVED = 17;
-
-  /// < Place is updated
-  static const int GEOFENCE_MANAGE_PLACE_UPDATED = 18;
-
-  /// < Setting for geofencing is enabled
-  static const int GEOFENCE_MANAGE_SETTING_ENABLED = 32;
-
-  /// < Setting for geofencing is disabled
-  static const int GEOFENCE_MANAGE_SETTING_DISABLED = 33;
+  /// < Geofence Out state
+  static const int GEOFENCE_STATE_OUT = 2;
 }
-
-/// @deprecated Deprecated since 8.0.
-/// @brief Called when a proximity state of device is changed.
-/// @since_tizen 3.0
-/// @param[in] geofence_id The specified geofence ID
-/// @param[in] state The proximity state
-/// @param[in] provider The proximity provider
-/// @param[in] user_data The user data passed from callback registration function
-/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_proximity_state_changed_cb().
-/// @see geofence_proximity_state_e
-/// @see geofence_proximity_provider_e
-/// @see geofence_manager_start()
-/// @see geofence_manager_set_geofence_proximity_state_changed_cb()
-typedef geofence_proximity_state_changed_cb = ffi
-    .Pointer<ffi.NativeFunction<geofence_proximity_state_changed_cbFunction>>;
-typedef geofence_proximity_state_changed_cbFunction = ffi.Void Function(
-    ffi.Int geofence_id,
-    ffi.Int32 state,
-    ffi.Int32 provider,
-    ffi.Pointer<ffi.Void> user_data);
-typedef Dartgeofence_proximity_state_changed_cbFunction = void Function(
-    int geofence_id, int state, int provider, ffi.Pointer<ffi.Void> user_data);
 
 /// @deprecated Deprecated since 8.0.
 /// @brief Enumeration for the state of proximity.
@@ -1450,6 +1340,132 @@ abstract class geofence_proximity_provider_e {
   /// < Proximity is specified by Sensor
   static const int GEOFENCE_PROXIMITY_PROVIDER_SENSOR = 4;
 }
+
+/// @deprecated Deprecated since 8.0.
+/// @brief Enumeration for geofence type.
+/// @since_tizen 2.4
+abstract class geofence_type_e {
+  /// < Geofence is specified by geospatial coordinate
+  static const int GEOFENCE_TYPE_GEOPOINT = 1;
+
+  /// < Geofence is specified by Wi-Fi access point
+  static const int GEOFENCE_TYPE_WIFI = 2;
+
+  /// < Geofence is specified by Bluetooth device
+  static const int GEOFENCE_TYPE_BT = 3;
+}
+
+/// @deprecated Deprecated since 8.0.
+/// @brief Enumeration for geofence management events.
+/// @since_tizen 2.4
+abstract class geofence_manage_e {
+  /// < Geofence is added
+  static const int GEOFENCE_MANAGE_FENCE_ADDED = 0;
+
+  /// < Geofence is removed
+  static const int GEOFENCE_MANAGE_FENCE_REMOVED = 1;
+
+  /// < Geofencing is started
+  static const int GEOFENCE_MANAGE_FENCE_STARTED = 2;
+
+  /// < Geofencing is stopped
+  static const int GEOFENCE_MANAGE_FENCE_STOPPED = 3;
+
+  /// < Place is added
+  static const int GEOFENCE_MANAGE_PLACE_ADDED = 16;
+
+  /// < Place is removed
+  static const int GEOFENCE_MANAGE_PLACE_REMOVED = 17;
+
+  /// < Place is updated
+  static const int GEOFENCE_MANAGE_PLACE_UPDATED = 18;
+
+  /// < Setting for geofencing is enabled
+  static const int GEOFENCE_MANAGE_SETTING_ENABLED = 32;
+
+  /// < Setting for geofencing is disabled
+  static const int GEOFENCE_MANAGE_SETTING_DISABLED = 33;
+}
+
+final class geofence_manager_s extends ffi.Opaque {}
+
+final class geofence_s extends ffi.Opaque {}
+
+final class geofence_status_s extends ffi.Opaque {}
+
+/// @deprecated Deprecated since 8.0.
+/// @brief The geofence manager handle.
+/// @since_tizen 2.4
+typedef geofence_manager_h = ffi.Pointer<geofence_manager_s>;
+
+/// @deprecated Deprecated since 8.0.
+/// @brief The geofence handle.
+/// @since_tizen 2.4
+typedef geofence_h = ffi.Pointer<geofence_s>;
+
+/// @deprecated Deprecated since 8.0.
+/// @brief Called when a device enters or exits the given geofence.
+/// @since_tizen 2.4
+/// @param[in] geofence_id The specified geofence ID
+/// @param[in] state The geofence state
+/// @param[in] user_data The user data passed from callback registration function
+/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_state_changed_cb().
+/// @see geofence_state_e
+/// @see geofence_manager_start()
+/// @see geofence_manager_set_geofence_state_changed_cb()
+typedef geofence_state_changed_cb
+    = ffi.Pointer<ffi.NativeFunction<geofence_state_changed_cbFunction>>;
+typedef geofence_state_changed_cbFunction = ffi.Void Function(
+    ffi.Int geofence_id, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
+typedef Dartgeofence_state_changed_cbFunction = void Function(
+    int geofence_id, int state, ffi.Pointer<ffi.Void> user_data);
+
+/// @deprecated Deprecated since 8.0.
+/// @brief Called when the some event occurs in geofence and place such as add, update, etc..
+/// @details The events of public geofence is also received if there are public geofences.
+/// @since_tizen 2.4
+/// @remarks The value of place_id or geofence_id is -1 when the place ID or geofence ID is not assigned.
+/// @param[in] place_id The place ID
+/// @param[in] geofence_id The specified geofence ID
+/// @param[in] error The error code for the particular action
+/// @param[in] manage The result code for the particular place and geofence management
+/// @param[in] user_data The user data passed from callback registration function
+/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_event_cb()
+/// @see geofence_manage_e
+/// @see geofence_manager_start()
+/// @see geofence_manager_set_geofence_event_cb()
+typedef geofence_event_cb
+    = ffi.Pointer<ffi.NativeFunction<geofence_event_cbFunction>>;
+typedef geofence_event_cbFunction = ffi.Void Function(
+    ffi.Int place_id,
+    ffi.Int geofence_id,
+    ffi.Int32 error,
+    ffi.Int32 manage,
+    ffi.Pointer<ffi.Void> user_data);
+typedef Dartgeofence_event_cbFunction = void Function(int place_id,
+    int geofence_id, int error, int manage, ffi.Pointer<ffi.Void> user_data);
+
+/// @deprecated Deprecated since 8.0.
+/// @brief Called when a proximity state of device is changed.
+/// @since_tizen 3.0
+/// @param[in] geofence_id The specified geofence ID
+/// @param[in] state The proximity state
+/// @param[in] provider The proximity provider
+/// @param[in] user_data The user data passed from callback registration function
+/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_proximity_state_changed_cb().
+/// @see geofence_proximity_state_e
+/// @see geofence_proximity_provider_e
+/// @see geofence_manager_start()
+/// @see geofence_manager_set_geofence_proximity_state_changed_cb()
+typedef geofence_proximity_state_changed_cb = ffi
+    .Pointer<ffi.NativeFunction<geofence_proximity_state_changed_cbFunction>>;
+typedef geofence_proximity_state_changed_cbFunction = ffi.Void Function(
+    ffi.Int geofence_id,
+    ffi.Int32 state,
+    ffi.Int32 provider,
+    ffi.Pointer<ffi.Void> user_data);
+typedef Dartgeofence_proximity_state_changed_cbFunction = void Function(
+    int geofence_id, int state, int provider, ffi.Pointer<ffi.Void> user_data);
 
 /// @deprecated Deprecated since 8.0.
 /// @brief Called when the fence list is requested.
@@ -1509,22 +1525,6 @@ typedef Dartgeofence_manager_place_cbFunction = bool Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @deprecated Deprecated since 8.0.
-/// @brief Enumeration for geofence type.
-/// @since_tizen 2.4
-abstract class geofence_type_e {
-  /// < Geofence is specified by geospatial coordinate
-  static const int GEOFENCE_TYPE_GEOPOINT = 1;
-
-  /// < Geofence is specified by Wi-Fi access point
-  static const int GEOFENCE_TYPE_WIFI = 2;
-
-  /// < Geofence is specified by Bluetooth device
-  static const int GEOFENCE_TYPE_BT = 3;
-}
-
-/// @deprecated Deprecated since 8.0.
 /// @brief The geofence status handle.
 /// @since_tizen 2.4
 typedef geofence_status_h = ffi.Pointer<geofence_status_s>;
-
-final class geofence_status_s extends ffi.Opaque {}

--- a/lib/src/bindings/8.0/generated_bindings_capi_media_controller.dart
+++ b/lib/src/bindings/8.0/generated_bindings_capi_media_controller.dart
@@ -6781,6 +6781,461 @@ class Tizen80CapiMediaController {
       .asFunction<int Function(mc_server_h, ffi.Pointer<ffi.Char>)>();
 }
 
+/// @brief Enumeration for the media controller error.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_error_e {
+  /// < Successful
+  static const int MEDIA_CONTROLLER_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int MEDIA_CONTROLLER_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int MEDIA_CONTROLLER_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Invalid Operation
+  static const int MEDIA_CONTROLLER_ERROR_INVALID_OPERATION = -38;
+
+  /// < No space left on device
+  static const int MEDIA_CONTROLLER_ERROR_FILE_NO_SPACE_ON_DEVICE = -28;
+
+  /// < Permission denied
+  static const int MEDIA_CONTROLLER_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Limited by server application (since 5.5)
+  static const int MEDIA_CONTROLLER_ERROR_ABILITY_LIMITED_BY_SERVER_APP =
+      -50462719;
+}
+
+/// @brief Enumeration for the media controller server state.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_server_state_e {
+  /// < None state
+  static const int MC_SERVER_STATE_NONE = 0;
+
+  /// < Activate state
+  static const int MC_SERVER_STATE_ACTIVATE = 1;
+
+  /// < Deactivate state
+  static const int MC_SERVER_STATE_DEACTIVATE = 2;
+}
+
+/// @brief Enumeration for the media meta info.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_meta_e {
+  /// < Title
+  static const int MC_META_MEDIA_TITLE = 0;
+
+  /// < Artist
+  static const int MC_META_MEDIA_ARTIST = 1;
+
+  /// < Album
+  static const int MC_META_MEDIA_ALBUM = 2;
+
+  /// < Author
+  static const int MC_META_MEDIA_AUTHOR = 3;
+
+  /// < Genre
+  static const int MC_META_MEDIA_GENRE = 4;
+
+  /// < Duration
+  static const int MC_META_MEDIA_DURATION = 5;
+
+  /// < Date
+  static const int MC_META_MEDIA_DATE = 6;
+
+  /// < Copyright
+  static const int MC_META_MEDIA_COPYRIGHT = 7;
+
+  /// < Description
+  static const int MC_META_MEDIA_DESCRIPTION = 8;
+
+  /// < Track Number
+  static const int MC_META_MEDIA_TRACK_NUM = 9;
+
+  /// < Picture. Album Art
+  static const int MC_META_MEDIA_PICTURE = 10;
+
+  /// < Season (Since 5.5)
+  static const int MC_META_MEDIA_SEASON = 11;
+
+  /// < Episode (Since 5.5)
+  static const int MC_META_MEDIA_EPISODE = 12;
+
+  /// < Content resolution (Since 5.5)
+  static const int MC_META_MEDIA_RESOLUTION = 13;
+}
+
+/// @brief Enumeration for the media playback state.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_playback_states_e {
+  /// < None
+  static const int MC_PLAYBACK_STATE_NONE = 0;
+
+  /// < Playing
+  static const int MC_PLAYBACK_STATE_PLAYING = 1;
+
+  /// < Paused
+  static const int MC_PLAYBACK_STATE_PAUSED = 2;
+
+  /// < Stopped
+  static const int MC_PLAYBACK_STATE_STOPPED = 3;
+
+  /// < Moving to the next item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_MOVING_TO_NEXT = 8;
+
+  /// < Moving to the previous item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_MOVING_TO_PREVIOUS = 9;
+
+  /// < Fast forwarding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_FAST_FORWARDING = 10;
+
+  /// < Rewinding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_PLAYBACK_STATE_REWINDING = 11;
+
+  /// < Connecting (Since 6.0)
+  static const int MC_PLAYBACK_STATE_CONNECTING = 12;
+
+  /// < Buffering (Since 6.0)
+  static const int MC_PLAYBACK_STATE_BUFFERING = 13;
+
+  /// < Error (Since 6.0)
+  static const int MC_PLAYBACK_STATE_ERROR = 14;
+}
+
+/// @brief Enumeration for the media playback action.
+/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
+abstract class mc_playback_action_e {
+  /// < Play
+  static const int MC_PLAYBACK_ACTION_PLAY = 0;
+
+  /// < Pause
+  static const int MC_PLAYBACK_ACTION_PAUSE = 1;
+
+  /// < Stop
+  static const int MC_PLAYBACK_ACTION_STOP = 2;
+
+  /// < Next item
+  static const int MC_PLAYBACK_ACTION_NEXT = 3;
+
+  /// < Previous item
+  static const int MC_PLAYBACK_ACTION_PREV = 4;
+
+  /// < Fast forward
+  static const int MC_PLAYBACK_ACTION_FAST_FORWARD = 5;
+
+  /// < Rewind
+  static const int MC_PLAYBACK_ACTION_REWIND = 6;
+
+  /// < Play/Pause toggle
+  static const int MC_PLAYBACK_ACTION_TOGGLE_PLAY_PAUSE = 7;
+}
+
+/// @brief Enumeration for the shuffle mode.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_shuffle_mode_e {
+  /// < Shuffle mode on
+  static const int MC_SHUFFLE_MODE_ON = 0;
+
+  /// < Shuffle mode off
+  static const int MC_SHUFFLE_MODE_OFF = 1;
+}
+
+/// @brief Enumeration for the repeat mode.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_repeat_mode_e {
+  /// < Repeat mode on for all media
+  static const int MC_REPEAT_MODE_ON = 0;
+
+  /// < Repeat mode off
+  static const int MC_REPEAT_MODE_OFF = 1;
+
+  /// < Repeat mode on for one media (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_REPEAT_MODE_ONE_MEDIA = 2;
+}
+
+/// @brief Enumeration for the subscription type.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class mc_subscription_type_e {
+  /// < Server state
+  static const int MC_SUBSCRIPTION_TYPE_SERVER_STATE = 0;
+
+  /// < Playback
+  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK = 1;
+
+  /// < Metadata
+  static const int MC_SUBSCRIPTION_TYPE_METADATA = 2;
+
+  /// < Shuffle mode
+  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_MODE = 3;
+
+  /// < Repeat mode
+  static const int MC_SUBSCRIPTION_TYPE_REPEAT_MODE = 4;
+
+  /// < Playlist (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
+  static const int MC_SUBSCRIPTION_TYPE_PLAYLIST = 5;
+
+  /// < Playback ability (Since 5.0)
+  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK_ABILITY = 6;
+
+  /// < Shuffle ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
+  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_ABILITY = 7;
+
+  /// < Repeat ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
+  static const int MC_SUBSCRIPTION_TYPE_REPEAT_ABILITY = 8;
+
+  /// < Ability support (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT = 9;
+
+  /// < Display mode ability (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_MODE_ABILITY = 10;
+
+  /// < Display rotation ability (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_ROTATION_ABILITY = 11;
+}
+
+/// @brief Enumeration for the playlist update mode.
+/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
+abstract class mc_playlist_update_mode_e {
+  /// < Create or Update playlist
+  static const int MC_PLAYLIST_UPDATED = 0;
+
+  /// < Remove playlist
+  static const int MC_PLAYLIST_REMOVED = 1;
+}
+
+/// @brief Enumeration for the content type of the content.
+/// @since_tizen 5.0
+abstract class mc_content_type_e {
+  /// < Image content type
+  static const int MC_CONTENT_TYPE_IMAGE = 0;
+
+  /// < Video content type
+  static const int MC_CONTENT_TYPE_VIDEO = 1;
+
+  /// < Music content type
+  static const int MC_CONTENT_TYPE_MUSIC = 2;
+
+  /// < Other content type
+  static const int MC_CONTENT_TYPE_OTHER = 3;
+
+  /// < Not decided
+  static const int MC_CONTENT_TYPE_UNDECIDED = 4;
+}
+
+/// @brief Enumeration for the content age rating of the content.
+/// @since_tizen 5.0
+abstract class mc_content_age_rating_e {
+  /// < Suitable for all ages
+  static const int MC_CONTENT_RATING_ALL = 0;
+
+  /// < Suitable for ages 1 and up
+  static const int MC_CONTENT_RATING_1_PLUS = 1;
+
+  /// < Suitable for ages 2 and up
+  static const int MC_CONTENT_RATING_2_PLUS = 2;
+
+  /// < Suitable for ages 3 and up
+  static const int MC_CONTENT_RATING_3_PLUS = 3;
+
+  /// < Suitable for ages 4 and up
+  static const int MC_CONTENT_RATING_4_PLUS = 4;
+
+  /// < Suitable for ages 5 and up
+  static const int MC_CONTENT_RATING_5_PLUS = 5;
+
+  /// < Suitable for ages 6 and up
+  static const int MC_CONTENT_RATING_6_PLUS = 6;
+
+  /// < Suitable for ages 7 and up
+  static const int MC_CONTENT_RATING_7_PLUS = 7;
+
+  /// < Suitable for ages 8 and up
+  static const int MC_CONTENT_RATING_8_PLUS = 8;
+
+  /// < Suitable for ages 9 and up
+  static const int MC_CONTENT_RATING_9_PLUS = 9;
+
+  /// < Suitable for ages 10 and up
+  static const int MC_CONTENT_RATING_10_PLUS = 10;
+
+  /// < Suitable for ages 11 and up
+  static const int MC_CONTENT_RATING_11_PLUS = 11;
+
+  /// < Suitable for ages 12 and up
+  static const int MC_CONTENT_RATING_12_PLUS = 12;
+
+  /// < Suitable for ages 13 and up
+  static const int MC_CONTENT_RATING_13_PLUS = 13;
+
+  /// < Suitable for ages 14 and up
+  static const int MC_CONTENT_RATING_14_PLUS = 14;
+
+  /// < Suitable for ages 15 and up
+  static const int MC_CONTENT_RATING_15_PLUS = 15;
+
+  /// < Suitable for ages 16 and up
+  static const int MC_CONTENT_RATING_16_PLUS = 16;
+
+  /// < Suitable for ages 17 and up
+  static const int MC_CONTENT_RATING_17_PLUS = 17;
+
+  /// < Suitable for ages 18 and up
+  static const int MC_CONTENT_RATING_18_PLUS = 18;
+
+  /// < Suitable for ages 19 and up
+  static const int MC_CONTENT_RATING_19_PLUS = 19;
+}
+
+/// @brief Enumeration for the support of the ability.
+/// @since_tizen 5.0
+abstract class mc_ability_support_e {
+  /// < Supported
+  static const int MC_ABILITY_SUPPORTED_YES = 0;
+
+  /// < Not supported
+  static const int MC_ABILITY_SUPPORTED_NO = 1;
+
+  /// < Not decided
+  static const int MC_ABILITY_SUPPORTED_UNDECIDED = 2;
+}
+
+/// @brief Enumeration for the ability.
+/// @since_tizen 5.5
+abstract class mc_ability_e {
+  /// < Shuffle
+  static const int MC_ABILITY_SHUFFLE = 0;
+
+  /// < Repeat
+  static const int MC_ABILITY_REPEAT = 1;
+
+  /// < Playback Position
+  static const int MC_ABILITY_PLAYBACK_POSITION = 2;
+
+  /// < Playlist
+  static const int MC_ABILITY_PLAYLIST = 3;
+
+  /// < Custom command from a client
+  static const int MC_ABILITY_CLIENT_CUSTOM = 4;
+
+  /// < Search
+  static const int MC_ABILITY_SEARCH = 5;
+
+  /// < Subtitles display
+  static const int MC_ABILITY_SUBTITLES = 6;
+
+  /// < 360 content mode display
+  static const int MC_ABILITY_360_MODE = 7;
+}
+
+/// @brief Enumeration for the search category.
+/// @since_tizen 5.0
+abstract class mc_search_category_e {
+  /// < No search category
+  static const int MC_SEARCH_NO_CATEGORY = 0;
+
+  /// < Search by content title
+  static const int MC_SEARCH_TITLE = 1;
+
+  /// < Search by content artist
+  static const int MC_SEARCH_ARTIST = 2;
+
+  /// < Search by content album
+  static const int MC_SEARCH_ALBUM = 3;
+
+  /// < Search by content genre
+  static const int MC_SEARCH_GENRE = 4;
+
+  /// < Search by Time Place Occasion
+  static const int MC_SEARCH_TPO = 5;
+}
+
+/// @brief Enumeration for the display mode.
+/// @since_tizen 5.5
+abstract class mc_display_mode_e {
+  /// < Letter box
+  static const int MC_DISPLAY_MODE_LETTER_BOX = 1;
+
+  /// < Origin size
+  static const int MC_DISPLAY_MODE_ORIGIN_SIZE = 2;
+
+  /// < Full-screen
+  static const int MC_DISPLAY_MODE_FULL_SCREEN = 4;
+
+  /// < Cropped full-screen
+  static const int MC_DISPLAY_MODE_CROPPED_FULL = 8;
+}
+
+/// @brief Enumeration for the display rotation.
+/// @since_tizen 5.5
+abstract class mc_display_rotation_e {
+  /// < Display is not rotated
+  static const int MC_DISPLAY_ROTATION_NONE = 1;
+
+  /// < Display is rotated 90 degrees
+  static const int MC_DISPLAY_ROTATION_90 = 2;
+
+  /// < Display is rotated 180 degrees
+  static const int MC_DISPLAY_ROTATION_180 = 4;
+
+  /// < Display is rotated 270 degrees
+  static const int MC_DISPLAY_ROTATION_270 = 8;
+}
+
+/// @brief The result codes of the reply for the command or the event.
+/// @since_tizen 6.0
+///
+/// @see mc_cmd_reply_received_cb()
+/// @see mc_client_send_event_reply()
+/// @see mc_server_event_reply_received_cb()
+/// @see mc_server_send_cmd_reply()
+abstract class mc_result_code_e {
+  /// < The command or the event has been successfully completed.
+  static const int MC_RESULT_CODE_SUCCESS = 0;
+
+  /// < The command or the event had already been completed.
+  static const int MC_RESULT_CODE_ALREADY_DONE = 200;
+
+  /// < The command or the event is aborted by some external event (e.g. aborted play command by incoming call).
+  static const int MC_RESULT_CODE_ABORTED = 300;
+
+  /// < The command or the event is denied due to application policy (e.g. cannot rewind in recording).
+  static const int MC_RESULT_CODE_DENIED = 301;
+
+  /// < The command or the event is not supported.
+  static const int MC_RESULT_CODE_NOT_SUPPORTED = 302;
+
+  /// < The command or the event is out of supported range or the limit is reached.
+  static const int MC_RESULT_CODE_INVALID = 303;
+
+  /// < Timeout has occurred.
+  static const int MC_RESULT_CODE_TIMEOUT = 400;
+
+  /// < The application has failed.
+  static const int MC_RESULT_CODE_APP_FAILED = 401;
+
+  /// < The command or the event has failed because the application has no media.
+  static const int MC_RESULT_CODE_NO_MEDIA = 402;
+
+  /// < The command or the event has failed because there is no audio output device.
+  static const int MC_RESULT_CODE_NO_AUDIO_OUTPUT_DEVICE = 403;
+
+  /// < The command or the event has failed because there is no peer.
+  static const int MC_RESULT_CODE_NO_PEER = 404;
+
+  /// < The network has failed.
+  static const int MC_RESULT_CODE_NETWORK_FAILED = 500;
+
+  /// < The application needs to have an account to which it's logged in.
+  static const int MC_RESULT_CODE_NO_ACCOUNT = 600;
+
+  /// < The application could not log in.
+  static const int MC_RESULT_CODE_LOGIN_FAILED = 601;
+
+  /// < Unknown error.
+  static const int MC_RESULT_CODE_UNKNOWN = 2147483647;
+}
+
 /// @brief The structure type for the media controller playlist handle.
 /// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
 typedef mc_playlist_h = ffi.Pointer<ffi.Void>;
@@ -6848,141 +7303,13 @@ typedef mc_playlist_cbFunction = ffi.Bool Function(
 typedef Dartmc_playlist_cbFunction = bool Function(
     mc_playlist_h playlist, ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the media meta info.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_meta_e {
-  /// < Title
-  static const int MC_META_MEDIA_TITLE = 0;
-
-  /// < Artist
-  static const int MC_META_MEDIA_ARTIST = 1;
-
-  /// < Album
-  static const int MC_META_MEDIA_ALBUM = 2;
-
-  /// < Author
-  static const int MC_META_MEDIA_AUTHOR = 3;
-
-  /// < Genre
-  static const int MC_META_MEDIA_GENRE = 4;
-
-  /// < Duration
-  static const int MC_META_MEDIA_DURATION = 5;
-
-  /// < Date
-  static const int MC_META_MEDIA_DATE = 6;
-
-  /// < Copyright
-  static const int MC_META_MEDIA_COPYRIGHT = 7;
-
-  /// < Description
-  static const int MC_META_MEDIA_DESCRIPTION = 8;
-
-  /// < Track Number
-  static const int MC_META_MEDIA_TRACK_NUM = 9;
-
-  /// < Picture. Album Art
-  static const int MC_META_MEDIA_PICTURE = 10;
-
-  /// < Season (Since 5.5)
-  static const int MC_META_MEDIA_SEASON = 11;
-
-  /// < Episode (Since 5.5)
-  static const int MC_META_MEDIA_EPISODE = 12;
-
-  /// < Content resolution (Since 5.5)
-  static const int MC_META_MEDIA_RESOLUTION = 13;
-}
-
 /// @brief The structure type for the media controller ability handle.
 /// @since_tizen 5.0
 typedef mc_playback_ability_h = ffi.Pointer<ffi.Void>;
 
-/// @brief Enumeration for the media playback action.
-/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
-abstract class mc_playback_action_e {
-  /// < Play
-  static const int MC_PLAYBACK_ACTION_PLAY = 0;
-
-  /// < Pause
-  static const int MC_PLAYBACK_ACTION_PAUSE = 1;
-
-  /// < Stop
-  static const int MC_PLAYBACK_ACTION_STOP = 2;
-
-  /// < Next item
-  static const int MC_PLAYBACK_ACTION_NEXT = 3;
-
-  /// < Previous item
-  static const int MC_PLAYBACK_ACTION_PREV = 4;
-
-  /// < Fast forward
-  static const int MC_PLAYBACK_ACTION_FAST_FORWARD = 5;
-
-  /// < Rewind
-  static const int MC_PLAYBACK_ACTION_REWIND = 6;
-
-  /// < Play/Pause toggle
-  static const int MC_PLAYBACK_ACTION_TOGGLE_PLAY_PAUSE = 7;
-}
-
-/// @brief Enumeration for the support of the ability.
-/// @since_tizen 5.0
-abstract class mc_ability_support_e {
-  /// < Supported
-  static const int MC_ABILITY_SUPPORTED_YES = 0;
-
-  /// < Not supported
-  static const int MC_ABILITY_SUPPORTED_NO = 1;
-
-  /// < Not decided
-  static const int MC_ABILITY_SUPPORTED_UNDECIDED = 2;
-}
-
 /// @brief The structure type for the media controller search handle.
 /// @since_tizen 5.0
 typedef mc_search_h = ffi.Pointer<ffi.Void>;
-
-/// @brief Enumeration for the content type of the content.
-/// @since_tizen 5.0
-abstract class mc_content_type_e {
-  /// < Image content type
-  static const int MC_CONTENT_TYPE_IMAGE = 0;
-
-  /// < Video content type
-  static const int MC_CONTENT_TYPE_VIDEO = 1;
-
-  /// < Music content type
-  static const int MC_CONTENT_TYPE_MUSIC = 2;
-
-  /// < Other content type
-  static const int MC_CONTENT_TYPE_OTHER = 3;
-
-  /// < Not decided
-  static const int MC_CONTENT_TYPE_UNDECIDED = 4;
-}
-
-/// @brief Enumeration for the search category.
-/// @since_tizen 5.0
-abstract class mc_search_category_e {
-  /// < No search category
-  static const int MC_SEARCH_NO_CATEGORY = 0;
-
-  /// < Search by content title
-  static const int MC_SEARCH_TITLE = 1;
-
-  /// < Search by content artist
-  static const int MC_SEARCH_ARTIST = 2;
-
-  /// < Search by content album
-  static const int MC_SEARCH_ALBUM = 3;
-
-  /// < Search by content genre
-  static const int MC_SEARCH_GENRE = 4;
-
-  /// < Search by Time Place Occasion
-  static const int MC_SEARCH_TPO = 5;
-}
 
 /// @brief Called for every search condition information in the obtained list of search.
 /// @details Iterates over a search list.
@@ -7047,19 +7374,6 @@ typedef Dartmc_server_state_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the media controller server state.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_server_state_e {
-  /// < None state
-  static const int MC_SERVER_STATE_NONE = 0;
-
-  /// < Activate state
-  static const int MC_SERVER_STATE_ACTIVATE = 1;
-
-  /// < Deactivate state
-  static const int MC_SERVER_STATE_DEACTIVATE = 2;
-}
 
 /// @brief Called when the playback information of the media controller server is updated.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
@@ -7146,16 +7460,6 @@ typedef Dartmc_shuffle_mode_updated_cbFunction = void Function(
     int mode,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the shuffle mode.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_shuffle_mode_e {
-  /// < Shuffle mode on
-  static const int MC_SHUFFLE_MODE_ON = 0;
-
-  /// < Shuffle mode off
-  static const int MC_SHUFFLE_MODE_OFF = 1;
-}
-
 /// @brief Called when the repeat mode of the media controller server is updated.
 /// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
 ///
@@ -7180,19 +7484,6 @@ typedef Dartmc_repeat_mode_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int mode,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the repeat mode.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_repeat_mode_e {
-  /// < Repeat mode on for all media
-  static const int MC_REPEAT_MODE_ON = 0;
-
-  /// < Repeat mode off
-  static const int MC_REPEAT_MODE_OFF = 1;
-
-  /// < Repeat mode on for one media (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_REPEAT_MODE_ONE_MEDIA = 2;
-}
 
 /// @brief Called when the playback ability support of the media controller server is updated.
 /// @since_tizen 5.0
@@ -7299,34 +7590,6 @@ typedef Dartmc_ability_support_updated_cbFunction = void Function(
     int support,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the ability.
-/// @since_tizen 5.5
-abstract class mc_ability_e {
-  /// < Shuffle
-  static const int MC_ABILITY_SHUFFLE = 0;
-
-  /// < Repeat
-  static const int MC_ABILITY_REPEAT = 1;
-
-  /// < Playback Position
-  static const int MC_ABILITY_PLAYBACK_POSITION = 2;
-
-  /// < Playlist
-  static const int MC_ABILITY_PLAYLIST = 3;
-
-  /// < Custom command from a client
-  static const int MC_ABILITY_CLIENT_CUSTOM = 4;
-
-  /// < Search
-  static const int MC_ABILITY_SEARCH = 5;
-
-  /// < Subtitles display
-  static const int MC_ABILITY_SUBTITLES = 6;
-
-  /// < 360 content mode display
-  static const int MC_ABILITY_360_MODE = 7;
-}
-
 /// @brief Called when a media controller server's supported items for an ability is updated.
 /// @since_tizen 5.5
 ///
@@ -7416,16 +7679,6 @@ typedef Dartmc_playlist_updated_cbFunction = void Function(
     mc_playlist_h playlist,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the playlist update mode.
-/// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
-abstract class mc_playlist_update_mode_e {
-  /// < Create or Update playlist
-  static const int MC_PLAYLIST_UPDATED = 0;
-
-  /// < Remove playlist
-  static const int MC_PLAYLIST_REMOVED = 1;
-}
-
 /// @brief Called when the status of a media controller server's boolean attribute (subtitles or 360 mode) is updated.
 /// @since_tizen 5.5
 ///
@@ -7473,22 +7726,6 @@ typedef Dartmc_display_mode_updated_cbFunction = void Function(
     int mode,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the display mode.
-/// @since_tizen 5.5
-abstract class mc_display_mode_e {
-  /// < Letter box
-  static const int MC_DISPLAY_MODE_LETTER_BOX = 1;
-
-  /// < Origin size
-  static const int MC_DISPLAY_MODE_ORIGIN_SIZE = 2;
-
-  /// < Full-screen
-  static const int MC_DISPLAY_MODE_FULL_SCREEN = 4;
-
-  /// < Cropped full-screen
-  static const int MC_DISPLAY_MODE_CROPPED_FULL = 8;
-}
-
 /// @brief Called when a media controller server's display rotation is updated.
 /// @since_tizen 5.5
 ///
@@ -7511,22 +7748,6 @@ typedef Dartmc_display_rotation_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int rotation,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the display rotation.
-/// @since_tizen 5.5
-abstract class mc_display_rotation_e {
-  /// < Display is not rotated
-  static const int MC_DISPLAY_ROTATION_NONE = 1;
-
-  /// < Display is rotated 90 degrees
-  static const int MC_DISPLAY_ROTATION_90 = 2;
-
-  /// < Display is rotated 180 degrees
-  static const int MC_DISPLAY_ROTATION_180 = 4;
-
-  /// < Display is rotated 270 degrees
-  static const int MC_DISPLAY_ROTATION_270 = 8;
-}
 
 /// @brief Called when receiving custom event of media controller servers.
 /// @since_tizen @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif
@@ -7563,46 +7784,6 @@ typedef Dartmc_client_custom_event_received_cbFunction = void Function(
     ffi.Pointer<bundle.bundle> data,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the subscription type.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_subscription_type_e {
-  /// < Server state
-  static const int MC_SUBSCRIPTION_TYPE_SERVER_STATE = 0;
-
-  /// < Playback
-  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK = 1;
-
-  /// < Metadata
-  static const int MC_SUBSCRIPTION_TYPE_METADATA = 2;
-
-  /// < Shuffle mode
-  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_MODE = 3;
-
-  /// < Repeat mode
-  static const int MC_SUBSCRIPTION_TYPE_REPEAT_MODE = 4;
-
-  /// < Playlist (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_SUBSCRIPTION_TYPE_PLAYLIST = 5;
-
-  /// < Playback ability (Since 5.0)
-  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK_ABILITY = 6;
-
-  /// < Shuffle ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
-  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_ABILITY = 7;
-
-  /// < Repeat ability (Since 5.0) (Deprecated since 5.5. Use #MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT instead)
-  static const int MC_SUBSCRIPTION_TYPE_REPEAT_ABILITY = 8;
-
-  /// < Ability support (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT = 9;
-
-  /// < Display mode ability (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_MODE_ABILITY = 10;
-
-  /// < Display rotation ability (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_ROTATION_ABILITY = 11;
-}
-
 /// @brief Called when requesting the list of subscribed servers.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
 ///
@@ -7625,107 +7806,6 @@ typedef mc_subscribed_server_cbFunction = ffi.Bool Function(
     ffi.Pointer<ffi.Char> server_name, ffi.Pointer<ffi.Void> user_data);
 typedef Dartmc_subscribed_server_cbFunction = bool Function(
     ffi.Pointer<ffi.Char> server_name, ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the media playback state.
-/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-abstract class mc_playback_states_e {
-  /// < None
-  static const int MC_PLAYBACK_STATE_NONE = 0;
-
-  /// < Playing
-  static const int MC_PLAYBACK_STATE_PLAYING = 1;
-
-  /// < Paused
-  static const int MC_PLAYBACK_STATE_PAUSED = 2;
-
-  /// < Stopped
-  static const int MC_PLAYBACK_STATE_STOPPED = 3;
-
-  /// < Moving to the next item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_MOVING_TO_NEXT = 8;
-
-  /// < Moving to the previous item (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_MOVING_TO_PREVIOUS = 9;
-
-  /// < Fast forwarding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_FAST_FORWARDING = 10;
-
-  /// < Rewinding (Since @if MOBILE 4.0 @elseif WEARABLE 5.0 @endif)
-  static const int MC_PLAYBACK_STATE_REWINDING = 11;
-
-  /// < Connecting (Since 6.0)
-  static const int MC_PLAYBACK_STATE_CONNECTING = 12;
-
-  /// < Buffering (Since 6.0)
-  static const int MC_PLAYBACK_STATE_BUFFERING = 13;
-
-  /// < Error (Since 6.0)
-  static const int MC_PLAYBACK_STATE_ERROR = 14;
-}
-
-/// @brief Enumeration for the content age rating of the content.
-/// @since_tizen 5.0
-abstract class mc_content_age_rating_e {
-  /// < Suitable for all ages
-  static const int MC_CONTENT_RATING_ALL = 0;
-
-  /// < Suitable for ages 1 and up
-  static const int MC_CONTENT_RATING_1_PLUS = 1;
-
-  /// < Suitable for ages 2 and up
-  static const int MC_CONTENT_RATING_2_PLUS = 2;
-
-  /// < Suitable for ages 3 and up
-  static const int MC_CONTENT_RATING_3_PLUS = 3;
-
-  /// < Suitable for ages 4 and up
-  static const int MC_CONTENT_RATING_4_PLUS = 4;
-
-  /// < Suitable for ages 5 and up
-  static const int MC_CONTENT_RATING_5_PLUS = 5;
-
-  /// < Suitable for ages 6 and up
-  static const int MC_CONTENT_RATING_6_PLUS = 6;
-
-  /// < Suitable for ages 7 and up
-  static const int MC_CONTENT_RATING_7_PLUS = 7;
-
-  /// < Suitable for ages 8 and up
-  static const int MC_CONTENT_RATING_8_PLUS = 8;
-
-  /// < Suitable for ages 9 and up
-  static const int MC_CONTENT_RATING_9_PLUS = 9;
-
-  /// < Suitable for ages 10 and up
-  static const int MC_CONTENT_RATING_10_PLUS = 10;
-
-  /// < Suitable for ages 11 and up
-  static const int MC_CONTENT_RATING_11_PLUS = 11;
-
-  /// < Suitable for ages 12 and up
-  static const int MC_CONTENT_RATING_12_PLUS = 12;
-
-  /// < Suitable for ages 13 and up
-  static const int MC_CONTENT_RATING_13_PLUS = 13;
-
-  /// < Suitable for ages 14 and up
-  static const int MC_CONTENT_RATING_14_PLUS = 14;
-
-  /// < Suitable for ages 15 and up
-  static const int MC_CONTENT_RATING_15_PLUS = 15;
-
-  /// < Suitable for ages 16 and up
-  static const int MC_CONTENT_RATING_16_PLUS = 16;
-
-  /// < Suitable for ages 17 and up
-  static const int MC_CONTENT_RATING_17_PLUS = 17;
-
-  /// < Suitable for ages 18 and up
-  static const int MC_CONTENT_RATING_18_PLUS = 18;
-
-  /// < Suitable for ages 19 and up
-  static const int MC_CONTENT_RATING_19_PLUS = 19;
-}
 
 /// @brief Called when requesting the list of created servers.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
@@ -8131,3 +8211,5 @@ typedef Dartmc_server_search_cmd_received_cbFunction = void Function(
     ffi.Pointer<ffi.Char> request_id,
     mc_search_h search,
     ffi.Pointer<ffi.Void> user_data);
+
+const int MEDIA_CONTROLLER_ERROR_CLASS = -50462720;

--- a/lib/src/bindings/8.0/generated_bindings_capi_media_metadata_editor.dart
+++ b/lib/src/bindings/8.0/generated_bindings_capi_media_metadata_editor.dart
@@ -368,9 +368,34 @@ class Tizen80CapiMediaMetadataEditor {
 }
 
 /// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
-/// @brief The handle of media metadata.
+/// @brief The enumerations of media metadata error.
 /// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
-typedef metadata_editor_h = ffi.Pointer<ffi.Void>;
+abstract class metadata_editor_error_e {
+  /// < Successful
+  static const int METADATA_EDITOR_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int METADATA_EDITOR_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int METADATA_EDITOR_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < File not exist
+  static const int METADATA_EDITOR_ERROR_FILE_EXISTS = -17;
+
+  /// < Permission denied
+  static const int METADATA_EDITOR_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Unsupported type
+  static const int METADATA_EDITOR_ERROR_NOT_SUPPORTED = -1073741822;
+
+  /// < Invalid internal operation
+  static const int METADATA_EDITOR_ERROR_OPERATION_FAILED = -27000831;
+
+  /// < Update not possible (Since 6.0)
+  static const int METADATA_EDITOR_ERROR_METADATA_UPDATE_NOT_POSSIBLE =
+      -27000830;
+}
 
 /// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
 /// @brief The enumerations of attribute.
@@ -415,3 +440,10 @@ abstract class metadata_editor_attr_e {
   /// < Unsynchronized lyric
   static const int METADATA_EDITOR_ATTR_UNSYNCLYRICS = 12;
 }
+
+/// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
+/// @brief The handle of media metadata.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+typedef metadata_editor_h = ffi.Pointer<ffi.Void>;
+
+const int METADATA_EDITOR_ERROR_CLASS = -27000832;

--- a/lib/src/bindings/8.0/generated_bindings_capi_media_metadata_extractor.dart
+++ b/lib/src/bindings/8.0/generated_bindings_capi_media_metadata_extractor.dart
@@ -384,11 +384,27 @@ class Tizen80CapiMediaMetadataExtractor {
 }
 
 /// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
-/// @brief The metadata extractor handle.
+/// @brief Enumeration for metadata extractor error.
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
-typedef metadata_extractor_h = ffi.Pointer<metadata_extractor_s>;
+abstract class metadata_extractor_error_e {
+  /// < Successful
+  static const int METADATA_EXTRACTOR_ERROR_NONE = 0;
 
-final class metadata_extractor_s extends ffi.Opaque {}
+  /// < Invalid parameter
+  static const int METADATA_EXTRACTOR_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int METADATA_EXTRACTOR_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < File does not exist
+  static const int METADATA_EXTRACTOR_ERROR_FILE_EXISTS = -17;
+
+  /// < Permission denied
+  static const int METADATA_EXTRACTOR_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Invalid internal operation
+  static const int METADATA_EXTRACTOR_ERROR_OPERATION_FAILED = -26411007;
+}
 
 /// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
 /// @brief Enumeration for attribute.
@@ -499,3 +515,12 @@ abstract class metadata_extractor_attr_e {
   /// < Flag indicating if the video is a spherical video (Since 3.0)
   static const int METADATA_360 = 34;
 }
+
+final class metadata_extractor_s extends ffi.Opaque {}
+
+/// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
+/// @brief The metadata extractor handle.
+/// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
+typedef metadata_extractor_h = ffi.Pointer<metadata_extractor_s>;
+
+const int METADATA_EXTRACTOR_ERROR_CLASS = -26411008;

--- a/lib/src/bindings/8.0/generated_bindings_capi_media_screen_mirroring.dart
+++ b/lib/src/bindings/8.0/generated_bindings_capi_media_screen_mirroring.dart
@@ -880,29 +880,6 @@ class Tizen80CapiMediaScreenMirroring {
           int Function(scmirroring_sink_h, ffi.Pointer<ffi.Int32>)>();
 }
 
-/// @brief	The handle to the screen mirroring sink.
-/// @since_tizen 2.4
-typedef scmirroring_sink_h = ffi.Pointer<ffi.Void>;
-
-/// @brief Called when each status is changed.
-/// @since_tizen 2.4
-///
-/// @details This callback is called for state and error of screen mirroring sink
-///
-/// @param[in] error     The error code
-/// @param[in] state     The screen mirroring sink state
-/// @param[in] user_data The user data passed from the scmirroring_sink_set_state_cb() function
-///
-/// @pre scmirroring_sink_create()
-///
-/// @see scmirroring_sink_create()
-typedef scmirroring_sink_state_cb
-    = ffi.Pointer<ffi.NativeFunction<scmirroring_sink_state_cbFunction>>;
-typedef scmirroring_sink_state_cbFunction = ffi.Void Function(
-    ffi.Int32 error, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
-typedef Dartscmirroring_sink_state_cbFunction = void Function(
-    int error, int state, ffi.Pointer<ffi.Void> user_data);
-
 /// @brief Enumeration for screen mirroring error.
 /// @since_tizen 2.4
 abstract class scmirroring_error_e {
@@ -957,6 +934,41 @@ abstract class scmirroring_sink_state_e {
   static const int SCMIRRORING_SINK_STATE_MAX = 7;
 }
 
+/// @brief Enumeration for screen mirroring resolution.
+/// @since_tizen 2.4
+abstract class scmirroring_resolution_e {
+  static const int SCMIRRORING_RESOLUTION_UNKNOWN = 0;
+
+  /// < W-1920, H-1080, 30 fps
+  static const int SCMIRRORING_RESOLUTION_1920x1080_P30 = 1;
+
+  /// < W-1280, H-720, 30 fps
+  static const int SCMIRRORING_RESOLUTION_1280x720_P30 = 2;
+
+  /// < W-960, H-540, 30 fps
+  static const int SCMIRRORING_RESOLUTION_960x540_P30 = 4;
+
+  /// < W-864, H-480, 30 fps
+  static const int SCMIRRORING_RESOLUTION_864x480_P30 = 8;
+
+  /// < W-720, H-480, 30 fps
+  static const int SCMIRRORING_RESOLUTION_720x480_P60 = 16;
+
+  /// < W-640, H-480, 60 fps
+  static const int SCMIRRORING_RESOLUTION_640x480_P60 = 32;
+
+  /// < W-640, H-360, 30 fps
+  static const int SCMIRRORING_RESOLUTION_640x360_P30 = 64;
+  static const int SCMIRRORING_RESOLUTION_MAX = 128;
+}
+
+/// @brief Ability to send to multisink.
+/// @since_tizen 3.0
+abstract class scmirroring_multisink_e {
+  static const int SCMIRRORING_MULTISINK_DISABLE = 0;
+  static const int SCMIRRORING_MULTISINK_ENABLE = 1;
+}
+
 /// @brief Enumeration for screen mirroring display surface type.
 /// @since_tizen 2.4
 abstract class scmirroring_display_type_e {
@@ -966,16 +978,6 @@ abstract class scmirroring_display_type_e {
   /// < Use Evas pixmap surface to display streaming multimedia data
   static const int SCMIRRORING_DISPLAY_TYPE_EVAS = 1;
   static const int SCMIRRORING_DISPLAY_TYPE_MAX = 2;
-}
-
-/// @brief Enumeration for screen mirroring video codec.
-/// @since_tizen 2.4
-abstract class scmirroring_video_codec_e {
-  /// < Screen mirroring is not negotiated yet
-  static const int SCMIRRORING_VIDEO_CODEC_NONE = 0;
-
-  /// < H.264 codec for video
-  static const int SCMIRRORING_VIDEO_CODEC_H264 = 1;
 }
 
 /// @brief Enumeration for screen mirroring audio codec.
@@ -993,3 +995,56 @@ abstract class scmirroring_audio_codec_e {
   /// < LPCM codec for audio
   static const int SCMIRRORING_AUDIO_CODEC_LPCM = 3;
 }
+
+/// @brief Enumeration for screen mirroring video codec.
+/// @since_tizen 2.4
+abstract class scmirroring_video_codec_e {
+  /// < Screen mirroring is not negotiated yet
+  static const int SCMIRRORING_VIDEO_CODEC_NONE = 0;
+
+  /// < H.264 codec for video
+  static const int SCMIRRORING_VIDEO_CODEC_H264 = 1;
+}
+
+/// @brief Enumeration for screen mirroring direct streaming mode.
+/// @since_tizen 3.0
+abstract class scmirroring_direct_streaming_e {
+  /// < Disable screen mirroring direct streaming mode
+  static const int SCMIRRORING_DIRECT_STREAMING_DISABLED = 0;
+
+  /// < Enable direct streaming for files
+  static const int SCMIRRORING_DIRECT_STREAMING_ENABLED = 1;
+}
+
+/// @brief Enumeration for screen mirroring AV streaming transport.
+/// @since_tizen 3.0
+abstract class scmirroring_av_transport_e {
+  /// < UDP transport for AV streaming data
+  static const int SCMIRRORING_AV_TRANSPORT_UDP = 0;
+
+  /// < TCP transport for AV streaming data
+  static const int SCMIRRORING_AV_TRANSPORT_TCP = 1;
+}
+
+/// @brief	The handle to the screen mirroring sink.
+/// @since_tizen 2.4
+typedef scmirroring_sink_h = ffi.Pointer<ffi.Void>;
+
+/// @brief Called when each status is changed.
+/// @since_tizen 2.4
+///
+/// @details This callback is called for state and error of screen mirroring sink
+///
+/// @param[in] error     The error code
+/// @param[in] state     The screen mirroring sink state
+/// @param[in] user_data The user data passed from the scmirroring_sink_set_state_cb() function
+///
+/// @pre scmirroring_sink_create()
+///
+/// @see scmirroring_sink_create()
+typedef scmirroring_sink_state_cb
+    = ffi.Pointer<ffi.NativeFunction<scmirroring_sink_state_cbFunction>>;
+typedef scmirroring_sink_state_cbFunction = ffi.Void Function(
+    ffi.Int32 error, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
+typedef Dartscmirroring_sink_state_cbFunction = void Function(
+    int error, int state, ffi.Pointer<ffi.Void> user_data);

--- a/lib/src/bindings/8.0/generated_bindings_capi_media_sound_pool.dart
+++ b/lib/src/bindings/8.0/generated_bindings_capi_media_sound_pool.dart
@@ -865,10 +865,52 @@ class Tizen80CapiMediaSoundPool {
       .asFunction<int Function(sound_pool_h, int, ffi.Pointer<ffi.Int32>)>();
 }
 
-/// @brief Sound pool handle type.
+/// @brief Enumeration for Tizen Sound Pool error.
 ///
 /// @since_tizen 4.0
-typedef sound_pool_h = ffi.Pointer<ffi.Void>;
+abstract class sound_pool_error_e {
+  static const int SOUND_POOL_ERROR_NONE = 0;
+  static const int SOUND_POOL_ERROR_KEY_NOT_AVAILABLE = -126;
+  static const int SOUND_POOL_ERROR_OUT_OF_MEMORY = -12;
+  static const int SOUND_POOL_ERROR_INVALID_PARAMETER = -22;
+  static const int SOUND_POOL_ERROR_INVALID_OPERATION = -38;
+  static const int SOUND_POOL_ERROR_NOT_PERMITTED = -1;
+  static const int SOUND_POOL_ERROR_NO_SUCH_FILE = -2;
+}
+
+/// @brief Enumeration of sound pool stream state.
+///
+/// @since_tizen 4.0
+abstract class sound_pool_stream_state_e {
+  /// < Stream state isn't determined
+  static const int SOUND_POOL_STREAM_STATE_NONE = 0;
+
+  /// < Stream state is playing
+  static const int SOUND_POOL_STREAM_STATE_PLAYING = 1;
+
+  /// < Stream state is paused
+  static const int SOUND_POOL_STREAM_STATE_PAUSED = 2;
+
+  /// < Stream state is stopped
+  static const int SOUND_POOL_STREAM_STATE_STOPPED = 3;
+
+  /// < Stream state is finished
+  static const int SOUND_POOL_STREAM_STATE_FINISHED = 4;
+
+  /// < Stream state is suspended
+  static const int SOUND_POOL_STREAM_STATE_SUSPENDED = 5;
+}
+
+/// @brief Enumeration of sound pool stream priority policy.
+///
+/// @since_tizen 4.0
+abstract class sound_pool_stream_priority_policy_e {
+  /// < Stream priority policy is mute
+  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_MUTE = 0;
+
+  /// < Stream priority policy is suspended
+  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_SUSPENDED = 1;
+}
 
 /// @brief Enumeration of sound pool state.
 ///
@@ -880,6 +922,11 @@ abstract class sound_pool_state_e {
   /// < Sound pool inactive state: streams can't be played
   static const int SOUND_POOL_STATE_INACTIVE = 1;
 }
+
+/// @brief Sound pool handle type.
+///
+/// @since_tizen 4.0
+typedef sound_pool_h = ffi.Pointer<ffi.Void>;
 
 /// @brief Called when the sound pool state is changed.
 ///
@@ -910,17 +957,6 @@ typedef Dartsound_pool_state_changed_cbFunction = void Function(
     int prev_state,
     int cur_state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration of sound pool stream priority policy.
-///
-/// @since_tizen 4.0
-abstract class sound_pool_stream_priority_policy_e {
-  /// < Stream priority policy is mute
-  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_MUTE = 0;
-
-  /// < Stream priority policy is suspended
-  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_SUSPENDED = 1;
-}
 
 /// @brief Called when the sound pool stream state is changed.
 ///
@@ -954,26 +990,3 @@ typedef Dartsound_pool_stream_state_changed_cbFunction = void Function(
     int prev_state,
     int cur_state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration of sound pool stream state.
-///
-/// @since_tizen 4.0
-abstract class sound_pool_stream_state_e {
-  /// < Stream state isn't determined
-  static const int SOUND_POOL_STREAM_STATE_NONE = 0;
-
-  /// < Stream state is playing
-  static const int SOUND_POOL_STREAM_STATE_PLAYING = 1;
-
-  /// < Stream state is paused
-  static const int SOUND_POOL_STREAM_STATE_PAUSED = 2;
-
-  /// < Stream state is stopped
-  static const int SOUND_POOL_STREAM_STATE_STOPPED = 3;
-
-  /// < Stream state is finished
-  static const int SOUND_POOL_STREAM_STATE_FINISHED = 4;
-
-  /// < Stream state is suspended
-  static const int SOUND_POOL_STREAM_STATE_SUSPENDED = 5;
-}

--- a/lib/src/bindings/8.0/generated_bindings_capi_media_thumbnail_util.dart
+++ b/lib/src/bindings/8.0/generated_bindings_capi_media_thumbnail_util.dart
@@ -156,3 +156,31 @@ class Tizen80CapiMediaThumbnailUtil {
               ffi.Pointer<ffi.UnsignedInt>,
               ffi.Pointer<ffi.UnsignedInt>)>();
 }
+
+/// @ingroup CAPI_MEDIA_THUMBNAIL_UTIL_MODULE
+/// @brief Enumeration for a thumbnail util error.
+/// @since_tizen @if MOBILE 2.4 @elseif WEARABLE 3.0 @endif
+abstract class thumbnail_util_error_e {
+  /// < Successful
+  static const int THUMBNAIL_UTIL_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int THUMBNAIL_UTIL_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int THUMBNAIL_UTIL_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Invalid Operation
+  static const int THUMBNAIL_UTIL_ERROR_INVALID_OPERATION = -38;
+
+  /// < No space left on device
+  static const int THUMBNAIL_UTIL_ERROR_FILE_NO_SPACE_ON_DEVICE = -28;
+
+  /// < Permission denied
+  static const int THUMBNAIL_UTIL_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Unsupported Content (Since 4.0)
+  static const int THUMBNAIL_UTIL_ERROR_UNSUPPORTED_CONTENT = -49872895;
+}
+
+const int THUMBNAIL_UTIL_ERROR_CLASS = -49872896;

--- a/lib/src/bindings/8.0/generated_bindings_capi_network_bluetooth.dart
+++ b/lib/src/bindings/8.0/generated_bindings_capi_network_bluetooth.dart
@@ -10730,6 +10730,188 @@ class Tizen80CapiNetworkBluetooth {
                   ffi.Pointer<bt_adapter_le_device_scan_result_info_s>>)>();
 }
 
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of PBAP fields.
+/// @since_tizen 3.0
+abstract class bt_pbap_field_e {
+  /// < All field
+  static const int BT_PBAP_FIELD_ALL = -1;
+
+  /// < vCard Version
+  static const int BT_PBAP_FIELD_VERSION = 1;
+
+  /// < Formatted Name
+  static const int BT_PBAP_FIELD_FN = 2;
+
+  /// < Structured Presentation of Name
+  static const int BT_PBAP_FIELD_N = 4;
+
+  /// < Associated Image or Photo
+  static const int BT_PBAP_FIELD_PHOTO = 8;
+
+  /// < Birthday
+  static const int BT_PBAP_FIELD_BDAY = 16;
+
+  /// < Delivery Address
+  static const int BT_PBAP_FIELD_ADR = 32;
+
+  /// < Delivery
+  static const int BT_PBAP_FIELD_LABEL = 64;
+
+  /// < Telephone Number
+  static const int BT_PBAP_FIELD_TEL = 128;
+
+  /// < Electronic Mail Address
+  static const int BT_PBAP_FIELD_EMAIL = 256;
+
+  /// < Electronic Mail
+  static const int BT_PBAP_FIELD_MAILER = 512;
+
+  /// < Time Zone
+  static const int BT_PBAP_FIELD_TZ = 1024;
+
+  /// < Geographic Position
+  static const int BT_PBAP_FIELD_GEO = 2048;
+
+  /// < Job
+  static const int BT_PBAP_FIELD_TITLE = 4096;
+
+  /// < Role within the Organization
+  static const int BT_PBAP_FIELD_ROLE = 8192;
+
+  /// < Organization Logo
+  static const int BT_PBAP_FIELD_LOGO = 16384;
+
+  /// < vCard of Person Representing
+  static const int BT_PBAP_FIELD_AGENT = 32768;
+
+  /// < Name of Organization
+  static const int BT_PBAP_FIELD_ORG = 65536;
+
+  /// < Comments
+  static const int BT_PBAP_FIELD_NOTE = 131072;
+
+  /// < Revision
+  static const int BT_PBAP_FIELD_REV = 262144;
+
+  /// < Pronunciation of Name
+  static const int BT_PBAP_FIELD_SOUND = 524288;
+
+  /// < Uniform Resource Locator
+  static const int BT_PBAP_FIELD_URL = 1048576;
+
+  /// < Unique ID
+  static const int BT_PBAP_FIELD_UID = 2097152;
+
+  /// < Public Encryption Key
+  static const int BT_PBAP_FIELD_KEY = 4194304;
+
+  /// < Nickname
+  static const int BT_PBAP_FIELD_NICKNAME = 8388608;
+
+  /// < Categories
+  static const int BT_PBAP_FIELD_CATEGORIES = 16777216;
+
+  /// < Product ID
+  static const int BT_PBAP_FIELD_PROID = 33554432;
+
+  /// < Class information
+  static const int BT_PBAP_FIELD_CLASS = 67108864;
+
+  /// < String used for sorting operations
+  static const int BT_PBAP_FIELD_SORT_STRING = 134217728;
+
+  /// < Time stamp
+  static const int BT_PBAP_FIELD_X_IRMC_CALL_DATETIME = 268435456;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_MODULE
+/// @brief Enumerations of Bluetooth error codes.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_error_e {
+  /// < Successful
+  static const int BT_ERROR_NONE = 0;
+
+  /// < Operation cancelled
+  static const int BT_ERROR_CANCELLED = -125;
+
+  /// < Invalid parameter
+  static const int BT_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int BT_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Device or resource busy
+  static const int BT_ERROR_RESOURCE_BUSY = -16;
+
+  /// < Timeout error
+  static const int BT_ERROR_TIMED_OUT = -1073741823;
+
+  /// < Operation now in progress
+  static const int BT_ERROR_NOW_IN_PROGRESS = -115;
+
+  /// < BT is Not Supported
+  static const int BT_ERROR_NOT_SUPPORTED = -1073741822;
+
+  /// < Permission denied
+  static const int BT_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Quota exceeded
+  static const int BT_ERROR_QUOTA_EXCEEDED = -122;
+
+  /// < No data available
+  static const int BT_ERROR_NO_DATA = -61;
+
+  /// < Device policy restriction (Since 3.0)
+  static const int BT_ERROR_DEVICE_POLICY_RESTRICTION = -1073741820;
+
+  /// < Local adapter not initialized
+  static const int BT_ERROR_NOT_INITIALIZED = -29359871;
+
+  /// < Local adapter not enabled
+  static const int BT_ERROR_NOT_ENABLED = -29359870;
+
+  /// < Operation already done
+  static const int BT_ERROR_ALREADY_DONE = -29359869;
+
+  /// < Operation failed
+  static const int BT_ERROR_OPERATION_FAILED = -29359868;
+
+  /// < Operation not in progress
+  static const int BT_ERROR_NOT_IN_PROGRESS = -29359867;
+
+  /// < Remote device not bonded
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_BONDED = -29359866;
+
+  /// < Authentication rejected
+  static const int BT_ERROR_AUTH_REJECTED = -29359865;
+
+  /// < Authentication failed
+  static const int BT_ERROR_AUTH_FAILED = -29359864;
+
+  /// < Remote device not found
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_FOUND = -29359863;
+
+  /// < Service search failed
+  static const int BT_ERROR_SERVICE_SEARCH_FAILED = -29359862;
+
+  /// < Remote device is not connected
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_CONNECTED = -29359861;
+
+  /// < Resource temporarily unavailable
+  static const int BT_ERROR_AGAIN = -29359860;
+
+  /// < Service Not Found
+  static const int BT_ERROR_SERVICE_NOT_FOUND = -29359859;
+
+  /// < Authorization rejected (Since 5.0)
+  static const int BT_ERROR_AUTHORIZATION_REJECTED = -29359858;
+
+  /// < Max of connection exceeded (Since 8.0)
+  static const int BT_ERROR_MAX_CONNECTION = -29359857;
+}
+
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
 /// @brief  Enumerations of the Bluetooth adapter state.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
@@ -10754,6 +10936,198 @@ abstract class bt_adapter_visibility_mode_e {
   /// < Discoverable mode with time limit. After specific period,
   /// it is changed to #BT_ADAPTER_VISIBILITY_MODE_NON_DISCOVERABLE.
   static const int BT_ADAPTER_VISIBILITY_MODE_LIMITED_DISCOVERABLE = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief Enumerations of the discovery state of Bluetooth device.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_device_discovery_state_e {
+  /// < Device discovery is started
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_STARTED = 0;
+
+  /// < Device discovery is finished
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_FINISHED = 1;
+
+  /// < The remote Bluetooth device is found
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_FOUND = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising state.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_le_advertising_state_e {
+  /// < Bluetooth advertising is stopped
+  static const int BT_ADAPTER_LE_ADVERTISING_STOPPED = 0;
+
+  /// < Bluetooth advertising is started
+  static const int BT_ADAPTER_LE_ADVERTISING_STARTED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising mode.
+/// @since_tizen 2.3.1
+abstract class bt_adapter_le_advertising_mode_e {
+  /// < Balanced advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_BALANCED = 0;
+
+  /// < Low latency advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_LATENCY = 1;
+
+  /// < Low energy advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_ENERGY = 2;
+
+  /// < Custom mode to set advertising parameters
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_CUSTOM = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising filter policy.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_le_advertising_filter_policy_e {
+  /// < White list is not in use
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_DEFAULT = 0;
+
+  /// < Allow the scan
+  /// request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_SCAN_WL = 1;
+
+  /// < Allow the connection
+  /// request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_CONN_WL = 2;
+
+  /// < Allow the
+  /// scan and connection request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_SCAN_CONN_WL = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief Enumerations of the Bluetooth LE advertising flags.
+/// @since_tizen 8.0
+abstract class bt_adapter_le_advertising_flags_e {
+  /// < LE Limited Discoverable Mode
+  static const int BT_ADAPTER_LE_ADVERTISING_FLAGS_LIM_DISC = 1;
+
+  /// < LE General Discoverable Mode
+  static const int BT_ADAPTER_LE_ADVERTISING_FLAGS_GEN_DISC = 2;
+
+  /// < BR/EDR Not Supported
+  static const int BT_ADAPTER_LE_ADVERTISING_FLAGS_BREDR_UNSUP = 4;
+
+  /// < Simultaneous LE and BR/EDR to Same Device Capable (Controller)
+  static const int BT_ADAPTER_LE_ADVERTISING_FLAGS_CONTROLLER = 8;
+
+  /// < Simultaneous LE and BR/EDR to Same Device Capable (Host)
+  static const int BT_ADAPTER_LE_ADVERTISING_FLAGS_SIM_HOST = 16;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth LE packet type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_adapter_le_packet_type_e {
+  /// < Advertising packet
+  static const int BT_ADAPTER_LE_PACKET_ADVERTISING = 0;
+
+  /// < Scan response packet
+  static const int BT_ADAPTER_LE_PACKET_SCAN_RESPONSE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth le scan mode.
+/// @since_tizen 3.0
+abstract class bt_adapter_le_scan_mode_e {
+  /// < Balanced mode of power consumption and connection latency
+  static const int BT_ADAPTER_LE_SCAN_MODE_BALANCED = 0;
+
+  /// < Low connection latency but high power consumption
+  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_LATENCY = 1;
+
+  /// < Low power consumption but high connection latency
+  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_ENERGY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device disconnect reason.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_disconnect_reason_e {
+  /// < Disconnected by unknown reason
+  static const int BT_DEVICE_DISCONNECT_REASON_UNKNOWN = 0;
+
+  /// < Disconnected by timeout
+  static const int BT_DEVICE_DISCONNECT_REASON_TIMEOUT = 1;
+
+  /// < Disconnected by local host
+  static const int BT_DEVICE_DISCONNECT_REASON_LOCAL_HOST = 2;
+
+  /// < Disconnected by remote
+  static const int BT_DEVICE_DISCONNECT_REASON_REMOTE = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of connection link type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_connection_link_type_e {
+  /// < BR/EDR link
+  static const int BT_DEVICE_CONNECTION_LINK_BREDR = 0;
+
+  /// < LE link
+  static const int BT_DEVICE_CONNECTION_LINK_LE = 1;
+
+  /// < The connection type default
+  static const int BT_DEVICE_CONNECTION_LINK_DEFAULT = 255;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device authorization state.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_authorization_e {
+  /// < The remote Bluetooth device is authorized
+  static const int BT_DEVICE_AUTHORIZED = 0;
+
+  /// < The remote Bluetooth device is unauthorized
+  static const int BT_DEVICE_UNAUTHORIZED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of Bluetooth profile.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_profile_e {
+  /// < RFCOMM Profile
+  static const int BT_PROFILE_RFCOMM = 1;
+
+  /// < Advanced Audio Distribution Profile Source role
+  static const int BT_PROFILE_A2DP = 2;
+
+  /// < Headset Profile
+  static const int BT_PROFILE_HSP = 4;
+
+  /// < Human Interface Device Profile
+  static const int BT_PROFILE_HID = 8;
+
+  /// < Network Access Point Profile
+  static const int BT_PROFILE_NAP = 16;
+
+  /// < Audio Gateway Profile
+  static const int BT_PROFILE_AG = 32;
+
+  /// < Generic Attribute Profile
+  static const int BT_PROFILE_GATT = 64;
+
+  /// < NAP server Profile
+  static const int BT_PROFILE_NAP_SERVER = 128;
+
+  /// < Advanced Audio Distribution Profile Sink role
+  static const int BT_PROFILE_A2DP_SINK = 256;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device address type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_device_address_type_e {
+  /// < Public address
+  static const int BT_DEVICE_PUBLIC_ADDRESS = 0;
+
+  /// < Random address
+  static const int BT_DEVICE_RANDOM_ADDRESS = 1;
 }
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
@@ -10839,88 +11213,36 @@ abstract class bt_service_class_t {
   static const int BT_SC_MAX = 16777216;
 }
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief  Called when you get bonded devices repeatedly.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @param[in] device_info The bonded device information
-/// @param[in] user_data The user data passed from the foreach function
-/// @return @c true to continue with the next iteration of the loop,
-/// \n @c false to break out of the loop.
-/// @pre bt_adapter_foreach_bonded_device() will invoke this function.
-///
-/// @see bt_adapter_foreach_bonded_device()
-typedef bt_adapter_bonded_device_cb
-    = ffi.Pointer<ffi.NativeFunction<bt_adapter_bonded_device_cbFunction>>;
-typedef bt_adapter_bonded_device_cbFunction = ffi.Bool Function(
-    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
-typedef Dartbt_adapter_bonded_device_cbFunction = bool Function(
-    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Device information structure used for identifying pear device.
+/// @brief  Enumerations of major service class.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see #bt_class_s
-/// @see bt_device_bond_created_cb()
-final class bt_device_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
+abstract class bt_major_service_class_e {
+  /// < Limited discoverable mode
+  static const int BT_MAJOR_SERVICE_CLASS_LIMITED_DISCOVERABLE_MODE = 8192;
 
-  /// < The name of remote device
-  external ffi.Pointer<ffi.Char> remote_name;
+  /// < Positioning class
+  static const int BT_MAJOR_SERVICE_CLASS_POSITIONING = 65536;
 
-  /// < The Bluetooth classes
-  external bt_class_s bt_class;
+  /// < Networking class
+  static const int BT_MAJOR_SERVICE_CLASS_NETWORKING = 131072;
 
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+  /// < Rendering class
+  static const int BT_MAJOR_SERVICE_CLASS_RENDERING = 262144;
 
-  /// < The number of services
-  @ffi.Int()
-  external int service_count;
+  /// < Capturing class
+  static const int BT_MAJOR_SERVICE_CLASS_CAPTURING = 524288;
 
-  /// < The bonding state
-  @ffi.Bool()
-  external bool is_bonded;
+  /// < Object transferring class
+  static const int BT_MAJOR_SERVICE_CLASS_OBJECT_TRANSFER = 1048576;
 
-  /// < The connection state
-  @ffi.Bool()
-  external bool is_connected;
+  /// < Audio class
+  static const int BT_MAJOR_SERVICE_CLASS_AUDIO = 2097152;
 
-  /// < The authorization state
-  @ffi.Bool()
-  external bool is_authorized;
+  /// < Telephony class
+  static const int BT_MAJOR_SERVICE_CLASS_TELEPHONY = 4194304;
 
-  /// < manufacturer specific data length
-  @ffi.Int()
-  external int manufacturer_data_len;
-
-  /// < manufacturer specific data
-  external ffi.Pointer<ffi.Char> manufacturer_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Class structure of device and service.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see #bt_device_info_s
-/// @see #bt_adapter_device_discovery_info_s
-/// @see bt_device_bond_created_cb()
-/// @see bt_adapter_device_discovery_state_changed_cb()
-final class bt_class_s extends ffi.Struct {
-  /// < Major device class.
-  @ffi.Int32()
-  external int major_device_class;
-
-  /// < Minor device class.
-  @ffi.Int32()
-  external int minor_device_class;
-
-  /// < Major service class mask.
-  /// This value can be a combination of #bt_major_service_class_e like #BT_MAJOR_SERVICE_CLASS_RENDERING | #BT_MAJOR_SERVICE_CLASS_AUDIO
-  @ffi.Int()
-  external int major_service_class_mask;
+  /// < Information class
+  static const int BT_MAJOR_SERVICE_CLASS_INFORMATION = 8388608;
 }
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
@@ -11221,6 +11543,1029 @@ abstract class bt_minor_device_class_e {
   static const int BT_MINOR_DEVICE_CLASS_HEALTH_ANKLE_PROSTHESIS = 52;
 }
 
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief  Enumerations of gap appearance type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_appearance_type_e {
+  /// < Unknown appearance type
+  static const int BT_APPEARANCE_TYPE_UNKNOWN = 0;
+
+  /// < Generic Phone type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_PHONE = 64;
+
+  /// < Generic Computer type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_COMPUTER = 128;
+
+  /// < Generic Watch type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_WATCH = 192;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief  Enumerations of the Bluetooth device's LE connection mode.
+/// @since_tizen 3.0
+abstract class bt_device_le_connection_mode_e {
+  /// < Balanced mode of power consumption and connection latency
+  static const int BT_DEVICE_LE_CONNECTION_MODE_BALANCED = 0;
+
+  /// < Low connection latency but high power consumption
+  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_LATENCY = 1;
+
+  /// < Low power consumption but high connection latency
+  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_ENERGY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief  Enumerations of connected Bluetooth device event role.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_socket_role_e {
+  /// < Unknown role
+  static const int BT_SOCKET_UNKNOWN = 0;
+
+  /// < Server role
+  static const int BT_SOCKET_SERVER = 1;
+
+  /// < Client role
+  static const int BT_SOCKET_CLIENT = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief  Enumerations of Bluetooth socket connection state.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_socket_connection_state_e {
+  /// < RFCOMM is connected
+  static const int BT_SOCKET_CONNECTED = 0;
+
+  /// < RFCOMM is disconnected
+  static const int BT_SOCKET_DISCONNECTED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
+/// @brief  Enumerations for the types of profiles related with audio.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_audio_profile_type_e {
+  /// < All supported profiles related with audio (Both Host and Device role)
+  static const int BT_AUDIO_PROFILE_TYPE_ALL = 0;
+
+  /// < local device AG and remote device HF Client (Host role, ex: mobile)
+  static const int BT_AUDIO_PROFILE_TYPE_HSP_HFP = 1;
+
+  /// < A2DP Source Connection, remote device is A2DP Sink (Host role, ex: mobile)
+  static const int BT_AUDIO_PROFILE_TYPE_A2DP = 2;
+
+  /// < local device HF Client and remote device AG (Device role, ex: headset)
+  static const int BT_AUDIO_PROFILE_TYPE_AG = 3;
+
+  /// < A2DP Sink Connection, remote device is A2DP Source (Device role, ex: headset)
+  static const int BT_AUDIO_PROFILE_TYPE_A2DP_SINK = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_AG_MODULE
+/// @brief  Enumerations for the call handling event.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_ag_call_handling_event_e {
+  /// < Request to answer an incoming call
+  static const int BT_AG_CALL_HANDLING_EVENT_ANSWER = 0;
+
+  /// < Request to release a call
+  static const int BT_AG_CALL_HANDLING_EVENT_RELEASE = 1;
+
+  /// < Request to reject an incoming call
+  static const int BT_AG_CALL_HANDLING_EVENT_REJECT = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_AG_MODULE
+/// @brief  Enumerations for the multi call handling event.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_ag_multi_call_handling_event_e {
+  /// < Request to release held calls
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_RELEASE_HELD_CALLS = 0;
+
+  /// < Request to release active calls
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_RELEASE_ACTIVE_CALLS = 1;
+
+  /// < Request to put active calls into hold state and activate another (held or waiting) call
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_ACTIVATE_HELD_CALL = 2;
+
+  /// < Request to add a held call to the conversation
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_MERGE_CALLS = 3;
+
+  /// < Request to let a user who has two calls to connect these two calls together and release its connections to both other parties
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_EXPLICIT_CALL_TRANSFER = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the equalizer state.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_equalizer_state_e {
+  /// < Equalizer Off
+  static const int BT_AVRCP_EQUALIZER_STATE_OFF = 1;
+
+  /// < Equalizer On
+  static const int BT_AVRCP_EQUALIZER_STATE_ON = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the repeat mode.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_repeat_mode_e {
+  /// < Repeat Off
+  static const int BT_AVRCP_REPEAT_MODE_OFF = 1;
+
+  /// < Single track repeat
+  static const int BT_AVRCP_REPEAT_MODE_SINGLE_TRACK = 2;
+
+  /// < All track repeat
+  static const int BT_AVRCP_REPEAT_MODE_ALL_TRACK = 3;
+
+  /// < Group repeat
+  static const int BT_AVRCP_REPEAT_MODE_GROUP = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the shuffle mode.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_shuffle_mode_e {
+  /// < Shuffle Off
+  static const int BT_AVRCP_SHUFFLE_MODE_OFF = 1;
+
+  /// < All tracks shuffle
+  static const int BT_AVRCP_SHUFFLE_MODE_ALL_TRACK = 2;
+
+  /// < Group shuffle
+  static const int BT_AVRCP_SHUFFLE_MODE_GROUP = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the scan mode.
+/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
+abstract class bt_avrcp_scan_mode_e {
+  /// < Scan Off
+  static const int BT_AVRCP_SCAN_MODE_OFF = 1;
+
+  /// < All tracks scan
+  static const int BT_AVRCP_SCAN_MODE_ALL_TRACK = 2;
+
+  /// < Group scan
+  static const int BT_AVRCP_SCAN_MODE_GROUP = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the player state.
+/// @since_tizen 3.0
+abstract class bt_avrcp_player_state_e {
+  /// < Stopped
+  static const int BT_AVRCP_PLAYER_STATE_STOPPED = 0;
+
+  /// < Playing
+  static const int BT_AVRCP_PLAYER_STATE_PLAYING = 1;
+
+  /// < Paused
+  static const int BT_AVRCP_PLAYER_STATE_PAUSED = 2;
+
+  /// < Seek Forward
+  static const int BT_AVRCP_PLAYER_STATE_FORWARD_SEEK = 3;
+
+  /// < Seek Rewind
+  static const int BT_AVRCP_PLAYER_STATE_REWIND_SEEK = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumeration for the player control commands.
+/// @since_tizen 3.0
+abstract class bt_avrcp_player_command_e {
+  /// < Play
+  static const int BT_AVRCP_CONTROL_PLAY = 1;
+
+  /// < Pause
+  static const int BT_AVRCP_CONTROL_PAUSE = 2;
+
+  /// < Stop
+  static const int BT_AVRCP_CONTROL_STOP = 3;
+
+  /// < Next Track
+  static const int BT_AVRCP_CONTROL_NEXT = 4;
+
+  /// < Previous track
+  static const int BT_AVRCP_CONTROL_PREVIOUS = 5;
+
+  /// < Fast Forward
+  static const int BT_AVRCP_CONTROL_FAST_FORWARD = 6;
+
+  /// < Rewind
+  static const int BT_AVRCP_CONTROL_REWIND = 7;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief Structure of Track metadata information.
+/// @since_tizen 3.0
+///
+/// @see #bt_class_s
+final class bt_avrcp_metadata_attributes_info_s extends ffi.Struct {
+  /// < Title
+  external ffi.Pointer<ffi.Char> title;
+
+  /// < Artist
+  external ffi.Pointer<ffi.Char> artist;
+
+  /// < Album name
+  external ffi.Pointer<ffi.Char> album;
+
+  /// < Album Genre
+  external ffi.Pointer<ffi.Char> genre;
+
+  /// < The total number of tracks
+  @ffi.UnsignedInt()
+  external int total_tracks;
+
+  /// < Track number
+  @ffi.UnsignedInt()
+  external int number;
+
+  /// < Duration
+  @ffi.UnsignedInt()
+  external int duration;
+}
+
+/// @deprecated Deprecated since 5.0.
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
+/// @brief  Enumerations for the data channel type.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+/// @remarks Deprecated, because of no usecase and supported devices.
+abstract class bt_hdp_channel_type_e {
+  /// < Reliable Data Channel
+  static const int BT_HDP_CHANNEL_TYPE_RELIABLE = 1;
+
+  /// < Streaming Data Channel
+  static const int BT_HDP_CHANNEL_TYPE_STREAMING = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the integer type for GATT handle's value.
+/// @since_tizen 2.3.1
+abstract class bt_data_type_int_e {
+  /// < 8 bit signed int type
+  static const int BT_DATA_TYPE_SINT8 = 0;
+
+  /// < 16 bit signed int type
+  static const int BT_DATA_TYPE_SINT16 = 1;
+
+  /// < 32 bit signed int type
+  static const int BT_DATA_TYPE_SINT32 = 2;
+
+  /// < 8 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT8 = 3;
+
+  /// < 16 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT16 = 4;
+
+  /// < 32 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT32 = 5;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the float type for GATT handle's value.
+/// @since_tizen 2.3.1
+abstract class bt_data_type_float_e {
+  /// < 32 bit float type
+  static const int BT_DATA_TYPE_FLOAT = 0;
+
+  /// < 16 bit float type
+  static const int BT_DATA_TYPE_SFLOAT = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the write type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_write_type_e {
+  /// < Write without response type
+  static const int BT_GATT_WRITE_TYPE_WRITE_NO_RESPONSE = 0;
+
+  /// < Write type
+  static const int BT_GATT_WRITE_TYPE_WRITE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the GATT handle's type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_type_e {
+  /// < GATT service type
+  static const int BT_GATT_TYPE_SERVICE = 1;
+
+  /// < GATT characteristic type
+  static const int BT_GATT_TYPE_CHARACTERISTIC = 2;
+
+  /// < GATT descriptor type
+  static const int BT_GATT_TYPE_DESCRIPTOR = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the service type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_service_type_e {
+  /// < GATT primary service type
+  static const int BT_GATT_SERVICE_TYPE_PRIMARY = 1;
+
+  /// < GATT secondary service type
+  static const int BT_GATT_SERVICE_TYPE_SECONDARY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the characteristic's property.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_property_e {
+  /// < Broadcast property
+  static const int BT_GATT_PROPERTY_BROADCAST = 1;
+
+  /// < Read property
+  static const int BT_GATT_PROPERTY_READ = 2;
+
+  /// < Write without response property
+  static const int BT_GATT_PROPERTY_WRITE_WITHOUT_RESPONSE = 4;
+
+  /// < Write property
+  static const int BT_GATT_PROPERTY_WRITE = 8;
+
+  /// < Notify property
+  static const int BT_GATT_PROPERTY_NOTIFY = 16;
+
+  /// < Indicate property
+  static const int BT_GATT_PROPERTY_INDICATE = 32;
+
+  /// < Authenticated signed writes property
+  static const int BT_GATT_PROPERTY_AUTHENTICATED_SIGNED_WRITES = 64;
+
+  /// < Extended properties
+  static const int BT_GATT_PROPERTY_EXTENDED_PROPERTIES = 128;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
+/// @brief  Enumerations of gatt server's service changing mode.
+/// @since_tizen 3.0
+abstract class bt_gatt_client_service_change_type_e {
+  /// < Service added
+  static const int BT_GATT_CLIENT_SERVICE_ADDED = 0;
+
+  /// < Service removed
+  static const int BT_GATT_CLIENT_SERVICE_REMOVED = 1;
+
+  /// < Resync is required (Since 6.5)
+  static const int BT_GATT_CLIENT_SERVICE_RESYNC = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the attribute's permission.
+/// @since_tizen 3.0
+abstract class bt_gatt_permission_e {
+  /// < Readable permission
+  static const int BT_GATT_PERMISSION_READ = 1;
+
+  /// < Writable permission
+  static const int BT_GATT_PERMISSION_WRITE = 2;
+
+  /// < Readable permission required encryption
+  static const int BT_GATT_PERMISSION_ENCRYPT_READ = 4;
+
+  /// < Writable permission required encryption
+  static const int BT_GATT_PERMISSION_ENCRYPT_WRITE = 8;
+
+  /// < Readable permission required encryption and authentication
+  static const int BT_GATT_PERMISSION_ENCRYPT_AUTHENTICATED_READ = 16;
+
+  /// < Writable permission required encryption and authentication
+  static const int BT_GATT_PERMISSION_ENCRYPT_AUTHENTICATED_WRITE = 32;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
+/// @brief  Enumerations of the remote device request types for attributes.
+/// @since_tizen 3.0
+abstract class bt_gatt_att_request_type_e {
+  /// < Read Requested
+  static const int BT_GATT_REQUEST_TYPE_READ = 0;
+
+  /// < Write Requested
+  static const int BT_GATT_REQUEST_TYPE_WRITE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PAN_PANU_MODULE
+/// @brief  Enumerations for the types of PAN (Personal Area Networking) service.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+abstract class bt_panu_service_type_e {
+  /// < Network Access Point
+  static const int BT_PANU_SERVICE_TYPE_NAP = 0;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of address book location for PBAP.
+/// @since_tizen 3.0
+abstract class bt_pbap_address_book_source_e {
+  /// < Request for Addressbook from remote device
+  static const int BT_PBAP_SOURCE_DEVICE = 0;
+
+  /// < Request for address book from SIM
+  static const int BT_PBAP_SOURCE_SIM = 1;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of folder type.
+/// @since_tizen 3.0
+abstract class bt_pbap_folder_type_e {
+  /// < Request for address book
+  static const int BT_PBAP_FOLDER_PHONE_BOOK = 0;
+
+  /// < Request for incoming calls
+  static const int BT_PBAP_FOLDER_INCOMING = 1;
+
+  /// < Request for outgoing calls
+  static const int BT_PBAP_FOLDER_OUTGOING = 2;
+
+  /// < Request for missed calls
+  static const int BT_PBAP_FOLDER_MISSED = 3;
+
+  /// < Request for combined calls
+  static const int BT_PBAP_FOLDER_COMBINED = 4;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of phone book search fields.
+/// @since_tizen 3.0
+abstract class bt_pbap_search_field_e {
+  /// < Request for search by name (default)
+  static const int BT_PBAP_SEARCH_NAME = 0;
+
+  /// < Request for search by phone number
+  static const int BT_PBAP_SEARCH_NUMBER = 1;
+
+  /// < Request for search by sound
+  static const int BT_PBAP_SEARCH_SOUND = 2;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of vCard Formats.
+/// @since_tizen 3.0
+abstract class bt_pbap_vcard_format_e {
+  /// < vCard format 2.1 (default)
+  static const int BT_PBAP_VCARD_FORMAT_VCARD21 = 0;
+
+  /// < vCard format 3.0
+  static const int BT_PBAP_VCARD_FORMAT_VCARD30 = 1;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of sorting orders.
+/// @since_tizen 3.0
+abstract class bt_pbap_sort_order_e {
+  /// < Filter order indexed (default)
+  static const int BT_PBAP_ORDER_INDEXED = 0;
+
+  /// < Filter order alphanumeric
+  static const int BT_PBAP_ORDER_ALPHANUMERIC = 1;
+
+  /// < Filter order phonetic
+  static const int BT_PBAP_ORDER_PHONETIC = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Class structure of device and service.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see #bt_device_info_s
+/// @see #bt_adapter_device_discovery_info_s
+/// @see bt_device_bond_created_cb()
+/// @see bt_adapter_device_discovery_state_changed_cb()
+final class bt_class_s extends ffi.Struct {
+  /// < Major device class.
+  @ffi.Int32()
+  external int major_device_class;
+
+  /// < Minor device class.
+  @ffi.Int32()
+  external int minor_device_class;
+
+  /// < Major service class mask.
+  /// This value can be a combination of #bt_major_service_class_e like #BT_MAJOR_SERVICE_CLASS_RENDERING | #BT_MAJOR_SERVICE_CLASS_AUDIO
+  @ffi.Int()
+  external int major_service_class_mask;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief Structure of device discovery information.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see #bt_class_s
+/// @see bt_adapter_device_discovery_state_changed_cb()
+final class bt_adapter_device_discovery_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The name of remote device
+  external ffi.Pointer<ffi.Char> remote_name;
+
+  /// < The Bluetooth classes
+  external bt_class_s bt_class;
+
+  /// < The strength indicator of received signal
+  @ffi.Int()
+  external int rssi;
+
+  /// < The bonding state
+  @ffi.Bool()
+  external bool is_bonded;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services
+  @ffi.Int()
+  external int service_count;
+
+  /// < The Bluetooth appearance
+  @ffi.Int32()
+  external int appearance;
+
+  /// < manufacturer specific data length
+  @ffi.Int()
+  external int manufacturer_data_len;
+
+  /// < manufacturer specific data
+  external ffi.Pointer<ffi.Char> manufacturer_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief Structure of le scan result information.
+/// @since_tizen 2.3.1
+///
+/// @see bt_adapter_le_start_scan()
+final class bt_adapter_le_device_scan_result_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The address type of remote device
+  @ffi.Int32()
+  external int address_type;
+
+  /// < The strength indicator of received signal
+  @ffi.Int()
+  external int rssi;
+
+  /// < advertising indication data length
+  @ffi.Int()
+  external int adv_data_len;
+
+  /// < advertising indication data
+  external ffi.Pointer<ffi.Char> adv_data;
+
+  /// < scan response data length
+  @ffi.Int()
+  external int scan_data_len;
+
+  /// < scan response data
+  external ffi.Pointer<ffi.Char> scan_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief The structure for LE iBeacon scan result information.
+/// @since_tizen 4.0
+///
+/// @see bt_adapter_le_start_scan()
+final class bt_adapter_le_ibeacon_scan_result_info_s extends ffi.Struct {
+  /// < Company ID
+  @ffi.Int()
+  external int company_id;
+
+  /// < iBeacon type
+  @ffi.Int()
+  external int ibeacon_type;
+
+  /// < UUID
+  external ffi.Pointer<ffi.Char> uuid;
+
+  /// < Major ID
+  @ffi.Int()
+  external int major_id;
+
+  /// < Minor ID
+  @ffi.Int()
+  external int minor_id;
+
+  /// < Measured power
+  @ffi.Int()
+  external int measured_power;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief LE service data structure.
+/// @since_tizen 2.3.1
+///
+/// @see bt_adapter_le_get_scan_result_service_data()
+final class bt_adapter_le_service_data_s extends ffi.Struct {
+  /// < 16 bit UUID of the service data
+  external ffi.Pointer<ffi.Char> service_uuid;
+
+  /// < Service data
+  external ffi.Pointer<ffi.Char> service_data;
+
+  /// < Service data length
+  @ffi.Int()
+  external int service_data_len;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Device information structure used for identifying pear device.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see #bt_class_s
+/// @see bt_device_bond_created_cb()
+final class bt_device_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The name of remote device
+  external ffi.Pointer<ffi.Char> remote_name;
+
+  /// < The Bluetooth classes
+  external bt_class_s bt_class;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services
+  @ffi.Int()
+  external int service_count;
+
+  /// < The bonding state
+  @ffi.Bool()
+  external bool is_bonded;
+
+  /// < The connection state
+  @ffi.Bool()
+  external bool is_connected;
+
+  /// < The authorization state
+  @ffi.Bool()
+  external bool is_authorized;
+
+  /// < manufacturer specific data length
+  @ffi.Int()
+  external int manufacturer_data_len;
+
+  /// < manufacturer specific data
+  external ffi.Pointer<ffi.Char> manufacturer_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Service Discovery Protocol (SDP) data structure.
+///
+/// @details This protocol is used for discovering available services or pear device,
+/// and finding one to connect with.
+///
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+/// @see bt_device_service_searched_cb()
+final class bt_device_sdp_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services.
+  @ffi.Int()
+  external int service_count;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Device connection information structure.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see bt_device_connection_state_changed_cb()
+final class bt_device_connection_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < Link type
+  @ffi.Int32()
+  external int link;
+
+  /// < Disconnection reason
+  @ffi.Int32()
+  external int disconn_reason;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief Rfcomm connection data used for exchanging data between Bluetooth devices.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @see bt_socket_connection_state_changed_cb()
+final class bt_socket_connection_s extends ffi.Struct {
+  /// < The file descriptor of connected socket
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The file descriptor of the server socket or -1 for client connection
+  @ffi.Int()
+  external int server_fd;
+
+  /// < The local device role in this connection
+  @ffi.Int32()
+  external int local_role;
+
+  /// < The remote device address
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The service UUId
+  external ffi.Pointer<ffi.Char> service_uuid;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief Structure of RFCOMM received data.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @remarks User can use standard linux functions for reading/writing \n
+/// data from/to sockets.
+///
+/// @see bt_socket_data_received_cb()
+final class bt_socket_received_data_s extends ffi.Struct {
+  /// < The socket fd
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The length of the received data
+  @ffi.Int()
+  external int data_size;
+
+  /// < The received data
+  external ffi.Pointer<ffi.Char> data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
+/// @brief Attribute protocol MTU change information structure.
+/// @since_tizen 4.0
+///
+/// @see bt_gatt_client_att_mtu_changed_cb()
+final class bt_gatt_client_att_mtu_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < MTU value
+  @ffi.UnsignedInt()
+  external int mtu;
+
+  /// < Request status
+  @ffi.UnsignedInt()
+  external int status;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID mouse's button.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_mouse_button_e {
+  /// <The mouse's none value
+  static const int BT_HID_MOUSE_BUTTON_NONE = 0;
+
+  /// <The mouse's left button value
+  static const int BT_HID_MOUSE_BUTTON_LEFT = 1;
+
+  /// <The mouse's right button value
+  static const int BT_HID_MOUSE_BUTTON_RIGHT = 2;
+
+  /// <The mouse's middle button value
+  static const int BT_HID_MOUSE_BUTTON_MIDDLE = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing the HID mouse event information.
+/// @since_tizen @if WEARABLE 3.0 @endif
+///
+/// @see bt_hid_device_send_mouse_event()
+final class bt_hid_mouse_data_s extends ffi.Struct {
+  /// < The button values, we can combine key's values when we pressed multiple mouse buttons
+  @ffi.Int()
+  external int buttons;
+
+  /// < The location's x value, -128 ~127
+  @ffi.Int()
+  external int axis_x;
+
+  /// < The location's y value, -128 ~127
+  @ffi.Int()
+  external int axis_y;
+
+  /// < The padding value, -128 ~127
+  @ffi.Int()
+  external int padding;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing the HID keyboard event information.
+/// @details If you want to know more detail values, refer to http://www.usb.org/developers/hidpage/ and see "HID Usage Tables"
+/// @since_tizen @if WEARABLE 3.0 @endif
+///
+/// @see bt_hid_device_send_key_event()
+final class bt_hid_key_data_s extends ffi.Struct {
+  /// < The modifier keys : such as shift, alt
+  @ffi.UnsignedChar()
+  external int modifier;
+
+  /// < The key value - currently pressed keys : Max 8 at once
+  @ffi.Array.multi([8])
+  external ffi.Array<ffi.UnsignedChar> key;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID header type.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_header_type_e {
+  /// < The Bluetooth HID header type: Handshake
+  static const int BT_HID_HEADER_HANDSHAKE = 0;
+
+  /// < The Bluetooth HID header type: HID control
+  static const int BT_HID_HEADER_HID_CONTROL = 1;
+
+  /// < The Bluetooth HID header type: Get report
+  static const int BT_HID_HEADER_GET_REPORT = 2;
+
+  /// < The Bluetooth HID header type: Set report
+  static const int BT_HID_HEADER_SET_REPORT = 3;
+
+  /// < The Bluetooth HID header type: Get protocol
+  static const int BT_HID_HEADER_GET_PROTOCOL = 4;
+
+  /// < The Bluetooth HID header type: Set protocol
+  static const int BT_HID_HEADER_SET_PROTOCOL = 5;
+
+  /// < The Bluetooth HID header type: Data
+  static const int BT_HID_HEADER_DATA = 6;
+
+  /// < The Bluetooth HID header type: Unknown
+  static const int BT_HID_HEADER_UNKNOWN = 7;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID parameter type.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_param_type_e {
+  /// < Parameter type: Input
+  static const int BT_HID_PARAM_DATA_RTYPE_INPUT = 0;
+
+  /// < Parameter type: Output
+  static const int BT_HID_PARAM_DATA_RTYPE_OUTPUT = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID handshake type.
+/// @since_tizen @if WEARABLE 3.0 @endif
+abstract class bt_hid_handshake_type_e {
+  /// < Handshake error code none
+  static const int BT_HID_HANDSHAKE_SUCCESSFUL = 0;
+
+  /// < Handshake error code Not Ready
+  static const int BT_HID_HANDSHAKE_NOT_READY = 1;
+
+  /// < Handshake error code send invalid report id
+  static const int BT_HID_HANDSHAKE_ERR_INVALID_REPORT_ID = 2;
+
+  /// < Handshake error code request unsupported request
+  static const int BT_HID_HANDSHAKE_ERR_UNSUPPORTED_REQUEST = 3;
+
+  /// < Handshake error code received invalid parameter
+  static const int BT_HID_HANDSHAKE_ERR_INVALID_PARAMETER = 4;
+
+  /// < unknown error
+  static const int BT_HID_HANDSHAKE_ERR_UNKNOWN = 14;
+
+  /// < Fatal error
+  static const int BT_HID_HANDSHAKE_ERR_FATAL = 15;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing data received from the HID Host.
+/// @since_tizen @if WEARABLE 3.0 @endif
+final class bt_hid_device_received_data_s extends ffi.Struct {
+  /// < The remote device's address
+  external ffi.Pointer<ffi.Char> address;
+
+  /// < The header type
+  @ffi.Int32()
+  external int header_type;
+
+  /// < The parameter type
+  @ffi.Int32()
+  external int param_type;
+
+  /// < The length of the received data
+  @ffi.Int()
+  external int data_size;
+
+  /// < The received data
+  external ffi.Pointer<ffi.Char> data;
+}
+
+/// @WEARABLE_ONLY
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief The structure type containing vCard information.
+/// @since_tizen 3.0
+///
+/// @see bt_pbap_client_pull_vcard()
+final class bt_pbap_vcard_info_s extends ffi.Struct {
+  /// < The vcard index, used as a parameter for bt_pbap_client_pull_vcard()
+  @ffi.Int()
+  external int index;
+
+  /// < The contact name of the vCard
+  external ffi.Pointer<ffi.Char> contact_name;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief Enumeration for the scan filter type.
+/// @since_tizen 4.0
+/// @see bt_adapter_le_scan_filter_set_type()
+abstract class bt_adapter_le_scan_filter_type_e {
+  /// < iBeacon filter type
+  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_IBEACON = 0;
+
+  /// < Proximity UUID filter type
+  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_PROXIMITY_UUID = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief L2CAP CoC connection data used for exchanging data between Bluetooth devices.
+/// @since_tizen 7.0
+///
+/// @see bt_socket_l2cap_channel_connection_state_changed_cb()
+final class bt_socket_l2cap_le_connection_s extends ffi.Struct {
+  /// < The file descriptor of connected socket
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The file descriptor of the server socket or -1 for client connection
+  @ffi.Int()
+  external int server_fd;
+
+  /// < The local device role in this connection
+  @ffi.Int32()
+  external int local_role;
+
+  /// < The remote device address
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The psm of the connected socket
+  @ffi.Int()
+  external int psm;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_ADV_EXT_MODULE
+/// @brief Enumerations of the Bluetooth LE scan role.
+/// @since_tizen 8.0
+abstract class bt_adapter_le_scan_role_e {
+  /// < Scan all
+  static const int BT_ADAPTER_LE_SCAN_ALL = 0;
+
+  /// < Legacy scan only
+  static const int BT_ADAPTER_LE_SCAN_LEGACY_ONLY = 1;
+
+  /// < Extended scan only
+  static const int BT_ADAPTER_LE_SCAN_EXTENDED_ONLY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_ADV_EXT_MODULE
+/// @brief Enumerations of the Bluetooth LE phy.
+/// @since_tizen 8.0
+abstract class bt_adapter_le_phy_e {
+  /// < All phy
+  static const int BT_LE_ALL_PHY = 0;
+
+  /// < 1M phy
+  static const int BT_LE_1M_PHY = 1;
+
+  /// < 2M phy
+  static const int BT_LE_2M_PHY = 2;
+
+  /// < Coded phy
+  static const int BT_LE_CODED_PHY = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief  Called when you get bonded devices repeatedly.
+/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
+///
+/// @param[in] device_info The bonded device information
+/// @param[in] user_data The user data passed from the foreach function
+/// @return @c true to continue with the next iteration of the loop,
+/// \n @c false to break out of the loop.
+/// @pre bt_adapter_foreach_bonded_device() will invoke this function.
+///
+/// @see bt_adapter_foreach_bonded_device()
+typedef bt_adapter_bonded_device_cb
+    = ffi.Pointer<ffi.NativeFunction<bt_adapter_bonded_device_cbFunction>>;
+typedef bt_adapter_bonded_device_cbFunction = ffi.Bool Function(
+    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
+typedef Dartbt_adapter_bonded_device_cbFunction = bool Function(
+    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
+
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
 /// @brief  Called when the Bluetooth adapter state changes.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
@@ -11328,80 +12673,6 @@ typedef Dartbt_adapter_device_discovery_state_changed_cbFunction
         ffi.Pointer<bt_adapter_device_discovery_info_s> discovery_info,
         ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief Enumerations of the discovery state of Bluetooth device.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_adapter_device_discovery_state_e {
-  /// < Device discovery is started
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_STARTED = 0;
-
-  /// < Device discovery is finished
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_FINISHED = 1;
-
-  /// < The remote Bluetooth device is found
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_FOUND = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief Structure of device discovery information.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see #bt_class_s
-/// @see bt_adapter_device_discovery_state_changed_cb()
-final class bt_adapter_device_discovery_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The name of remote device
-  external ffi.Pointer<ffi.Char> remote_name;
-
-  /// < The Bluetooth classes
-  external bt_class_s bt_class;
-
-  /// < The strength indicator of received signal
-  @ffi.Int()
-  external int rssi;
-
-  /// < The bonding state
-  @ffi.Bool()
-  external bool is_bonded;
-
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
-
-  /// < The number of services
-  @ffi.Int()
-  external int service_count;
-
-  /// < The Bluetooth appearance
-  @ffi.Int32()
-  external int appearance;
-
-  /// < manufacturer specific data length
-  @ffi.Int()
-  external int manufacturer_data_len;
-
-  /// < manufacturer specific data
-  external ffi.Pointer<ffi.Char> manufacturer_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief  Enumerations of gap appearance type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_appearance_type_e {
-  /// < Unknown appearance type
-  static const int BT_APPEARANCE_TYPE_UNKNOWN = 0;
-
-  /// < Generic Phone type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_PHONE = 64;
-
-  /// < Generic Computer type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_COMPUTER = 128;
-
-  /// < Generic Watch type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_WATCH = 192;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief  Called when the LE advertisement has been found.
 /// @since_tizen 2.3.1
@@ -11421,107 +12692,6 @@ typedef Dartbt_adapter_le_scan_result_cbFunction = void Function(
     int result,
     ffi.Pointer<bt_adapter_le_device_scan_result_info_s> info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief Structure of le scan result information.
-/// @since_tizen 2.3.1
-///
-/// @see bt_adapter_le_start_scan()
-final class bt_adapter_le_device_scan_result_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The address type of remote device
-  @ffi.Int32()
-  external int address_type;
-
-  /// < The strength indicator of received signal
-  @ffi.Int()
-  external int rssi;
-
-  /// < advertising indication data length
-  @ffi.Int()
-  external int adv_data_len;
-
-  /// < advertising indication data
-  external ffi.Pointer<ffi.Char> adv_data;
-
-  /// < scan response data length
-  @ffi.Int()
-  external int scan_data_len;
-
-  /// < scan response data
-  external ffi.Pointer<ffi.Char> scan_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device address type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_address_type_e {
-  /// < Public address
-  static const int BT_DEVICE_PUBLIC_ADDRESS = 0;
-
-  /// < Random address
-  static const int BT_DEVICE_RANDOM_ADDRESS = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth LE packet type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_adapter_le_packet_type_e {
-  /// < Advertising packet
-  static const int BT_ADAPTER_LE_PACKET_ADVERTISING = 0;
-
-  /// < Scan response packet
-  static const int BT_ADAPTER_LE_PACKET_SCAN_RESPONSE = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief LE service data structure.
-/// @since_tizen 2.3.1
-///
-/// @see bt_adapter_le_get_scan_result_service_data()
-final class bt_adapter_le_service_data_s extends ffi.Struct {
-  /// < 16 bit UUID of the service data
-  external ffi.Pointer<ffi.Char> service_uuid;
-
-  /// < Service data
-  external ffi.Pointer<ffi.Char> service_data;
-
-  /// < Service data length
-  @ffi.Int()
-  external int service_data_len;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief The structure for LE iBeacon scan result information.
-/// @since_tizen 4.0
-///
-/// @see bt_adapter_le_start_scan()
-final class bt_adapter_le_ibeacon_scan_result_info_s extends ffi.Struct {
-  /// < Company ID
-  @ffi.Int()
-  external int company_id;
-
-  /// < iBeacon type
-  @ffi.Int()
-  external int ibeacon_type;
-
-  /// < UUID
-  external ffi.Pointer<ffi.Char> uuid;
-
-  /// < Major ID
-  @ffi.Int()
-  external int major_id;
-
-  /// < Minor ID
-  @ffi.Int()
-  external int minor_id;
-
-  /// < Measured power
-  @ffi.Int()
-  external int measured_power;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief The handle to control Bluetooth LE advertising.
@@ -11592,59 +12762,6 @@ typedef Dartbt_adapter_le_advertising_state_changed_cbFunction = void Function(
     int adv_state,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth advertising state.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_adapter_le_advertising_state_e {
-  /// < Bluetooth advertising is stopped
-  static const int BT_ADAPTER_LE_ADVERTISING_STOPPED = 0;
-
-  /// < Bluetooth advertising is started
-  static const int BT_ADAPTER_LE_ADVERTISING_STARTED = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth advertising mode.
-/// @since_tizen 2.3.1
-abstract class bt_adapter_le_advertising_mode_e {
-  /// < Balanced advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_BALANCED = 0;
-
-  /// < Low latency advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_LATENCY = 1;
-
-  /// < Low energy advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_ENERGY = 2;
-
-  /// < Custom mode to set advertising parameters
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_CUSTOM = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth le scan mode.
-/// @since_tizen 3.0
-abstract class bt_adapter_le_scan_mode_e {
-  /// < Balanced mode of power consumption and connection latency
-  static const int BT_ADAPTER_LE_SCAN_MODE_BALANCED = 0;
-
-  /// < Low connection latency but high power consumption
-  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_LATENCY = 1;
-
-  /// < Low power consumption but high connection latency
-  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_ENERGY = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device authorization state.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_authorization_e {
-  /// < The remote Bluetooth device is authorized
-  static const int BT_DEVICE_AUTHORIZED = 0;
-
-  /// < The remote Bluetooth device is unauthorized
-  static const int BT_DEVICE_UNAUTHORIZED = 1;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief  Called when you get connected profiles repeatedly.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
@@ -11661,52 +12778,6 @@ typedef bt_device_connected_profileFunction = ffi.Bool Function(
     ffi.Int32 profile, ffi.Pointer<ffi.Void> user_data);
 typedef Dartbt_device_connected_profileFunction = bool Function(
     int profile, ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of Bluetooth profile.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_profile_e {
-  /// < RFCOMM Profile
-  static const int BT_PROFILE_RFCOMM = 1;
-
-  /// < Advanced Audio Distribution Profile Source role
-  static const int BT_PROFILE_A2DP = 2;
-
-  /// < Headset Profile
-  static const int BT_PROFILE_HSP = 4;
-
-  /// < Human Interface Device Profile
-  static const int BT_PROFILE_HID = 8;
-
-  /// < Network Access Point Profile
-  static const int BT_PROFILE_NAP = 16;
-
-  /// < Audio Gateway Profile
-  static const int BT_PROFILE_AG = 32;
-
-  /// < Generic Attribute Profile
-  static const int BT_PROFILE_GATT = 64;
-
-  /// < NAP server Profile
-  static const int BT_PROFILE_NAP_SERVER = 128;
-
-  /// < Advanced Audio Distribution Profile Sink role
-  static const int BT_PROFILE_A2DP_SINK = 256;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief  Enumerations of the Bluetooth device's LE connection mode.
-/// @since_tizen 3.0
-abstract class bt_device_le_connection_mode_e {
-  /// < Balanced mode of power consumption and connection latency
-  static const int BT_DEVICE_LE_CONNECTION_MODE_BALANCED = 0;
-
-  /// < Low connection latency but high power consumption
-  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_LATENCY = 1;
-
-  /// < Low power consumption but high connection latency
-  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_ENERGY = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief Called when the process of creating bond finishes.
@@ -11804,26 +12875,6 @@ typedef Dartbt_device_service_searched_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Service Discovery Protocol (SDP) data structure.
-///
-/// @details This protocol is used for discovering available services or pear device,
-/// and finding one to connect with.
-///
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-/// @see bt_device_service_searched_cb()
-final class bt_device_sdp_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
-
-  /// < The number of services.
-  @ffi.Int()
-  external int service_count;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief  Called when the connection state is changed.
 /// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
 ///
@@ -11842,55 +12893,6 @@ typedef Dartbt_device_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<bt_device_connection_info_s> conn_info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Device connection information structure.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see bt_device_connection_state_changed_cb()
-final class bt_device_connection_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < Link type
-  @ffi.Int32()
-  external int link;
-
-  /// < Disconnection reason
-  @ffi.Int32()
-  external int disconn_reason;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of connection link type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_connection_link_type_e {
-  /// < BR/EDR link
-  static const int BT_DEVICE_CONNECTION_LINK_BREDR = 0;
-
-  /// < LE link
-  static const int BT_DEVICE_CONNECTION_LINK_LE = 1;
-
-  /// < The connection type default
-  static const int BT_DEVICE_CONNECTION_LINK_DEFAULT = 255;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device disconnect reason.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_device_disconnect_reason_e {
-  /// < Disconnected by unknown reason
-  static const int BT_DEVICE_DISCONNECT_REASON_UNKNOWN = 0;
-
-  /// < Disconnected by timeout
-  static const int BT_DEVICE_DISCONNECT_REASON_TIMEOUT = 1;
-
-  /// < Disconnected by local host
-  static const int BT_DEVICE_DISCONNECT_REASON_LOCAL_HOST = 2;
-
-  /// < Disconnected by remote
-  static const int BT_DEVICE_DISCONNECT_REASON_REMOTE = 3;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief Called when you receive data.
@@ -11913,27 +12915,6 @@ typedef bt_socket_data_received_cbFunction = ffi.Void Function(
 typedef Dartbt_socket_data_received_cbFunction = void Function(
     ffi.Pointer<bt_socket_received_data_s> data,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief Structure of RFCOMM received data.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @remarks User can use standard linux functions for reading/writing \n
-/// data from/to sockets.
-///
-/// @see bt_socket_data_received_cb()
-final class bt_socket_received_data_s extends ffi.Struct {
-  /// < The socket fd
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The length of the received data
-  @ffi.Int()
-  external int data_size;
-
-  /// < The received data
-  external ffi.Pointer<ffi.Char> data;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief  Called when a RFCOMM connection is requested.
@@ -11981,56 +12962,6 @@ typedef Dartbt_socket_connection_state_changed_cbFunction = void Function(
     int connection_state,
     ffi.Pointer<bt_socket_connection_s> connection,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief  Enumerations of Bluetooth socket connection state.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_socket_connection_state_e {
-  /// < RFCOMM is connected
-  static const int BT_SOCKET_CONNECTED = 0;
-
-  /// < RFCOMM is disconnected
-  static const int BT_SOCKET_DISCONNECTED = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief Rfcomm connection data used for exchanging data between Bluetooth devices.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-///
-/// @see bt_socket_connection_state_changed_cb()
-final class bt_socket_connection_s extends ffi.Struct {
-  /// < The file descriptor of connected socket
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The file descriptor of the server socket or -1 for client connection
-  @ffi.Int()
-  external int server_fd;
-
-  /// < The local device role in this connection
-  @ffi.Int32()
-  external int local_role;
-
-  /// < The remote device address
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The service UUId
-  external ffi.Pointer<ffi.Char> service_uuid;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief  Enumerations of connected Bluetooth device event role.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_socket_role_e {
-  /// < Unknown role
-  static const int BT_SOCKET_UNKNOWN = 0;
-
-  /// < Server role
-  static const int BT_SOCKET_SERVER = 1;
-
-  /// < Client role
-  static const int BT_SOCKET_CLIENT = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_OPP_SERVER_MODULE
 /// @brief  Called when an OPP connection is requested.
@@ -12202,45 +13133,6 @@ typedef Dartbt_hid_device_connection_state_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing the HID mouse event information.
-/// @since_tizen @if WEARABLE 3.0 @endif
-///
-/// @see bt_hid_device_send_mouse_event()
-final class bt_hid_mouse_data_s extends ffi.Struct {
-  /// < The button values, we can combine key's values when we pressed multiple mouse buttons
-  @ffi.Int()
-  external int buttons;
-
-  /// < The location's x value, -128 ~127
-  @ffi.Int()
-  external int axis_x;
-
-  /// < The location's y value, -128 ~127
-  @ffi.Int()
-  external int axis_y;
-
-  /// < The padding value, -128 ~127
-  @ffi.Int()
-  external int padding;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing the HID keyboard event information.
-/// @details If you want to know more detail values, refer to http://www.usb.org/developers/hidpage/ and see "HID Usage Tables"
-/// @since_tizen @if WEARABLE 3.0 @endif
-///
-/// @see bt_hid_device_send_key_event()
-final class bt_hid_key_data_s extends ffi.Struct {
-  /// < The modifier keys : such as shift, alt
-  @ffi.UnsignedChar()
-  external int modifier;
-
-  /// < The key value - currently pressed keys : Max 8 at once
-  @ffi.Array.multi([8])
-  external ffi.Array<ffi.UnsignedChar> key;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
 /// @brief  Called when the HID Device receives data from the HID Host.
 /// @details The following error codes can be delivered: \n
 /// #BT_ERROR_NONE \n
@@ -12258,89 +13150,6 @@ typedef bt_hid_device_data_received_cbFunction = ffi.Void Function(
 typedef Dartbt_hid_device_data_received_cbFunction = void Function(
     ffi.Pointer<bt_hid_device_received_data_s> data,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing data received from the HID Host.
-/// @since_tizen @if WEARABLE 3.0 @endif
-final class bt_hid_device_received_data_s extends ffi.Struct {
-  /// < The remote device's address
-  external ffi.Pointer<ffi.Char> address;
-
-  /// < The header type
-  @ffi.Int32()
-  external int header_type;
-
-  /// < The parameter type
-  @ffi.Int32()
-  external int param_type;
-
-  /// < The length of the received data
-  @ffi.Int()
-  external int data_size;
-
-  /// < The received data
-  external ffi.Pointer<ffi.Char> data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief Enumerations of the Bluetooth HID header type.
-/// @since_tizen @if WEARABLE 3.0 @endif
-abstract class bt_hid_header_type_e {
-  /// < The Bluetooth HID header type: Handshake
-  static const int BT_HID_HEADER_HANDSHAKE = 0;
-
-  /// < The Bluetooth HID header type: HID control
-  static const int BT_HID_HEADER_HID_CONTROL = 1;
-
-  /// < The Bluetooth HID header type: Get report
-  static const int BT_HID_HEADER_GET_REPORT = 2;
-
-  /// < The Bluetooth HID header type: Set report
-  static const int BT_HID_HEADER_SET_REPORT = 3;
-
-  /// < The Bluetooth HID header type: Get protocol
-  static const int BT_HID_HEADER_GET_PROTOCOL = 4;
-
-  /// < The Bluetooth HID header type: Set protocol
-  static const int BT_HID_HEADER_SET_PROTOCOL = 5;
-
-  /// < The Bluetooth HID header type: Data
-  static const int BT_HID_HEADER_DATA = 6;
-
-  /// < The Bluetooth HID header type: Unknown
-  static const int BT_HID_HEADER_UNKNOWN = 7;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief Enumerations of the Bluetooth HID parameter type.
-/// @since_tizen @if WEARABLE 3.0 @endif
-abstract class bt_hid_param_type_e {
-  /// < Parameter type: Input
-  static const int BT_HID_PARAM_DATA_RTYPE_INPUT = 0;
-
-  /// < Parameter type: Output
-  static const int BT_HID_PARAM_DATA_RTYPE_OUTPUT = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
-/// @brief  Enumerations for the types of profiles related with audio.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-abstract class bt_audio_profile_type_e {
-  /// < All supported profiles related with audio (Both Host and Device role)
-  static const int BT_AUDIO_PROFILE_TYPE_ALL = 0;
-
-  /// < local device AG and remote device HF Client (Host role, ex: mobile)
-  static const int BT_AUDIO_PROFILE_TYPE_HSP_HFP = 1;
-
-  /// < A2DP Source Connection, remote device is A2DP Sink (Host role, ex: mobile)
-  static const int BT_AUDIO_PROFILE_TYPE_A2DP = 2;
-
-  /// < local device HF Client and remote device AG (Device role, ex: headset)
-  static const int BT_AUDIO_PROFILE_TYPE_AG = 3;
-
-  /// < A2DP Sink Connection, remote device is A2DP Source (Device role, ex: headset)
-  static const int BT_AUDIO_PROFILE_TYPE_A2DP_SINK = 4;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
 /// @brief  Called when the connection state is changed.
@@ -12389,82 +13198,6 @@ typedef Dartbt_avrcp_target_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<ffi.Char> remote_address,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the equalizer state.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_equalizer_state_e {
-  /// < Equalizer Off
-  static const int BT_AVRCP_EQUALIZER_STATE_OFF = 1;
-
-  /// < Equalizer On
-  static const int BT_AVRCP_EQUALIZER_STATE_ON = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the repeat mode.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_repeat_mode_e {
-  /// < Repeat Off
-  static const int BT_AVRCP_REPEAT_MODE_OFF = 1;
-
-  /// < Single track repeat
-  static const int BT_AVRCP_REPEAT_MODE_SINGLE_TRACK = 2;
-
-  /// < All track repeat
-  static const int BT_AVRCP_REPEAT_MODE_ALL_TRACK = 3;
-
-  /// < Group repeat
-  static const int BT_AVRCP_REPEAT_MODE_GROUP = 4;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the shuffle mode.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_shuffle_mode_e {
-  /// < Shuffle Off
-  static const int BT_AVRCP_SHUFFLE_MODE_OFF = 1;
-
-  /// < All tracks shuffle
-  static const int BT_AVRCP_SHUFFLE_MODE_ALL_TRACK = 2;
-
-  /// < Group shuffle
-  static const int BT_AVRCP_SHUFFLE_MODE_GROUP = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the scan mode.
-/// @since_tizen @if WEARABLE 3.0 @else 2.4 @endif
-abstract class bt_avrcp_scan_mode_e {
-  /// < Scan Off
-  static const int BT_AVRCP_SCAN_MODE_OFF = 1;
-
-  /// < All tracks scan
-  static const int BT_AVRCP_SCAN_MODE_ALL_TRACK = 2;
-
-  /// < Group scan
-  static const int BT_AVRCP_SCAN_MODE_GROUP = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the player state.
-/// @since_tizen 3.0
-abstract class bt_avrcp_player_state_e {
-  /// < Stopped
-  static const int BT_AVRCP_PLAYER_STATE_STOPPED = 0;
-
-  /// < Playing
-  static const int BT_AVRCP_PLAYER_STATE_PLAYING = 1;
-
-  /// < Paused
-  static const int BT_AVRCP_PLAYER_STATE_PAUSED = 2;
-
-  /// < Seek Forward
-  static const int BT_AVRCP_PLAYER_STATE_FORWARD_SEEK = 3;
-
-  /// < Seek Rewind
-  static const int BT_AVRCP_PLAYER_STATE_REWIND_SEEK = 4;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
 /// @brief  Called when the equalizer state is changed by the remote control device.
@@ -12571,37 +13304,6 @@ typedef Dartbt_avrcp_track_info_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief Structure of Track metadata information.
-/// @since_tizen 3.0
-///
-/// @see #bt_class_s
-final class bt_avrcp_metadata_attributes_info_s extends ffi.Struct {
-  /// < Title
-  external ffi.Pointer<ffi.Char> title;
-
-  /// < Artist
-  external ffi.Pointer<ffi.Char> artist;
-
-  /// < Album name
-  external ffi.Pointer<ffi.Char> album;
-
-  /// < Album Genre
-  external ffi.Pointer<ffi.Char> genre;
-
-  /// < The total number of tracks
-  @ffi.UnsignedInt()
-  external int total_tracks;
-
-  /// < Track number
-  @ffi.UnsignedInt()
-  external int number;
-
-  /// < Duration
-  @ffi.UnsignedInt()
-  external int duration;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
 /// @brief  Called when the connection state is changed.
 /// @since_tizen 3.0
 /// @param[in] connected  The state to be changed. true means connected state, Otherwise, false.
@@ -12617,32 +13319,6 @@ typedef bt_avrcp_control_connection_state_changed_cbFunction
 typedef Dartbt_avrcp_control_connection_state_changed_cbFunction
     = void Function(bool connected, ffi.Pointer<ffi.Char> remote_address,
         ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumeration for the player control commands.
-/// @since_tizen 3.0
-abstract class bt_avrcp_player_command_e {
-  /// < Play
-  static const int BT_AVRCP_CONTROL_PLAY = 1;
-
-  /// < Pause
-  static const int BT_AVRCP_CONTROL_PAUSE = 2;
-
-  /// < Stop
-  static const int BT_AVRCP_CONTROL_STOP = 3;
-
-  /// < Next Track
-  static const int BT_AVRCP_CONTROL_NEXT = 4;
-
-  /// < Previous track
-  static const int BT_AVRCP_CONTROL_PREVIOUS = 5;
-
-  /// < Fast Forward
-  static const int BT_AVRCP_CONTROL_FAST_FORWARD = 6;
-
-  /// < Rewind
-  static const int BT_AVRCP_CONTROL_REWIND = 7;
-}
 
 /// @deprecated Deprecated since 5.0.
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
@@ -12674,19 +13350,6 @@ typedef Dartbt_hdp_connected_cbFunction = void Function(
     int type,
     int channel,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @deprecated Deprecated since 5.0.
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
-/// @brief  Enumerations for the data channel type.
-/// @since_tizen @if WEARABLE 2.3.1 @else 2.3 @endif
-/// @remarks Deprecated, because of no usecase and supported devices.
-abstract class bt_hdp_channel_type_e {
-  /// < Reliable Data Channel
-  static const int BT_HDP_CHANNEL_TYPE_RELIABLE = 1;
-
-  /// < Streaming Data Channel
-  static const int BT_HDP_CHANNEL_TYPE_STREAMING = 2;
-}
 
 /// @deprecated Deprecated since 5.0.
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
@@ -12740,54 +13403,6 @@ typedef Dartbt_hdp_data_received_cbFunction = void Function(int channel,
 /// @since_tizen 2.3.1
 typedef bt_gatt_h = ffi.Pointer<ffi.Void>;
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the integer type for GATT handle's value.
-/// @since_tizen 2.3.1
-abstract class bt_data_type_int_e {
-  /// < 8 bit signed int type
-  static const int BT_DATA_TYPE_SINT8 = 0;
-
-  /// < 16 bit signed int type
-  static const int BT_DATA_TYPE_SINT16 = 1;
-
-  /// < 32 bit signed int type
-  static const int BT_DATA_TYPE_SINT32 = 2;
-
-  /// < 8 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT8 = 3;
-
-  /// < 16 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT16 = 4;
-
-  /// < 32 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT32 = 5;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the float type for GATT handle's value.
-/// @since_tizen 2.3.1
-abstract class bt_data_type_float_e {
-  /// < 32 bit float type
-  static const int BT_DATA_TYPE_FLOAT = 0;
-
-  /// < 16 bit float type
-  static const int BT_DATA_TYPE_SFLOAT = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the GATT handle's type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_type_e {
-  /// < GATT service type
-  static const int BT_GATT_TYPE_SERVICE = 1;
-
-  /// < GATT characteristic type
-  static const int BT_GATT_TYPE_CHARACTERISTIC = 2;
-
-  /// < GATT descriptor type
-  static const int BT_GATT_TYPE_DESCRIPTOR = 3;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief The handle of a GATT client which is associated with a remote device.
 /// @since_tizen 2.3.1
@@ -12812,17 +13427,6 @@ typedef bt_gatt_foreach_cbFunction = ffi.Bool Function(ffi.Int total,
     ffi.Int index, bt_gatt_h gatt_handle, ffi.Pointer<ffi.Void> user_data);
 typedef Dartbt_gatt_foreach_cbFunction = bool Function(int total, int index,
     bt_gatt_h gatt_handle, ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the write type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_write_type_e {
-  /// < Write without response type
-  static const int BT_GATT_WRITE_TYPE_WRITE_NO_RESPONSE = 0;
-
-  /// < Write type
-  static const int BT_GATT_WRITE_TYPE_WRITE = 1;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief  Called when the client request(e.g. read / write) has been completed.
@@ -12863,24 +13467,6 @@ typedef Dartbt_gatt_client_att_mtu_changed_cbFunction = void Function(
     bt_gatt_client_h client,
     ffi.Pointer<bt_gatt_client_att_mtu_info_s> mtu_info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
-/// @brief Attribute protocol MTU change information structure.
-/// @since_tizen 4.0
-///
-/// @see bt_gatt_client_att_mtu_changed_cb()
-final class bt_gatt_client_att_mtu_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < MTU value
-  @ffi.UnsignedInt()
-  external int mtu;
-
-  /// < Request status
-  @ffi.UnsignedInt()
-  external int status;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief  Called when a value of a watched characteristic's GATT handle has been changed.
@@ -12927,20 +13513,6 @@ typedef Dartbt_gatt_client_service_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Char> service_uuid,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
-/// @brief  Enumerations of gatt server's service changing mode.
-/// @since_tizen 3.0
-abstract class bt_gatt_client_service_change_type_e {
-  /// < Service added
-  static const int BT_GATT_CLIENT_SERVICE_ADDED = 0;
-
-  /// < Service removed
-  static const int BT_GATT_CLIENT_SERVICE_REMOVED = 1;
-
-  /// < Resync is required (Since 6.5)
-  static const int BT_GATT_CLIENT_SERVICE_RESYNC = 2;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
 /// @brief Called when the connection state is changed.
 ///
@@ -12969,17 +13541,6 @@ typedef Dartbt_gatt_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<ffi.Char> remote_address,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the service type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_service_type_e {
-  /// < GATT primary service type
-  static const int BT_GATT_SERVICE_TYPE_PRIMARY = 1;
-
-  /// < GATT secondary service type
-  static const int BT_GATT_SERVICE_TYPE_SECONDARY = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
 /// @brief The handle of a GATT server.
@@ -13096,17 +13657,6 @@ typedef Dartbt_gatt_server_write_value_requested_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
-/// @brief  Enumerations of the remote device request types for attributes.
-/// @since_tizen 3.0
-abstract class bt_gatt_att_request_type_e {
-  /// < Read Requested
-  static const int BT_GATT_REQUEST_TYPE_READ = 0;
-
-  /// < Write Requested
-  static const int BT_GATT_REQUEST_TYPE_WRITE = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
 /// @brief  Called when the sending notification / indication is done.
 /// @since_tizen 3.0
 ///
@@ -13176,39 +13726,6 @@ typedef Dartbt_pbap_connection_state_changed_cbFunction = void Function(
 
 /// @WEARABLE_ONLY
 /// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of address book location for PBAP.
-/// @since_tizen 3.0
-abstract class bt_pbap_address_book_source_e {
-  /// < Request for Addressbook from remote device
-  static const int BT_PBAP_SOURCE_DEVICE = 0;
-
-  /// < Request for address book from SIM
-  static const int BT_PBAP_SOURCE_SIM = 1;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of folder type.
-/// @since_tizen 3.0
-abstract class bt_pbap_folder_type_e {
-  /// < Request for address book
-  static const int BT_PBAP_FOLDER_PHONE_BOOK = 0;
-
-  /// < Request for incoming calls
-  static const int BT_PBAP_FOLDER_INCOMING = 1;
-
-  /// < Request for outgoing calls
-  static const int BT_PBAP_FOLDER_OUTGOING = 2;
-
-  /// < Request for missed calls
-  static const int BT_PBAP_FOLDER_MISSED = 3;
-
-  /// < Request for combined calls
-  static const int BT_PBAP_FOLDER_COMBINED = 4;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
 /// @brief  Called when PBAP Phonebook size calculation completes.
 /// @details The following error codes can be delivered: \n
 /// #BT_ERROR_NONE \n
@@ -13234,33 +13751,6 @@ typedef Dartbt_pbap_phone_book_size_cbFunction = void Function(
     ffi.Pointer<ffi.Char> remote_address,
     int size,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of vCard Formats.
-/// @since_tizen 3.0
-abstract class bt_pbap_vcard_format_e {
-  /// < vCard format 2.1 (default)
-  static const int BT_PBAP_VCARD_FORMAT_VCARD21 = 0;
-
-  /// < vCard format 3.0
-  static const int BT_PBAP_VCARD_FORMAT_VCARD30 = 1;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of sorting orders.
-/// @since_tizen 3.0
-abstract class bt_pbap_sort_order_e {
-  /// < Filter order indexed (default)
-  static const int BT_PBAP_ORDER_INDEXED = 0;
-
-  /// < Filter order alphanumeric
-  static const int BT_PBAP_ORDER_ALPHANUMERIC = 1;
-
-  /// < Filter order phonetic
-  static const int BT_PBAP_ORDER_PHONETIC = 2;
-}
 
 /// @WEARABLE_ONLY
 /// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
@@ -13322,52 +13812,10 @@ typedef Dartbt_pbap_list_vcards_cbFunction = void Function(
     int count,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief The structure type containing vCard information.
-/// @since_tizen 3.0
-///
-/// @see bt_pbap_client_pull_vcard()
-final class bt_pbap_vcard_info_s extends ffi.Struct {
-  /// < The vcard index, used as a parameter for bt_pbap_client_pull_vcard()
-  @ffi.Int()
-  external int index;
-
-  /// < The contact name of the vCard
-  external ffi.Pointer<ffi.Char> contact_name;
-}
-
-/// @WEARABLE_ONLY
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of phone book search fields.
-/// @since_tizen 3.0
-abstract class bt_pbap_search_field_e {
-  /// < Request for search by name (default)
-  static const int BT_PBAP_SEARCH_NAME = 0;
-
-  /// < Request for search by phone number
-  static const int BT_PBAP_SEARCH_NUMBER = 1;
-
-  /// < Request for search by sound
-  static const int BT_PBAP_SEARCH_SOUND = 2;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief The handle of a Bluetooth LE scan filter.
 /// @since_tizen 4.0
 typedef bt_scan_filter_h = ffi.Pointer<ffi.Void>;
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief Enumeration for the scan filter type.
-/// @since_tizen 4.0
-/// @see bt_adapter_le_scan_filter_set_type()
-abstract class bt_adapter_le_scan_filter_type_e {
-  /// < iBeacon filter type
-  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_IBEACON = 0;
-
-  /// < Proximity UUID filter type
-  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_PROXIMITY_UUID = 1;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief  Called when the l2cap channel socket connection state changes.
@@ -13399,32 +13847,6 @@ typedef Dartbt_socket_l2cap_channel_connection_state_changed_cbFunction
         ffi.Pointer<bt_socket_l2cap_le_connection_s> connection,
         ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief L2CAP CoC connection data used for exchanging data between Bluetooth devices.
-/// @since_tizen 7.0
-///
-/// @see bt_socket_l2cap_channel_connection_state_changed_cb()
-final class bt_socket_l2cap_le_connection_s extends ffi.Struct {
-  /// < The file descriptor of connected socket
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The file descriptor of the server socket or -1 for client connection
-  @ffi.Int()
-  external int server_fd;
-
-  /// < The local device role in this connection
-  @ffi.Int32()
-  external int local_role;
-
-  /// < The remote device address
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The psm of the connected socket
-  @ffi.Int()
-  external int psm;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_ADV_EXT_MODULE
 /// @brief Called when the LE advertisement has been found.
 /// @since_tizen 8.0
@@ -13447,34 +13869,3 @@ typedef Dartbt_adapter_le_new_scan_result_cbFunction = void Function(
 /// @brief The handle of a new scan result.
 /// @since_tizen 8.0
 typedef bt_new_scan_result_h = ffi.Pointer<ffi.Void>;
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_ADV_EXT_MODULE
-/// @brief Enumerations of the Bluetooth LE scan role.
-/// @since_tizen 8.0
-abstract class bt_adapter_le_scan_role_e {
-  /// < Scan all
-  static const int BT_ADAPTER_LE_SCAN_ALL = 0;
-
-  /// < Legacy scan only
-  static const int BT_ADAPTER_LE_SCAN_LEGACY_ONLY = 1;
-
-  /// < Extended scan only
-  static const int BT_ADAPTER_LE_SCAN_EXTENDED_ONLY = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_ADV_EXT_MODULE
-/// @brief Enumerations of the Bluetooth LE phy.
-/// @since_tizen 8.0
-abstract class bt_adapter_le_phy_e {
-  /// < All phy
-  static const int BT_LE_ALL_PHY = 0;
-
-  /// < 1M phy
-  static const int BT_LE_1M_PHY = 1;
-
-  /// < 2M phy
-  static const int BT_LE_2M_PHY = 2;
-
-  /// < Coded phy
-  static const int BT_LE_CODED_PHY = 3;
-}

--- a/lib/src/bindings/8.0/generated_bindings_capi_system_info.dart
+++ b/lib/src/bindings/8.0/generated_bindings_capi_system_info.dart
@@ -369,6 +369,38 @@ class Tizen80CapiSystemInfo {
           int Function(ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Int32>)>();
 }
 
+/// @brief Enumeration for system information error codes.
+abstract class system_info_error_e {
+  /// < Successful
+  static const int SYSTEM_INFO_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int SYSTEM_INFO_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int SYSTEM_INFO_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < An input/output error occurred when reading value from system
+  static const int SYSTEM_INFO_ERROR_IO_ERROR = -5;
+
+  /// < No permission to use the API
+  static const int SYSTEM_INFO_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Not supported parameter (Since 3.0)
+  static const int SYSTEM_INFO_ERROR_NOT_SUPPORTED = -1073741822;
+}
+
+/// @internal
+/// @brief It is not decided if it should be opened to public.
+abstract class system_info_type_e {
+  static const int SYSTEM_INFO_TYPE_MIN = 0;
+  static const int SYSTEM_INFO_BOOL = 0;
+  static const int SYSTEM_INFO_INT = 1;
+  static const int SYSTEM_INFO_DOUBLE = 2;
+  static const int SYSTEM_INFO_STRING = 3;
+  static const int SYSTEM_INFO_TYPE_MAX = 4;
+}
+
 /// @internal
 /// @brief Enumeration for system information key.
 abstract class system_info_key_e {
@@ -416,15 +448,4 @@ abstract class system_info_key_e {
 
   /// < @internal Indicates whether the device supports tethering
   static const int SYSTEM_INFO_KEY_TETHERING_SUPPORTED = 14;
-}
-
-/// @internal
-/// @brief It is not decided if it should be opened to public.
-abstract class system_info_type_e {
-  static const int SYSTEM_INFO_TYPE_MIN = 0;
-  static const int SYSTEM_INFO_BOOL = 0;
-  static const int SYSTEM_INFO_INT = 1;
-  static const int SYSTEM_INFO_DOUBLE = 2;
-  static const int SYSTEM_INFO_STRING = 3;
-  static const int SYSTEM_INFO_TYPE_MAX = 4;
 }

--- a/lib/src/bindings/8.0/generated_bindings_mv_barcode_detector.dart
+++ b/lib/src/bindings/8.0/generated_bindings_mv_barcode_detector.dart
@@ -81,6 +81,123 @@ class Tizen80MvBarcodeDetector {
           ffi.Pointer<ffi.Void>)>();
 }
 
+/// @brief Enumeration for supported barcode types.
+/// @details QR codes (versions 1 to 40) and set of 1D barcodes are supported
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+/// @remarks #MV_BARCODE_UNDEFINED is deprecated. Use #MV_BARCODE_UNKNOWN instead
+abstract class mv_barcode_type_e {
+  /// < 2D barcode - Quick Response code
+  static const int MV_BARCODE_QR = 0;
+
+  /// < 1D barcode - Universal Product Code with 12-digit
+  static const int MV_BARCODE_UPC_A = 1;
+
+  /// < 1D barcode - Universal Product Code with 6-digit
+  static const int MV_BARCODE_UPC_E = 2;
+
+  /// < 1D barcode - International Article Number with 8-digit
+  static const int MV_BARCODE_EAN_8 = 3;
+
+  /// < 1D barcode - International Article Number with 13-digit
+  static const int MV_BARCODE_EAN_13 = 4;
+
+  /// < 1D barcode - Code 128
+  static const int MV_BARCODE_CODE128 = 5;
+
+  /// < 1D barcode - Code 39
+  static const int MV_BARCODE_CODE39 = 6;
+
+  /// < 1D barcode - Interleaved Two of Five
+  static const int MV_BARCODE_I2_5 = 7;
+
+  /// < @deprecated Undefined (Deprecated since 6.0)
+  static const int MV_BARCODE_UNDEFINED = 8;
+
+  /// < 1D barcode - International Article Number with 2-digit(add-on) (since 6.0)
+  static const int MV_BARCODE_EAN_2 = 9;
+
+  /// < 1D barcode - International Article Number with 5-digit(add-on) (since 6.0)
+  static const int MV_BARCODE_EAN_5 = 10;
+
+  /// < 1D barcode - Code 93 (since 6.0)
+  static const int MV_BARCODE_CODE93 = 11;
+
+  /// < 1D barcode - CODABAR (since 6.0)
+  static const int MV_BARCODE_CODABAR = 12;
+
+  /// < 1D barcode - GS1 DATABAR (since 6.0)
+  static const int MV_BARCODE_DATABAR = 13;
+
+  /// < 1D barcode - GS1 DATABAR EXPAND(since 6.0)
+  static const int MV_BARCODE_DATABAR_EXPAND = 14;
+
+  /// < Unknown (since 6.0)
+  static const int MV_BARCODE_UNKNOWN = 100;
+}
+
+/// @brief Enumeration for supported QR code error correction level.
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+/// @remarks This is unavailable for 1D barcodes
+abstract class mv_barcode_qr_ecc_e {
+  /// < Recovery up to  7% losses
+  static const int MV_BARCODE_QR_ECC_LOW = 0;
+
+  /// < Recovery up to 15% losses
+  static const int MV_BARCODE_QR_ECC_MEDIUM = 1;
+
+  /// < Recovery up to 25% losses
+  static const int MV_BARCODE_QR_ECC_QUARTILE = 2;
+
+  /// < Recovery up to 30% losses
+  static const int MV_BARCODE_QR_ECC_HIGH = 3;
+
+  /// < Unavailable
+  static const int MV_BARCODE_QR_ECC_UNAVAILABLE = 4;
+}
+
+/// @brief Enumeration for supported QR code encoding mode.
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+/// @remarks This is unavailable for 1D barcodes
+abstract class mv_barcode_qr_mode_e {
+  /// < Numeric digits
+  static const int MV_BARCODE_QR_MODE_NUMERIC = 0;
+
+  /// < Alphanumeric characters
+  static const int MV_BARCODE_QR_MODE_ALPHANUMERIC = 1;
+
+  /// < Raw 8-bit bytes
+  static const int MV_BARCODE_QR_MODE_BYTE = 2;
+
+  /// < UTF-8 character encoding
+  static const int MV_BARCODE_QR_MODE_UTF8 = 3;
+
+  /// < Unavailable
+  static const int MV_BARCODE_QR_MODE_UNAVAILABLE = 4;
+}
+
+/// @brief Enumeration for supported image formats for the barcode generating.
+///
+/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
+abstract class mv_barcode_image_format_e {
+  /// < Unavailable image format
+  static const int MV_BARCODE_IMAGE_FORMAT_UNAVAILABLE = -1;
+
+  /// < BMP image format
+  static const int MV_BARCODE_IMAGE_FORMAT_BMP = 0;
+
+  /// < JPEG image format
+  static const int MV_BARCODE_IMAGE_FORMAT_JPG = 1;
+
+  /// < PNG image format
+  static const int MV_BARCODE_IMAGE_FORMAT_PNG = 2;
+
+  /// < The number of supported image format
+  static const int MV_BARCODE_IMAGE_FORMAT_NUM = 3;
+}
+
 /// @brief Enumeration to target attribute
 ///
 /// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
@@ -150,61 +267,6 @@ typedef Dartmv_barcode_detected_cbFunction = void Function(
     ffi.Pointer<ffi.Int32> types,
     int number_of_barcodes,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for supported barcode types.
-/// @details QR codes (versions 1 to 40) and set of 1D barcodes are supported
-///
-/// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
-/// @remarks #MV_BARCODE_UNDEFINED is deprecated. Use #MV_BARCODE_UNKNOWN instead
-abstract class mv_barcode_type_e {
-  /// < 2D barcode - Quick Response code
-  static const int MV_BARCODE_QR = 0;
-
-  /// < 1D barcode - Universal Product Code with 12-digit
-  static const int MV_BARCODE_UPC_A = 1;
-
-  /// < 1D barcode - Universal Product Code with 6-digit
-  static const int MV_BARCODE_UPC_E = 2;
-
-  /// < 1D barcode - International Article Number with 8-digit
-  static const int MV_BARCODE_EAN_8 = 3;
-
-  /// < 1D barcode - International Article Number with 13-digit
-  static const int MV_BARCODE_EAN_13 = 4;
-
-  /// < 1D barcode - Code 128
-  static const int MV_BARCODE_CODE128 = 5;
-
-  /// < 1D barcode - Code 39
-  static const int MV_BARCODE_CODE39 = 6;
-
-  /// < 1D barcode - Interleaved Two of Five
-  static const int MV_BARCODE_I2_5 = 7;
-
-  /// < @deprecated Undefined (Deprecated since 6.0)
-  static const int MV_BARCODE_UNDEFINED = 8;
-
-  /// < 1D barcode - International Article Number with 2-digit(add-on) (since 6.0)
-  static const int MV_BARCODE_EAN_2 = 9;
-
-  /// < 1D barcode - International Article Number with 5-digit(add-on) (since 6.0)
-  static const int MV_BARCODE_EAN_5 = 10;
-
-  /// < 1D barcode - Code 93 (since 6.0)
-  static const int MV_BARCODE_CODE93 = 11;
-
-  /// < 1D barcode - CODABAR (since 6.0)
-  static const int MV_BARCODE_CODABAR = 12;
-
-  /// < 1D barcode - GS1 DATABAR (since 6.0)
-  static const int MV_BARCODE_DATABAR = 13;
-
-  /// < 1D barcode - GS1 DATABAR EXPAND(since 6.0)
-  static const int MV_BARCODE_DATABAR_EXPAND = 14;
-
-  /// < Unknown (since 6.0)
-  static const int MV_BARCODE_UNKNOWN = 100;
-}
 
 const String MV_BARCODE_DETECT_ATTR_TARGET = 'MV_BARCODE_DETECT_ATTR_TARGET';
 

--- a/lib/src/bindings/8.0/generated_bindings_mv_barcode_generator.dart
+++ b/lib/src/bindings/8.0/generated_bindings_mv_barcode_generator.dart
@@ -277,7 +277,7 @@ abstract class _mv_barcode_type_e {
 ///
 /// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
 /// @remarks This is unavailable for 1D barcodes
-abstract class mv_barcode_qr_mode_e {
+abstract class _mv_barcode_qr_mode_e {
   /// < Numeric digits
   static const int MV_BARCODE_QR_MODE_NUMERIC = 0;
 
@@ -298,7 +298,7 @@ abstract class mv_barcode_qr_mode_e {
 ///
 /// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
 /// @remarks This is unavailable for 1D barcodes
-abstract class mv_barcode_qr_ecc_e {
+abstract class _mv_barcode_qr_ecc_e {
   /// < Recovery up to  7% losses
   static const int MV_BARCODE_QR_ECC_LOW = 0;
 
@@ -318,7 +318,7 @@ abstract class mv_barcode_qr_ecc_e {
 /// @brief Enumeration for supported image formats for the barcode generating.
 ///
 /// @since_tizen @if MOBILE 2.4 @else 3.0 @endif
-abstract class mv_barcode_image_format_e {
+abstract class _mv_barcode_image_format_e {
   /// < Unavailable image format
   static const int MV_BARCODE_IMAGE_FORMAT_UNAVAILABLE = -1;
 

--- a/lib/src/bindings/8.0/generated_bindings_mv_face.dart
+++ b/lib/src/bindings/8.0/generated_bindings_mv_face.dart
@@ -1100,6 +1100,53 @@ class Tizen80MvFace {
               ffi.Pointer<ffi.Char>, ffi.Pointer<mv_face_tracking_model_h>)>();
 }
 
+/// @brief Enumeration for eyes state type.
+///
+/// @since_tizen 3.0
+///
+/// @see mv_face_eye_condition_recognize()
+abstract class mv_face_eye_condition_e {
+  /// < Eyes are open
+  static const int MV_FACE_EYES_OPEN = 0;
+
+  /// < Eyes are closed
+  static const int MV_FACE_EYES_CLOSED = 1;
+
+  /// < The eyes condition wasn't determined
+  static const int MV_FACE_EYES_NOT_FOUND = 2;
+}
+
+/// @brief Enumeration for expression types can be determined for faces.
+///
+/// @since_tizen 3.0
+///
+/// @see mv_face_facial_expression_recognize()
+abstract class mv_face_facial_expression_e {
+  /// < Unknown face expression
+  static const int MV_FACE_UNKNOWN = 0;
+
+  /// < Face expression is neutral
+  static const int MV_FACE_NEUTRAL = 1;
+
+  /// < Face expression is smiling
+  static const int MV_FACE_SMILE = 2;
+
+  /// < Face expression is sadness
+  static const int MV_FACE_SADNESS = 3;
+
+  /// < Face expression is surprise
+  static const int MV_FACE_SURPRISE = 4;
+
+  /// < Face expression is anger
+  static const int MV_FACE_ANGER = 5;
+
+  /// < Face expression is fear
+  static const int MV_FACE_FEAR = 6;
+
+  /// < Face expression is disgust
+  static const int MV_FACE_DISGUST = 7;
+}
+
 /// @brief Called when faces are detected for the @a source.
 /// @details This type callback can be invoked each time when
 /// mv_face_detect() is called to process the results of face
@@ -1311,22 +1358,6 @@ typedef Dartmv_face_eye_condition_recognized_cbFunction = void Function(
     int eye_condition,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for eyes state type.
-///
-/// @since_tizen 3.0
-///
-/// @see mv_face_eye_condition_recognize()
-abstract class mv_face_eye_condition_e {
-  /// < Eyes are open
-  static const int MV_FACE_EYES_OPEN = 0;
-
-  /// < Eyes are closed
-  static const int MV_FACE_EYES_CLOSED = 1;
-
-  /// < The eyes condition wasn't determined
-  static const int MV_FACE_EYES_NOT_FOUND = 2;
-}
-
 /// @brief Called when facial expression is recognized.
 /// @details This type callback can be invoked each time when
 /// mv_face_facial_expression_recognize() is called for @a face_location to
@@ -1362,37 +1393,6 @@ typedef Dartmv_face_facial_expression_recognized_cbFunction = void Function(
     mv_common.mv_rectangle_s face_location,
     int facial_expression,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for expression types can be determined for faces.
-///
-/// @since_tizen 3.0
-///
-/// @see mv_face_facial_expression_recognize()
-abstract class mv_face_facial_expression_e {
-  /// < Unknown face expression
-  static const int MV_FACE_UNKNOWN = 0;
-
-  /// < Face expression is neutral
-  static const int MV_FACE_NEUTRAL = 1;
-
-  /// < Face expression is smiling
-  static const int MV_FACE_SMILE = 2;
-
-  /// < Face expression is sadness
-  static const int MV_FACE_SADNESS = 3;
-
-  /// < Face expression is surprise
-  static const int MV_FACE_SURPRISE = 4;
-
-  /// < Face expression is anger
-  static const int MV_FACE_ANGER = 5;
-
-  /// < Face expression is fear
-  static const int MV_FACE_FEAR = 6;
-
-  /// < Face expression is disgust
-  static const int MV_FACE_DISGUST = 7;
-}
 
 const String MV_FACE_DETECTION_MODEL_FILE_PATH =
     'MV_FACE_DETECTION_MODEL_FILE_PATH';

--- a/lib/src/bindings/8.0/generated_bindings_mv_inference.dart
+++ b/lib/src/bindings/8.0/generated_bindings_mv_inference.dart
@@ -821,6 +821,164 @@ class Tizen80MvInference {
           ffi.Pointer<ffi.Float>)>();
 }
 
+/// @brief Enumeration for inference backend.
+/// #MV_INFERENCE_BACKEND_OPENCV An open source computer vision and machine learning
+/// software library.
+/// (https://opencv.org/about/)
+/// #MV_INFERENCE_BACKEND_TFLITE Google-introduced open source inference engine for embedded systems,
+/// which runs Tensorflow Lite model.
+/// (https://www.tensorflow.org/lite/guide/get_started)
+/// #MV_INFERENCE_BACKEND_ARMNN ARM-introduced open source inference engine for CPUs, GPUs and NPUs, which
+/// enables efficient translation of existing neural network frameworks
+/// such as TensorFlow, TensorFlow Lite and Caffes, allowing them to
+/// run efficiently without modification on Embedded hardware.
+/// (https://developer.arm.com/ip-products/processors/machine-learning/arm-nn)
+/// #MV_INFERENCE_BACKEND_MLAPI Samsung-introduced open source ML single API framework of NNStreamer, which
+/// runs various NN models via tensor filters of NNStreamer. (Deprecated since 7.0)
+/// (https://github.com/nnstreamer/nnstreamer)
+/// #MV_INFERENCE_BACKEND_ONE Samsung-introduced open source inference engine called On-device Neural Engine, which
+/// performs inference of a given NN model on various devices such as CPU, GPU, DSP and NPU.
+/// (https://github.com/Samsung/ONE)
+///
+/// @since_tizen 5.5
+///
+/// @see mv_inference_prepare()
+abstract class mv_inference_backend_type_e {
+  /// < None
+  static const int MV_INFERENCE_BACKEND_NONE = -1;
+
+  /// < OpenCV
+  static const int MV_INFERENCE_BACKEND_OPENCV = 0;
+
+  /// < TensorFlow-Lite
+  static const int MV_INFERENCE_BACKEND_TFLITE = 1;
+
+  /// < @deprecated ARMNN (Since 6.0) (Deprecated since 8.0)
+  static const int MV_INFERENCE_BACKEND_ARMNN = 2;
+
+  /// < @deprecated ML Single API of NNStreamer (Deprecated since 7.0)
+  static const int MV_INFERENCE_BACKEND_MLAPI = 3;
+
+  /// < On-device Neural Engine (Since 6.0)
+  static const int MV_INFERENCE_BACKEND_ONE = 4;
+
+  /// < NNTrainer (Since 7.0)
+  static const int MV_INFERENCE_BACKEND_NNTRAINER = 5;
+
+  /// < SNPE Engine (Since 7.0)
+  static const int MV_INFERENCE_BACKEND_SNPE = 6;
+
+  /// < @deprecated Backend MAX (Deprecated since 7.0)
+  static const int MV_INFERENCE_BACKEND_MAX = 7;
+}
+
+/// @brief Enumeration for inference target.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_target_device_e {
+  /// < None
+  static const int MV_INFERENCE_TARGET_DEVICE_NONE = 0;
+
+  /// < CPU
+  static const int MV_INFERENCE_TARGET_DEVICE_CPU = 1;
+
+  /// < GPU
+  static const int MV_INFERENCE_TARGET_DEVICE_GPU = 2;
+
+  /// < CUSTOM
+  static const int MV_INFERENCE_TARGET_DEVICE_CUSTOM = 4;
+
+  /// < Target MAX
+  static const int MV_INFERENCE_TARGET_DEVICE_MAX = 8;
+}
+
+/// @brief Enumeration for input data type.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_data_type_e {
+  /// < Data type of a given pre-trained model is float.
+  static const int MV_INFERENCE_DATA_FLOAT32 = 0;
+
+  /// < Data type of a given pre-trained model is unsigned char.
+  static const int MV_INFERENCE_DATA_UINT8 = 1;
+}
+
+/// @brief Enumeration for human pose landmark.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_human_pose_landmark_e {
+  /// < Head of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_HEAD = 1;
+
+  /// < Neck of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_NECK = 2;
+
+  /// < Thorax of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_THORAX = 3;
+
+  /// < Right shoulder of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_SHOULDER = 4;
+
+  /// < Right elbow of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_ELBOW = 5;
+
+  /// < Right wrist of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_WRIST = 6;
+
+  /// < Left shoulder of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_SHOULDER = 7;
+
+  /// < Left elbow of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_ELBOW = 8;
+
+  /// < Left wrist of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_WRIST = 9;
+
+  /// < Pelvis of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_PELVIS = 10;
+
+  /// < Right hip of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_HIP = 11;
+
+  /// < Right knee of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_KNEE = 12;
+
+  /// < Right ankle of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_ANKLE = 13;
+
+  /// < Left hip of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_HIP = 14;
+
+  /// < Left knee of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_KNEE = 15;
+
+  /// < Left ankle of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_ANKLE = 16;
+}
+
+/// @brief Enumeration for human body parts.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_human_body_part_e {
+  /// < HEAD, NECK, and THORAX
+  static const int MV_INFERENCE_HUMAN_BODY_PART_HEAD = 1;
+
+  /// < RIGHT SHOULDER, ELBOW, and WRIST
+  static const int MV_INFERENCE_HUMAN_BODY_PART_ARM_RIGHT = 2;
+
+  /// < LEFT SHOULDER, ELBOW, and WRIST
+  static const int MV_INFERENCE_HUMAN_BODY_PART_ARM_LEFT = 4;
+
+  /// < THORAX, PELVIS, RIGHT HIP, and LEFT HIP
+  static const int MV_INFERENCE_HUMAN_BODY_PART_BODY = 8;
+
+  /// < RIGHT HIP, KNEE, and ANKLE
+  static const int MV_INFERENCE_HUMAN_BODY_PART_LEG_RIGHT = 16;
+
+  /// < LEFT HIP, KNEE, and ANKLE
+  static const int MV_INFERENCE_HUMAN_BODY_PART_LEG_LEFT = 32;
+}
+
 /// @brief The inference handle.
 /// @details Contains information about location of
 /// detected landmarks for one or more poses.

--- a/lib/src/bindings/8.0/generated_bindings_tbm.dart
+++ b/lib/src/bindings/8.0/generated_bindings_tbm.dart
@@ -449,6 +449,8 @@ class Tizen80Tbm {
       _tbm_surface_get_formatPtr.asFunction<int Function(tbm_surface_h)>();
 }
 
+final class _tbm_surface extends ffi.Opaque {}
+
 /// @brief Enumeration for tbm_surface error type.
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
 abstract class tbm_surface_error_e {
@@ -544,11 +546,127 @@ typedef tbm_surface_plane_s = _tbm_surface_plane;
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
 typedef tbm_surface_h = ffi.Pointer<_tbm_surface>;
 
-final class _tbm_surface extends ffi.Opaque {}
-
 /// @brief Definition for the TBM surface information struct.
 /// @since_tizen @if MOBILE 2.3 @elseif WEARABLE 2.3.1 @endif
 typedef tbm_surface_info_s = _tbm_surface_info;
+
+const int TBM_FORMAT_C8 = 538982467;
+
+const int TBM_FORMAT_RGB332 = 943867730;
+
+const int TBM_FORMAT_BGR233 = 944916290;
+
+const int TBM_FORMAT_XRGB4444 = 842093144;
+
+const int TBM_FORMAT_XBGR4444 = 842089048;
+
+const int TBM_FORMAT_RGBX4444 = 842094674;
+
+const int TBM_FORMAT_BGRX4444 = 842094658;
+
+const int TBM_FORMAT_ARGB4444 = 842093121;
+
+const int TBM_FORMAT_ABGR4444 = 842089025;
+
+const int TBM_FORMAT_RGBA4444 = 842088786;
+
+const int TBM_FORMAT_BGRA4444 = 842088770;
+
+const int TBM_FORMAT_XRGB1555 = 892424792;
+
+const int TBM_FORMAT_XBGR1555 = 892420696;
+
+const int TBM_FORMAT_RGBX5551 = 892426322;
+
+const int TBM_FORMAT_BGRX5551 = 892426306;
+
+const int TBM_FORMAT_ARGB1555 = 892424769;
+
+const int TBM_FORMAT_ABGR1555 = 892420673;
+
+const int TBM_FORMAT_RGBA5551 = 892420434;
+
+const int TBM_FORMAT_BGRA5551 = 892420418;
+
+const int TBM_FORMAT_RGB565 = 909199186;
+
+const int TBM_FORMAT_BGR565 = 909199170;
+
+const int TBM_FORMAT_RGB888 = 875710290;
+
+const int TBM_FORMAT_BGR888 = 875710274;
+
+const int TBM_FORMAT_XRGB8888 = 875713112;
+
+const int TBM_FORMAT_XBGR8888 = 875709016;
+
+const int TBM_FORMAT_RGBX8888 = 875714642;
+
+const int TBM_FORMAT_BGRX8888 = 875714626;
+
+const int TBM_FORMAT_ARGB8888 = 875713089;
+
+const int TBM_FORMAT_ABGR8888 = 875708993;
+
+const int TBM_FORMAT_RGBA8888 = 875708754;
+
+const int TBM_FORMAT_BGRA8888 = 875708738;
+
+const int TBM_FORMAT_XRGB2101010 = 808669784;
+
+const int TBM_FORMAT_XBGR2101010 = 808665688;
+
+const int TBM_FORMAT_RGBX1010102 = 808671314;
+
+const int TBM_FORMAT_BGRX1010102 = 808671298;
+
+const int TBM_FORMAT_ARGB2101010 = 808669761;
+
+const int TBM_FORMAT_ABGR2101010 = 808665665;
+
+const int TBM_FORMAT_RGBA1010102 = 808665426;
+
+const int TBM_FORMAT_BGRA1010102 = 808665410;
+
+const int TBM_FORMAT_YUYV = 1448695129;
+
+const int TBM_FORMAT_YVYU = 1431918169;
+
+const int TBM_FORMAT_UYVY = 1498831189;
+
+const int TBM_FORMAT_VYUY = 1498765654;
+
+const int TBM_FORMAT_AYUV = 1448433985;
+
+const int TBM_FORMAT_NV12 = 842094158;
+
+const int TBM_FORMAT_NV21 = 825382478;
+
+const int TBM_FORMAT_NV16 = 909203022;
+
+const int TBM_FORMAT_NV61 = 825644622;
+
+const int TBM_FORMAT_YUV410 = 961959257;
+
+const int TBM_FORMAT_YVU410 = 961893977;
+
+const int TBM_FORMAT_YUV411 = 825316697;
+
+const int TBM_FORMAT_YVU411 = 825316953;
+
+const int TBM_FORMAT_YUV420 = 842093913;
+
+const int TBM_FORMAT_YVU420 = 842094169;
+
+const int TBM_FORMAT_YUV422 = 909202777;
+
+const int TBM_FORMAT_YVU422 = 909203033;
+
+const int TBM_FORMAT_YUV444 = 875713881;
+
+const int TBM_FORMAT_YVU444 = 875714137;
+
+const int TBM_FORMAT_NV12MT = 842091860;
 
 const int TBM_SURF_PLANE_MAX = 4;
 

--- a/lib/src/bindings/9.0/generated_bindings_capi_base_common.dart
+++ b/lib/src/bindings/9.0/generated_bindings_capi_base_common.dart
@@ -386,6 +386,8 @@ abstract class tizen_error_e {
   static const int TIZEN_ERROR_END_OF_COLLECTION = -1073741819;
 }
 
+const int NULL = 0;
+
 const int TIZEN_ERROR_MAX_PLATFORM_ERROR = 0;
 
 const int TIZEN_ERROR_MIN_PLATFORM_ERROR = -1073741824;

--- a/lib/src/bindings/9.0/generated_bindings_capi_geofence_manager.dart
+++ b/lib/src/bindings/9.0/generated_bindings_capi_geofence_manager.dart
@@ -1260,76 +1260,6 @@ class Tizen90CapiGeofenceManager {
 }
 
 /// @deprecated Deprecated since 8.0.
-/// @brief The geofence manager handle.
-/// @since_tizen 2.4
-typedef geofence_manager_h = ffi.Pointer<geofence_manager_s>;
-
-final class geofence_manager_s extends ffi.Opaque {}
-
-/// @deprecated Deprecated since 8.0.
-/// @brief The geofence handle.
-/// @since_tizen 2.4
-typedef geofence_h = ffi.Pointer<geofence_s>;
-
-final class geofence_s extends ffi.Opaque {}
-
-/// @deprecated Deprecated since 8.0.
-/// @brief Called when a device enters or exits the given geofence.
-/// @since_tizen 2.4
-/// @param[in] geofence_id The specified geofence ID
-/// @param[in] state The geofence state
-/// @param[in] user_data The user data passed from callback registration function
-/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_state_changed_cb().
-/// @see geofence_state_e
-/// @see geofence_manager_start()
-/// @see geofence_manager_set_geofence_state_changed_cb()
-typedef geofence_state_changed_cb
-    = ffi.Pointer<ffi.NativeFunction<geofence_state_changed_cbFunction>>;
-typedef geofence_state_changed_cbFunction = ffi.Void Function(
-    ffi.Int geofence_id, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
-typedef Dartgeofence_state_changed_cbFunction = void Function(
-    int geofence_id, int state, ffi.Pointer<ffi.Void> user_data);
-
-/// @deprecated Deprecated since 8.0.
-/// @brief Enumeration for the state of geofence manager.
-/// @since_tizen 2.4
-abstract class geofence_state_e {
-  /// < Uncertain state of geofence
-  static const int GEOFENCE_STATE_UNCERTAIN = 0;
-
-  /// < Geofence In state
-  static const int GEOFENCE_STATE_IN = 1;
-
-  /// < Geofence Out state
-  static const int GEOFENCE_STATE_OUT = 2;
-}
-
-/// @deprecated Deprecated since 8.0.
-/// @brief Called when the some event occurs in geofence and place such as add, update, etc..
-/// @details The events of public geofence is also received if there are public geofences.
-/// @since_tizen 2.4
-/// @remarks The value of place_id or geofence_id is -1 when the place ID or geofence ID is not assigned.
-/// @param[in] place_id The place ID
-/// @param[in] geofence_id The specified geofence ID
-/// @param[in] error The error code for the particular action
-/// @param[in] manage The result code for the particular place and geofence management
-/// @param[in] user_data The user data passed from callback registration function
-/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_event_cb()
-/// @see geofence_manage_e
-/// @see geofence_manager_start()
-/// @see geofence_manager_set_geofence_event_cb()
-typedef geofence_event_cb
-    = ffi.Pointer<ffi.NativeFunction<geofence_event_cbFunction>>;
-typedef geofence_event_cbFunction = ffi.Void Function(
-    ffi.Int place_id,
-    ffi.Int geofence_id,
-    ffi.Int32 error,
-    ffi.Int32 manage,
-    ffi.Pointer<ffi.Void> user_data);
-typedef Dartgeofence_event_cbFunction = void Function(int place_id,
-    int geofence_id, int error, int manage, ffi.Pointer<ffi.Void> user_data);
-
-/// @deprecated Deprecated since 8.0.
 /// @brief Enumeration for Geofence manager of error code.
 /// @since_tizen 2.4
 abstract class geofence_manager_error_e {
@@ -1377,58 +1307,18 @@ abstract class geofence_manager_error_e {
 }
 
 /// @deprecated Deprecated since 8.0.
-/// @brief Enumeration for geofence management events.
+/// @brief Enumeration for the state of geofence manager.
 /// @since_tizen 2.4
-abstract class geofence_manage_e {
-  /// < Geofence is added
-  static const int GEOFENCE_MANAGE_FENCE_ADDED = 0;
+abstract class geofence_state_e {
+  /// < Uncertain state of geofence
+  static const int GEOFENCE_STATE_UNCERTAIN = 0;
 
-  /// < Geofence is removed
-  static const int GEOFENCE_MANAGE_FENCE_REMOVED = 1;
+  /// < Geofence In state
+  static const int GEOFENCE_STATE_IN = 1;
 
-  /// < Geofencing is started
-  static const int GEOFENCE_MANAGE_FENCE_STARTED = 2;
-
-  /// < Geofencing is stopped
-  static const int GEOFENCE_MANAGE_FENCE_STOPPED = 3;
-
-  /// < Place is added
-  static const int GEOFENCE_MANAGE_PLACE_ADDED = 16;
-
-  /// < Place is removed
-  static const int GEOFENCE_MANAGE_PLACE_REMOVED = 17;
-
-  /// < Place is updated
-  static const int GEOFENCE_MANAGE_PLACE_UPDATED = 18;
-
-  /// < Setting for geofencing is enabled
-  static const int GEOFENCE_MANAGE_SETTING_ENABLED = 32;
-
-  /// < Setting for geofencing is disabled
-  static const int GEOFENCE_MANAGE_SETTING_DISABLED = 33;
+  /// < Geofence Out state
+  static const int GEOFENCE_STATE_OUT = 2;
 }
-
-/// @deprecated Deprecated since 8.0.
-/// @brief Called when a proximity state of device is changed.
-/// @since_tizen 3.0
-/// @param[in] geofence_id The specified geofence ID
-/// @param[in] state The proximity state
-/// @param[in] provider The proximity provider
-/// @param[in] user_data The user data passed from callback registration function
-/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_proximity_state_changed_cb().
-/// @see geofence_proximity_state_e
-/// @see geofence_proximity_provider_e
-/// @see geofence_manager_start()
-/// @see geofence_manager_set_geofence_proximity_state_changed_cb()
-typedef geofence_proximity_state_changed_cb = ffi
-    .Pointer<ffi.NativeFunction<geofence_proximity_state_changed_cbFunction>>;
-typedef geofence_proximity_state_changed_cbFunction = ffi.Void Function(
-    ffi.Int geofence_id,
-    ffi.Int32 state,
-    ffi.Int32 provider,
-    ffi.Pointer<ffi.Void> user_data);
-typedef Dartgeofence_proximity_state_changed_cbFunction = void Function(
-    int geofence_id, int state, int provider, ffi.Pointer<ffi.Void> user_data);
 
 /// @deprecated Deprecated since 8.0.
 /// @brief Enumeration for the state of proximity.
@@ -1466,6 +1356,132 @@ abstract class geofence_proximity_provider_e {
   /// < Proximity is specified by Sensor
   static const int GEOFENCE_PROXIMITY_PROVIDER_SENSOR = 4;
 }
+
+/// @deprecated Deprecated since 8.0.
+/// @brief Enumeration for geofence type.
+/// @since_tizen 2.4
+abstract class geofence_type_e {
+  /// < Geofence is specified by geospatial coordinate
+  static const int GEOFENCE_TYPE_GEOPOINT = 1;
+
+  /// < Geofence is specified by Wi-Fi access point
+  static const int GEOFENCE_TYPE_WIFI = 2;
+
+  /// < Geofence is specified by Bluetooth device
+  static const int GEOFENCE_TYPE_BT = 3;
+}
+
+/// @deprecated Deprecated since 8.0.
+/// @brief Enumeration for geofence management events.
+/// @since_tizen 2.4
+abstract class geofence_manage_e {
+  /// < Geofence is added
+  static const int GEOFENCE_MANAGE_FENCE_ADDED = 0;
+
+  /// < Geofence is removed
+  static const int GEOFENCE_MANAGE_FENCE_REMOVED = 1;
+
+  /// < Geofencing is started
+  static const int GEOFENCE_MANAGE_FENCE_STARTED = 2;
+
+  /// < Geofencing is stopped
+  static const int GEOFENCE_MANAGE_FENCE_STOPPED = 3;
+
+  /// < Place is added
+  static const int GEOFENCE_MANAGE_PLACE_ADDED = 16;
+
+  /// < Place is removed
+  static const int GEOFENCE_MANAGE_PLACE_REMOVED = 17;
+
+  /// < Place is updated
+  static const int GEOFENCE_MANAGE_PLACE_UPDATED = 18;
+
+  /// < Setting for geofencing is enabled
+  static const int GEOFENCE_MANAGE_SETTING_ENABLED = 32;
+
+  /// < Setting for geofencing is disabled
+  static const int GEOFENCE_MANAGE_SETTING_DISABLED = 33;
+}
+
+final class geofence_manager_s extends ffi.Opaque {}
+
+final class geofence_s extends ffi.Opaque {}
+
+final class geofence_status_s extends ffi.Opaque {}
+
+/// @deprecated Deprecated since 8.0.
+/// @brief The geofence manager handle.
+/// @since_tizen 2.4
+typedef geofence_manager_h = ffi.Pointer<geofence_manager_s>;
+
+/// @deprecated Deprecated since 8.0.
+/// @brief The geofence handle.
+/// @since_tizen 2.4
+typedef geofence_h = ffi.Pointer<geofence_s>;
+
+/// @deprecated Deprecated since 8.0.
+/// @brief Called when a device enters or exits the given geofence.
+/// @since_tizen 2.4
+/// @param[in] geofence_id The specified geofence ID
+/// @param[in] state The geofence state
+/// @param[in] user_data The user data passed from callback registration function
+/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_state_changed_cb().
+/// @see geofence_state_e
+/// @see geofence_manager_start()
+/// @see geofence_manager_set_geofence_state_changed_cb()
+typedef geofence_state_changed_cb
+    = ffi.Pointer<ffi.NativeFunction<geofence_state_changed_cbFunction>>;
+typedef geofence_state_changed_cbFunction = ffi.Void Function(
+    ffi.Int geofence_id, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
+typedef Dartgeofence_state_changed_cbFunction = void Function(
+    int geofence_id, int state, ffi.Pointer<ffi.Void> user_data);
+
+/// @deprecated Deprecated since 8.0.
+/// @brief Called when the some event occurs in geofence and place such as add, update, etc..
+/// @details The events of public geofence is also received if there are public geofences.
+/// @since_tizen 2.4
+/// @remarks The value of place_id or geofence_id is -1 when the place ID or geofence ID is not assigned.
+/// @param[in] place_id The place ID
+/// @param[in] geofence_id The specified geofence ID
+/// @param[in] error The error code for the particular action
+/// @param[in] manage The result code for the particular place and geofence management
+/// @param[in] user_data The user data passed from callback registration function
+/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_event_cb()
+/// @see geofence_manage_e
+/// @see geofence_manager_start()
+/// @see geofence_manager_set_geofence_event_cb()
+typedef geofence_event_cb
+    = ffi.Pointer<ffi.NativeFunction<geofence_event_cbFunction>>;
+typedef geofence_event_cbFunction = ffi.Void Function(
+    ffi.Int place_id,
+    ffi.Int geofence_id,
+    ffi.Int32 error,
+    ffi.Int32 manage,
+    ffi.Pointer<ffi.Void> user_data);
+typedef Dartgeofence_event_cbFunction = void Function(int place_id,
+    int geofence_id, int error, int manage, ffi.Pointer<ffi.Void> user_data);
+
+/// @deprecated Deprecated since 8.0.
+/// @brief Called when a proximity state of device is changed.
+/// @since_tizen 3.0
+/// @param[in] geofence_id The specified geofence ID
+/// @param[in] state The proximity state
+/// @param[in] provider The proximity provider
+/// @param[in] user_data The user data passed from callback registration function
+/// @pre geofence_manager_start() will invoke this callback if you register this callback using geofence_manager_set_geofence_proximity_state_changed_cb().
+/// @see geofence_proximity_state_e
+/// @see geofence_proximity_provider_e
+/// @see geofence_manager_start()
+/// @see geofence_manager_set_geofence_proximity_state_changed_cb()
+typedef geofence_proximity_state_changed_cb = ffi
+    .Pointer<ffi.NativeFunction<geofence_proximity_state_changed_cbFunction>>;
+typedef geofence_proximity_state_changed_cbFunction = ffi.Void Function(
+    ffi.Int geofence_id,
+    ffi.Int32 state,
+    ffi.Int32 provider,
+    ffi.Pointer<ffi.Void> user_data);
+typedef Dartgeofence_proximity_state_changed_cbFunction = void Function(
+    int geofence_id, int state, int provider, ffi.Pointer<ffi.Void> user_data);
 
 /// @deprecated Deprecated since 8.0.
 /// @brief Called when the fence list is requested.
@@ -1525,22 +1541,6 @@ typedef Dartgeofence_manager_place_cbFunction = bool Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @deprecated Deprecated since 8.0.
-/// @brief Enumeration for geofence type.
-/// @since_tizen 2.4
-abstract class geofence_type_e {
-  /// < Geofence is specified by geospatial coordinate
-  static const int GEOFENCE_TYPE_GEOPOINT = 1;
-
-  /// < Geofence is specified by Wi-Fi access point
-  static const int GEOFENCE_TYPE_WIFI = 2;
-
-  /// < Geofence is specified by Bluetooth device
-  static const int GEOFENCE_TYPE_BT = 3;
-}
-
-/// @deprecated Deprecated since 8.0.
 /// @brief The geofence status handle.
 /// @since_tizen 2.4
 typedef geofence_status_h = ffi.Pointer<geofence_status_s>;
-
-final class geofence_status_s extends ffi.Opaque {}

--- a/lib/src/bindings/9.0/generated_bindings_capi_media_controller.dart
+++ b/lib/src/bindings/9.0/generated_bindings_capi_media_controller.dart
@@ -6452,6 +6452,535 @@ class Tizen90CapiMediaController {
       .asFunction<int Function(mc_server_h, ffi.Pointer<ffi.Char>)>();
 }
 
+/// @brief Enumeration for the media controller error.
+/// @since_tizen 2.4
+abstract class mc_error_e {
+  /// < Successful
+  static const int MEDIA_CONTROLLER_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int MEDIA_CONTROLLER_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int MEDIA_CONTROLLER_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Invalid Operation
+  static const int MEDIA_CONTROLLER_ERROR_INVALID_OPERATION = -38;
+
+  /// < No space left on device
+  static const int MEDIA_CONTROLLER_ERROR_FILE_NO_SPACE_ON_DEVICE = -28;
+
+  /// < Permission denied
+  static const int MEDIA_CONTROLLER_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Limited by server application (since 5.5)
+  static const int MEDIA_CONTROLLER_ERROR_ABILITY_LIMITED_BY_SERVER_APP =
+      -50462719;
+}
+
+/// @brief Enumeration for the media controller server state.
+/// @since_tizen 2.4
+///
+/// @see mc_client_get_latest_server_info()
+/// @see mc_server_state_updated_cb()
+abstract class mc_server_state_e {
+  /// < None state
+  static const int MC_SERVER_STATE_NONE = 0;
+
+  /// < Activate state
+  static const int MC_SERVER_STATE_ACTIVATE = 1;
+
+  /// < Deactivate state
+  static const int MC_SERVER_STATE_DEACTIVATE = 2;
+}
+
+/// @brief Enumeration for the media meta info.
+/// @since_tizen 2.4
+///
+/// @see mc_server_set_metadata()
+/// @see mc_server_add_item_to_playlist()
+/// @see mc_metadata_get()
+abstract class mc_meta_e {
+  /// < Title
+  static const int MC_META_MEDIA_TITLE = 0;
+
+  /// < Artist
+  static const int MC_META_MEDIA_ARTIST = 1;
+
+  /// < Album
+  static const int MC_META_MEDIA_ALBUM = 2;
+
+  /// < Author
+  static const int MC_META_MEDIA_AUTHOR = 3;
+
+  /// < Genre
+  static const int MC_META_MEDIA_GENRE = 4;
+
+  /// < Duration
+  static const int MC_META_MEDIA_DURATION = 5;
+
+  /// < Date
+  static const int MC_META_MEDIA_DATE = 6;
+
+  /// < Copyright
+  static const int MC_META_MEDIA_COPYRIGHT = 7;
+
+  /// < Description
+  static const int MC_META_MEDIA_DESCRIPTION = 8;
+
+  /// < Track Number
+  static const int MC_META_MEDIA_TRACK_NUM = 9;
+
+  /// < Picture. Album Art
+  static const int MC_META_MEDIA_PICTURE = 10;
+
+  /// < Season (Since 5.5)
+  static const int MC_META_MEDIA_SEASON = 11;
+
+  /// < Episode (Since 5.5)
+  static const int MC_META_MEDIA_EPISODE = 12;
+
+  /// < Content resolution (Since 5.5)
+  static const int MC_META_MEDIA_RESOLUTION = 13;
+}
+
+/// @brief Enumeration for the media playback state of the media controller server.
+/// @since_tizen 2.4
+///
+/// @see mc_server_set_playback_state()
+/// @see mc_client_get_playback_state()
+abstract class mc_playback_states_e {
+  /// < None
+  static const int MC_PLAYBACK_STATE_NONE = 0;
+
+  /// < Playing
+  static const int MC_PLAYBACK_STATE_PLAYING = 1;
+
+  /// < Paused
+  static const int MC_PLAYBACK_STATE_PAUSED = 2;
+
+  /// < Stopped
+  static const int MC_PLAYBACK_STATE_STOPPED = 3;
+
+  /// < Moving to the next item (Since 4.0)
+  static const int MC_PLAYBACK_STATE_MOVING_TO_NEXT = 8;
+
+  /// < Moving to the previous item (Since 4.0)
+  static const int MC_PLAYBACK_STATE_MOVING_TO_PREVIOUS = 9;
+
+  /// < Fast forwarding (Since 4.0)
+  static const int MC_PLAYBACK_STATE_FAST_FORWARDING = 10;
+
+  /// < Rewinding (Since 4.0)
+  static const int MC_PLAYBACK_STATE_REWINDING = 11;
+
+  /// < Connecting (Since 6.0)
+  static const int MC_PLAYBACK_STATE_CONNECTING = 12;
+
+  /// < Buffering (Since 6.0)
+  static const int MC_PLAYBACK_STATE_BUFFERING = 13;
+
+  /// < Error (Since 6.0)
+  static const int MC_PLAYBACK_STATE_ERROR = 14;
+}
+
+/// @brief Enumeration for the media playback action.
+/// @details Media controller clients can control media controller server's playback by calling mc_client_send_playback_action_cmd() or mc_client_send_playlist_cmd(). \n
+/// Media controller servers have to set proper playback ability by using mc_server_set_playback_ability().
+/// @since_tizen 4.0
+///
+/// @see mc_server_set_playback_ability()
+/// @see mc_client_send_playback_action_cmd()
+/// @see mc_client_send_playlist_cmd()
+/// @see mc_playback_action_is_supported()
+/// @see mc_server_playback_action_cmd_received_cb()
+/// @see mc_server_playlist_cmd_received_cb()
+abstract class mc_playback_action_e {
+  /// < Play
+  static const int MC_PLAYBACK_ACTION_PLAY = 0;
+
+  /// < Pause
+  static const int MC_PLAYBACK_ACTION_PAUSE = 1;
+
+  /// < Stop
+  static const int MC_PLAYBACK_ACTION_STOP = 2;
+
+  /// < Next item
+  static const int MC_PLAYBACK_ACTION_NEXT = 3;
+
+  /// < Previous item
+  static const int MC_PLAYBACK_ACTION_PREV = 4;
+
+  /// < Fast forward
+  static const int MC_PLAYBACK_ACTION_FAST_FORWARD = 5;
+
+  /// < Rewind
+  static const int MC_PLAYBACK_ACTION_REWIND = 6;
+
+  /// < Play/Pause toggle
+  static const int MC_PLAYBACK_ACTION_TOGGLE_PLAY_PAUSE = 7;
+}
+
+/// @brief Enumeration for the shuffle mode of the media controller server.
+/// @since_tizen 2.4
+///
+/// @see mc_server_update_shuffle_mode()
+/// @see mc_server_shuffle_mode_cmd_received_cb()
+/// @see mc_client_get_server_shuffle_mode()
+/// @see mc_client_send_shuffle_mode_cmd()
+/// @see mc_shuffle_mode_updated_cb()
+abstract class mc_shuffle_mode_e {
+  /// < Shuffle mode on
+  static const int MC_SHUFFLE_MODE_ON = 0;
+
+  /// < Shuffle mode off
+  static const int MC_SHUFFLE_MODE_OFF = 1;
+}
+
+/// @brief Enumeration for the repeat mode of the media controller server.
+/// @since_tizen 2.4
+///
+/// @see mc_server_update_repeat_mode()
+/// @see mc_server_repeat_mode_cmd_received_cb()
+/// @see mc_client_get_server_repeat_mode()
+/// @see mc_client_send_repeat_mode_cmd()
+/// @see mc_repeat_mode_updated_cb()
+abstract class mc_repeat_mode_e {
+  /// < Repeat mode on for all media
+  static const int MC_REPEAT_MODE_ON = 0;
+
+  /// < Repeat mode off
+  static const int MC_REPEAT_MODE_OFF = 1;
+
+  /// < Repeat mode on for one media (Since 4.0)
+  static const int MC_REPEAT_MODE_ONE_MEDIA = 2;
+}
+
+/// @brief Enumeration for the subscription type of the media controller client.
+/// @since_tizen 2.4
+///
+/// @see mc_client_subscribe()
+/// @see mc_client_unsubscribe()
+/// @see mc_client_foreach_server_subscribed()
+abstract class mc_subscription_type_e {
+  /// < Server state
+  static const int MC_SUBSCRIPTION_TYPE_SERVER_STATE = 0;
+
+  /// < Playback
+  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK = 1;
+
+  /// < Metadata
+  static const int MC_SUBSCRIPTION_TYPE_METADATA = 2;
+
+  /// < Shuffle mode
+  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_MODE = 3;
+
+  /// < Repeat mode
+  static const int MC_SUBSCRIPTION_TYPE_REPEAT_MODE = 4;
+
+  /// < Playlist (Since 4.0)
+  static const int MC_SUBSCRIPTION_TYPE_PLAYLIST = 5;
+
+  /// < Playback ability (Since 5.0)
+  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK_ABILITY = 6;
+
+  /// < Ability support (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT = 9;
+
+  /// < Display mode ability (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_MODE_ABILITY = 10;
+
+  /// < Display rotation ability (Since 5.5)
+  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_ROTATION_ABILITY = 11;
+}
+
+/// @brief Enumeration for the playlist update mode.
+/// @details Media controller clients can know the playlist change status of the media controller server by calling mc_client_set_playlist_updated_cb(). \n
+/// @since_tizen 4.0
+///
+/// @see mc_client_set_playlist_updated_cb()
+/// @see mc_playlist_updated_cb()
+/// @see mc_server_update_playlist_done()
+/// @see mc_server_delete_playlist()
+abstract class mc_playlist_update_mode_e {
+  /// < Create or Update playlist
+  static const int MC_PLAYLIST_UPDATED = 0;
+
+  /// < Remove playlist
+  static const int MC_PLAYLIST_REMOVED = 1;
+}
+
+/// @brief Enumeration for the content type of the media content by the media controller server.
+/// @details Media controller clients can use this to know the playback status of the media controller server. \n
+/// And media controller clients can also use to search for the content provided by the media controller server.
+/// @since_tizen 5.0
+///
+/// @see mc_server_set_playback_content_type()
+/// @see mc_client_get_playback_content_type()
+/// @see mc_search_set_condition()
+abstract class mc_content_type_e {
+  /// < Image content type
+  static const int MC_CONTENT_TYPE_IMAGE = 0;
+
+  /// < Video content type
+  static const int MC_CONTENT_TYPE_VIDEO = 1;
+
+  /// < Music content type
+  static const int MC_CONTENT_TYPE_MUSIC = 2;
+
+  /// < Other content type
+  static const int MC_CONTENT_TYPE_OTHER = 3;
+
+  /// < Not decided
+  static const int MC_CONTENT_TYPE_UNDECIDED = 4;
+}
+
+/// @brief Enumeration for the content age rating of the media content by the media controller server.
+/// @since_tizen 5.0
+///
+/// @see mc_server_set_content_age_rating()
+/// @see mc_client_get_age_rating()
+abstract class mc_content_age_rating_e {
+  /// < Suitable for all ages
+  static const int MC_CONTENT_RATING_ALL = 0;
+
+  /// < Suitable for ages 1 and up
+  static const int MC_CONTENT_RATING_1_PLUS = 1;
+
+  /// < Suitable for ages 2 and up
+  static const int MC_CONTENT_RATING_2_PLUS = 2;
+
+  /// < Suitable for ages 3 and up
+  static const int MC_CONTENT_RATING_3_PLUS = 3;
+
+  /// < Suitable for ages 4 and up
+  static const int MC_CONTENT_RATING_4_PLUS = 4;
+
+  /// < Suitable for ages 5 and up
+  static const int MC_CONTENT_RATING_5_PLUS = 5;
+
+  /// < Suitable for ages 6 and up
+  static const int MC_CONTENT_RATING_6_PLUS = 6;
+
+  /// < Suitable for ages 7 and up
+  static const int MC_CONTENT_RATING_7_PLUS = 7;
+
+  /// < Suitable for ages 8 and up
+  static const int MC_CONTENT_RATING_8_PLUS = 8;
+
+  /// < Suitable for ages 9 and up
+  static const int MC_CONTENT_RATING_9_PLUS = 9;
+
+  /// < Suitable for ages 10 and up
+  static const int MC_CONTENT_RATING_10_PLUS = 10;
+
+  /// < Suitable for ages 11 and up
+  static const int MC_CONTENT_RATING_11_PLUS = 11;
+
+  /// < Suitable for ages 12 and up
+  static const int MC_CONTENT_RATING_12_PLUS = 12;
+
+  /// < Suitable for ages 13 and up
+  static const int MC_CONTENT_RATING_13_PLUS = 13;
+
+  /// < Suitable for ages 14 and up
+  static const int MC_CONTENT_RATING_14_PLUS = 14;
+
+  /// < Suitable for ages 15 and up
+  static const int MC_CONTENT_RATING_15_PLUS = 15;
+
+  /// < Suitable for ages 16 and up
+  static const int MC_CONTENT_RATING_16_PLUS = 16;
+
+  /// < Suitable for ages 17 and up
+  static const int MC_CONTENT_RATING_17_PLUS = 17;
+
+  /// < Suitable for ages 18 and up
+  static const int MC_CONTENT_RATING_18_PLUS = 18;
+
+  /// < Suitable for ages 19 and up
+  static const int MC_CONTENT_RATING_19_PLUS = 19;
+}
+
+/// @brief Enumeration for the support of the ability by the media controller server.
+/// @since_tizen 5.0
+///
+/// @remarks The media controller server should set the proper abilities. \n
+/// Only then can media controller clients send the appropriate control commands.
+///
+/// @see mc_server_set_playback_ability()
+/// @see mc_server_set_ability_support()
+/// @see mc_server_set_display_mode_ability()
+/// @see mc_server_set_display_rotation_ability()
+/// @see mc_client_get_server_ability_support()
+/// @see mc_ability_support_updated_cb()
+/// @see mc_playback_action_is_supported()
+abstract class mc_ability_support_e {
+  /// < Supported
+  static const int MC_ABILITY_SUPPORTED_YES = 0;
+
+  /// < Not supported
+  static const int MC_ABILITY_SUPPORTED_NO = 1;
+
+  /// < Not decided
+  static const int MC_ABILITY_SUPPORTED_UNDECIDED = 2;
+}
+
+/// @brief Enumeration for the ability of the media controller server.
+/// @since_tizen 5.5
+///
+/// @see mc_server_set_ability_support()
+/// @see mc_client_get_server_ability_support()
+/// @see mc_ability_support_updated_cb()
+abstract class mc_ability_e {
+  /// < Shuffle
+  static const int MC_ABILITY_SHUFFLE = 0;
+
+  /// < Repeat
+  static const int MC_ABILITY_REPEAT = 1;
+
+  /// < Playback Position
+  static const int MC_ABILITY_PLAYBACK_POSITION = 2;
+
+  /// < Playlist
+  static const int MC_ABILITY_PLAYLIST = 3;
+
+  /// < Custom command from a client
+  static const int MC_ABILITY_CLIENT_CUSTOM = 4;
+
+  /// < Search
+  static const int MC_ABILITY_SEARCH = 5;
+
+  /// < Subtitles display
+  static const int MC_ABILITY_SUBTITLES = 6;
+
+  /// < 360 content mode display
+  static const int MC_ABILITY_360_MODE = 7;
+}
+
+/// @brief Enumeration for the search category.
+/// @details Media controller clients can use this to search for the content provided by the media controller server.
+/// @since_tizen 5.0
+///
+/// @see mc_search_set_condition()
+abstract class mc_search_category_e {
+  /// < No search category
+  static const int MC_SEARCH_NO_CATEGORY = 0;
+
+  /// < Search by content title
+  static const int MC_SEARCH_TITLE = 1;
+
+  /// < Search by content artist
+  static const int MC_SEARCH_ARTIST = 2;
+
+  /// < Search by content album
+  static const int MC_SEARCH_ALBUM = 3;
+
+  /// < Search by content genre
+  static const int MC_SEARCH_GENRE = 4;
+
+  /// < Search by Time Place Occasion
+  static const int MC_SEARCH_TPO = 5;
+}
+
+/// @brief Enumeration for the display mode of the media controller server.
+/// @since_tizen 5.5
+///
+/// @see mc_server_update_display_mode()
+/// @see mc_server_display_mode_cmd_received_cb()
+/// @see mc_client_get_server_display_mode()
+/// @see mc_client_send_display_mode_cmd()
+/// @see mc_display_mode_updated_cb()
+abstract class mc_display_mode_e {
+  /// < Letter box
+  static const int MC_DISPLAY_MODE_LETTER_BOX = 1;
+
+  /// < Origin size
+  static const int MC_DISPLAY_MODE_ORIGIN_SIZE = 2;
+
+  /// < Full-screen
+  static const int MC_DISPLAY_MODE_FULL_SCREEN = 4;
+
+  /// < Cropped full-screen
+  static const int MC_DISPLAY_MODE_CROPPED_FULL = 8;
+}
+
+/// @brief Enumeration for the display rotation of the media controller server.
+/// @since_tizen 5.5
+///
+/// @see mc_server_update_display_rotation()
+/// @see mc_server_display_rotation_cmd_received_cb()
+/// @see mc_client_get_server_display_rotation()
+/// @see mc_client_send_display_rotation_cmd()
+/// @see mc_display_rotation_updated_cb()
+abstract class mc_display_rotation_e {
+  /// < Display is not rotated
+  static const int MC_DISPLAY_ROTATION_NONE = 1;
+
+  /// < Display is rotated 90 degrees
+  static const int MC_DISPLAY_ROTATION_90 = 2;
+
+  /// < Display is rotated 180 degrees
+  static const int MC_DISPLAY_ROTATION_180 = 4;
+
+  /// < Display is rotated 270 degrees
+  static const int MC_DISPLAY_ROTATION_270 = 8;
+}
+
+/// @brief The result codes of the reply for the command or the event.
+/// @since_tizen 6.0
+///
+/// @see mc_cmd_reply_received_cb()
+/// @see mc_client_send_event_reply()
+/// @see mc_server_event_reply_received_cb()
+/// @see mc_server_send_cmd_reply()
+abstract class mc_result_code_e {
+  /// < The command or the event has been successfully completed.
+  static const int MC_RESULT_CODE_SUCCESS = 0;
+
+  /// < The command or the event had already been completed.
+  static const int MC_RESULT_CODE_ALREADY_DONE = 200;
+
+  /// < The command or the event is aborted by some external event (e.g. aborted play command by incoming call).
+  static const int MC_RESULT_CODE_ABORTED = 300;
+
+  /// < The command or the event is denied due to application policy (e.g. cannot rewind in recording).
+  static const int MC_RESULT_CODE_DENIED = 301;
+
+  /// < The command or the event is not supported.
+  static const int MC_RESULT_CODE_NOT_SUPPORTED = 302;
+
+  /// < The command or the event is out of supported range or the limit is reached.
+  static const int MC_RESULT_CODE_INVALID = 303;
+
+  /// < Timeout has occurred.
+  static const int MC_RESULT_CODE_TIMEOUT = 400;
+
+  /// < The application has failed.
+  static const int MC_RESULT_CODE_APP_FAILED = 401;
+
+  /// < The command or the event has failed because the application has no media.
+  static const int MC_RESULT_CODE_NO_MEDIA = 402;
+
+  /// < The command or the event has failed because there is no audio output device.
+  static const int MC_RESULT_CODE_NO_AUDIO_OUTPUT_DEVICE = 403;
+
+  /// < The command or the event has failed because there is no peer.
+  static const int MC_RESULT_CODE_NO_PEER = 404;
+
+  /// < The network has failed.
+  static const int MC_RESULT_CODE_NETWORK_FAILED = 500;
+
+  /// < The application needs to have an account to which it's logged in.
+  static const int MC_RESULT_CODE_NO_ACCOUNT = 600;
+
+  /// < The application could not log in.
+  static const int MC_RESULT_CODE_LOGIN_FAILED = 601;
+
+  /// < Unknown error.
+  static const int MC_RESULT_CODE_UNKNOWN = 2147483647;
+}
+
 /// @brief The structure type for the media controller playlist handle.
 /// @since_tizen 4.0
 typedef mc_playlist_h = ffi.Pointer<ffi.Void>;
@@ -6519,174 +7048,13 @@ typedef mc_playlist_cbFunction = ffi.Bool Function(
 typedef Dartmc_playlist_cbFunction = bool Function(
     mc_playlist_h playlist, ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the media meta info.
-/// @since_tizen 2.4
-///
-/// @see mc_server_set_metadata()
-/// @see mc_server_add_item_to_playlist()
-/// @see mc_metadata_get()
-abstract class mc_meta_e {
-  /// < Title
-  static const int MC_META_MEDIA_TITLE = 0;
-
-  /// < Artist
-  static const int MC_META_MEDIA_ARTIST = 1;
-
-  /// < Album
-  static const int MC_META_MEDIA_ALBUM = 2;
-
-  /// < Author
-  static const int MC_META_MEDIA_AUTHOR = 3;
-
-  /// < Genre
-  static const int MC_META_MEDIA_GENRE = 4;
-
-  /// < Duration
-  static const int MC_META_MEDIA_DURATION = 5;
-
-  /// < Date
-  static const int MC_META_MEDIA_DATE = 6;
-
-  /// < Copyright
-  static const int MC_META_MEDIA_COPYRIGHT = 7;
-
-  /// < Description
-  static const int MC_META_MEDIA_DESCRIPTION = 8;
-
-  /// < Track Number
-  static const int MC_META_MEDIA_TRACK_NUM = 9;
-
-  /// < Picture. Album Art
-  static const int MC_META_MEDIA_PICTURE = 10;
-
-  /// < Season (Since 5.5)
-  static const int MC_META_MEDIA_SEASON = 11;
-
-  /// < Episode (Since 5.5)
-  static const int MC_META_MEDIA_EPISODE = 12;
-
-  /// < Content resolution (Since 5.5)
-  static const int MC_META_MEDIA_RESOLUTION = 13;
-}
-
 /// @brief The structure type for the media controller ability handle.
 /// @since_tizen 5.0
 typedef mc_playback_ability_h = ffi.Pointer<ffi.Void>;
 
-/// @brief Enumeration for the media playback action.
-/// @details Media controller clients can control media controller server's playback by calling mc_client_send_playback_action_cmd() or mc_client_send_playlist_cmd(). \n
-/// Media controller servers have to set proper playback ability by using mc_server_set_playback_ability().
-/// @since_tizen 4.0
-///
-/// @see mc_server_set_playback_ability()
-/// @see mc_client_send_playback_action_cmd()
-/// @see mc_client_send_playlist_cmd()
-/// @see mc_playback_action_is_supported()
-/// @see mc_server_playback_action_cmd_received_cb()
-/// @see mc_server_playlist_cmd_received_cb()
-abstract class mc_playback_action_e {
-  /// < Play
-  static const int MC_PLAYBACK_ACTION_PLAY = 0;
-
-  /// < Pause
-  static const int MC_PLAYBACK_ACTION_PAUSE = 1;
-
-  /// < Stop
-  static const int MC_PLAYBACK_ACTION_STOP = 2;
-
-  /// < Next item
-  static const int MC_PLAYBACK_ACTION_NEXT = 3;
-
-  /// < Previous item
-  static const int MC_PLAYBACK_ACTION_PREV = 4;
-
-  /// < Fast forward
-  static const int MC_PLAYBACK_ACTION_FAST_FORWARD = 5;
-
-  /// < Rewind
-  static const int MC_PLAYBACK_ACTION_REWIND = 6;
-
-  /// < Play/Pause toggle
-  static const int MC_PLAYBACK_ACTION_TOGGLE_PLAY_PAUSE = 7;
-}
-
-/// @brief Enumeration for the support of the ability by the media controller server.
-/// @since_tizen 5.0
-///
-/// @remarks The media controller server should set the proper abilities. \n
-/// Only then can media controller clients send the appropriate control commands.
-///
-/// @see mc_server_set_playback_ability()
-/// @see mc_server_set_ability_support()
-/// @see mc_server_set_display_mode_ability()
-/// @see mc_server_set_display_rotation_ability()
-/// @see mc_client_get_server_ability_support()
-/// @see mc_ability_support_updated_cb()
-/// @see mc_playback_action_is_supported()
-abstract class mc_ability_support_e {
-  /// < Supported
-  static const int MC_ABILITY_SUPPORTED_YES = 0;
-
-  /// < Not supported
-  static const int MC_ABILITY_SUPPORTED_NO = 1;
-
-  /// < Not decided
-  static const int MC_ABILITY_SUPPORTED_UNDECIDED = 2;
-}
-
 /// @brief The structure type for the media controller search handle.
 /// @since_tizen 5.0
 typedef mc_search_h = ffi.Pointer<ffi.Void>;
-
-/// @brief Enumeration for the content type of the media content by the media controller server.
-/// @details Media controller clients can use this to know the playback status of the media controller server. \n
-/// And media controller clients can also use to search for the content provided by the media controller server.
-/// @since_tizen 5.0
-///
-/// @see mc_server_set_playback_content_type()
-/// @see mc_client_get_playback_content_type()
-/// @see mc_search_set_condition()
-abstract class mc_content_type_e {
-  /// < Image content type
-  static const int MC_CONTENT_TYPE_IMAGE = 0;
-
-  /// < Video content type
-  static const int MC_CONTENT_TYPE_VIDEO = 1;
-
-  /// < Music content type
-  static const int MC_CONTENT_TYPE_MUSIC = 2;
-
-  /// < Other content type
-  static const int MC_CONTENT_TYPE_OTHER = 3;
-
-  /// < Not decided
-  static const int MC_CONTENT_TYPE_UNDECIDED = 4;
-}
-
-/// @brief Enumeration for the search category.
-/// @details Media controller clients can use this to search for the content provided by the media controller server.
-/// @since_tizen 5.0
-///
-/// @see mc_search_set_condition()
-abstract class mc_search_category_e {
-  /// < No search category
-  static const int MC_SEARCH_NO_CATEGORY = 0;
-
-  /// < Search by content title
-  static const int MC_SEARCH_TITLE = 1;
-
-  /// < Search by content artist
-  static const int MC_SEARCH_ARTIST = 2;
-
-  /// < Search by content album
-  static const int MC_SEARCH_ALBUM = 3;
-
-  /// < Search by content genre
-  static const int MC_SEARCH_GENRE = 4;
-
-  /// < Search by Time Place Occasion
-  static const int MC_SEARCH_TPO = 5;
-}
 
 /// @brief Called for every search condition information in the obtained list of search.
 /// @details Iterates over a search list.
@@ -6751,22 +7119,6 @@ typedef Dartmc_server_state_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the media controller server state.
-/// @since_tizen 2.4
-///
-/// @see mc_client_get_latest_server_info()
-/// @see mc_server_state_updated_cb()
-abstract class mc_server_state_e {
-  /// < None state
-  static const int MC_SERVER_STATE_NONE = 0;
-
-  /// < Activate state
-  static const int MC_SERVER_STATE_ACTIVATE = 1;
-
-  /// < Deactivate state
-  static const int MC_SERVER_STATE_DEACTIVATE = 2;
-}
 
 /// @brief Called when the playback information of the media controller server is updated.
 /// @since_tizen 2.4
@@ -6853,22 +7205,6 @@ typedef Dartmc_shuffle_mode_updated_cbFunction = void Function(
     int mode,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the shuffle mode of the media controller server.
-/// @since_tizen 2.4
-///
-/// @see mc_server_update_shuffle_mode()
-/// @see mc_server_shuffle_mode_cmd_received_cb()
-/// @see mc_client_get_server_shuffle_mode()
-/// @see mc_client_send_shuffle_mode_cmd()
-/// @see mc_shuffle_mode_updated_cb()
-abstract class mc_shuffle_mode_e {
-  /// < Shuffle mode on
-  static const int MC_SHUFFLE_MODE_ON = 0;
-
-  /// < Shuffle mode off
-  static const int MC_SHUFFLE_MODE_OFF = 1;
-}
-
 /// @brief Called when the repeat mode of the media controller server is updated.
 /// @since_tizen 4.0
 ///
@@ -6893,25 +7229,6 @@ typedef Dartmc_repeat_mode_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int mode,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the repeat mode of the media controller server.
-/// @since_tizen 2.4
-///
-/// @see mc_server_update_repeat_mode()
-/// @see mc_server_repeat_mode_cmd_received_cb()
-/// @see mc_client_get_server_repeat_mode()
-/// @see mc_client_send_repeat_mode_cmd()
-/// @see mc_repeat_mode_updated_cb()
-abstract class mc_repeat_mode_e {
-  /// < Repeat mode on for all media
-  static const int MC_REPEAT_MODE_ON = 0;
-
-  /// < Repeat mode off
-  static const int MC_REPEAT_MODE_OFF = 1;
-
-  /// < Repeat mode on for one media (Since 4.0)
-  static const int MC_REPEAT_MODE_ONE_MEDIA = 2;
-}
 
 /// @brief Called when the playback ability support of the media controller server is updated.
 /// @since_tizen 5.0
@@ -6966,38 +7283,6 @@ typedef Dartmc_ability_support_updated_cbFunction = void Function(
     int ability,
     int support,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the ability of the media controller server.
-/// @since_tizen 5.5
-///
-/// @see mc_server_set_ability_support()
-/// @see mc_client_get_server_ability_support()
-/// @see mc_ability_support_updated_cb()
-abstract class mc_ability_e {
-  /// < Shuffle
-  static const int MC_ABILITY_SHUFFLE = 0;
-
-  /// < Repeat
-  static const int MC_ABILITY_REPEAT = 1;
-
-  /// < Playback Position
-  static const int MC_ABILITY_PLAYBACK_POSITION = 2;
-
-  /// < Playlist
-  static const int MC_ABILITY_PLAYLIST = 3;
-
-  /// < Custom command from a client
-  static const int MC_ABILITY_CLIENT_CUSTOM = 4;
-
-  /// < Search
-  static const int MC_ABILITY_SEARCH = 5;
-
-  /// < Subtitles display
-  static const int MC_ABILITY_SUBTITLES = 6;
-
-  /// < 360 content mode display
-  static const int MC_ABILITY_360_MODE = 7;
-}
 
 /// @brief Called when a media controller server's supported items for an ability is updated.
 /// @since_tizen 5.5
@@ -7092,22 +7377,6 @@ typedef Dartmc_playlist_updated_cbFunction = void Function(
     mc_playlist_h playlist,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the playlist update mode.
-/// @details Media controller clients can know the playlist change status of the media controller server by calling mc_client_set_playlist_updated_cb(). \n
-/// @since_tizen 4.0
-///
-/// @see mc_client_set_playlist_updated_cb()
-/// @see mc_playlist_updated_cb()
-/// @see mc_server_update_playlist_done()
-/// @see mc_server_delete_playlist()
-abstract class mc_playlist_update_mode_e {
-  /// < Create or Update playlist
-  static const int MC_PLAYLIST_UPDATED = 0;
-
-  /// < Remove playlist
-  static const int MC_PLAYLIST_REMOVED = 1;
-}
-
 /// @brief Called when the status of a media controller server's boolean attribute (subtitles or 360 mode) is updated.
 /// @since_tizen 5.5
 ///
@@ -7155,28 +7424,6 @@ typedef Dartmc_display_mode_updated_cbFunction = void Function(
     int mode,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the display mode of the media controller server.
-/// @since_tizen 5.5
-///
-/// @see mc_server_update_display_mode()
-/// @see mc_server_display_mode_cmd_received_cb()
-/// @see mc_client_get_server_display_mode()
-/// @see mc_client_send_display_mode_cmd()
-/// @see mc_display_mode_updated_cb()
-abstract class mc_display_mode_e {
-  /// < Letter box
-  static const int MC_DISPLAY_MODE_LETTER_BOX = 1;
-
-  /// < Origin size
-  static const int MC_DISPLAY_MODE_ORIGIN_SIZE = 2;
-
-  /// < Full-screen
-  static const int MC_DISPLAY_MODE_FULL_SCREEN = 4;
-
-  /// < Cropped full-screen
-  static const int MC_DISPLAY_MODE_CROPPED_FULL = 8;
-}
-
 /// @brief Called when a media controller server's display rotation is updated.
 /// @since_tizen 5.5
 ///
@@ -7199,28 +7446,6 @@ typedef Dartmc_display_rotation_updated_cbFunction = void Function(
     ffi.Pointer<ffi.Char> server_name,
     int rotation,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the display rotation of the media controller server.
-/// @since_tizen 5.5
-///
-/// @see mc_server_update_display_rotation()
-/// @see mc_server_display_rotation_cmd_received_cb()
-/// @see mc_client_get_server_display_rotation()
-/// @see mc_client_send_display_rotation_cmd()
-/// @see mc_display_rotation_updated_cb()
-abstract class mc_display_rotation_e {
-  /// < Display is not rotated
-  static const int MC_DISPLAY_ROTATION_NONE = 1;
-
-  /// < Display is rotated 90 degrees
-  static const int MC_DISPLAY_ROTATION_90 = 2;
-
-  /// < Display is rotated 180 degrees
-  static const int MC_DISPLAY_ROTATION_180 = 4;
-
-  /// < Display is rotated 270 degrees
-  static const int MC_DISPLAY_ROTATION_270 = 8;
-}
 
 /// @brief Called when receiving custom event from media controller servers.
 /// @since_tizen 4.0
@@ -7257,44 +7482,6 @@ typedef Dartmc_client_custom_event_received_cbFunction = void Function(
     ffi.Pointer<bundle.bundle> data,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @brief Enumeration for the subscription type of the media controller client.
-/// @since_tizen 2.4
-///
-/// @see mc_client_subscribe()
-/// @see mc_client_unsubscribe()
-/// @see mc_client_foreach_server_subscribed()
-abstract class mc_subscription_type_e {
-  /// < Server state
-  static const int MC_SUBSCRIPTION_TYPE_SERVER_STATE = 0;
-
-  /// < Playback
-  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK = 1;
-
-  /// < Metadata
-  static const int MC_SUBSCRIPTION_TYPE_METADATA = 2;
-
-  /// < Shuffle mode
-  static const int MC_SUBSCRIPTION_TYPE_SHUFFLE_MODE = 3;
-
-  /// < Repeat mode
-  static const int MC_SUBSCRIPTION_TYPE_REPEAT_MODE = 4;
-
-  /// < Playlist (Since 4.0)
-  static const int MC_SUBSCRIPTION_TYPE_PLAYLIST = 5;
-
-  /// < Playback ability (Since 5.0)
-  static const int MC_SUBSCRIPTION_TYPE_PLAYBACK_ABILITY = 6;
-
-  /// < Ability support (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_ABILITY_SUPPORT = 9;
-
-  /// < Display mode ability (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_MODE_ABILITY = 10;
-
-  /// < Display rotation ability (Since 5.5)
-  static const int MC_SUBSCRIPTION_TYPE_DISPLAY_ROTATION_ABILITY = 11;
-}
-
 /// @brief Called when requesting the list of subscribed servers.
 /// @since_tizen 2.4
 ///
@@ -7317,113 +7504,6 @@ typedef mc_subscribed_server_cbFunction = ffi.Bool Function(
     ffi.Pointer<ffi.Char> server_name, ffi.Pointer<ffi.Void> user_data);
 typedef Dartmc_subscribed_server_cbFunction = bool Function(
     ffi.Pointer<ffi.Char> server_name, ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for the media playback state of the media controller server.
-/// @since_tizen 2.4
-///
-/// @see mc_server_set_playback_state()
-/// @see mc_client_get_playback_state()
-abstract class mc_playback_states_e {
-  /// < None
-  static const int MC_PLAYBACK_STATE_NONE = 0;
-
-  /// < Playing
-  static const int MC_PLAYBACK_STATE_PLAYING = 1;
-
-  /// < Paused
-  static const int MC_PLAYBACK_STATE_PAUSED = 2;
-
-  /// < Stopped
-  static const int MC_PLAYBACK_STATE_STOPPED = 3;
-
-  /// < Moving to the next item (Since 4.0)
-  static const int MC_PLAYBACK_STATE_MOVING_TO_NEXT = 8;
-
-  /// < Moving to the previous item (Since 4.0)
-  static const int MC_PLAYBACK_STATE_MOVING_TO_PREVIOUS = 9;
-
-  /// < Fast forwarding (Since 4.0)
-  static const int MC_PLAYBACK_STATE_FAST_FORWARDING = 10;
-
-  /// < Rewinding (Since 4.0)
-  static const int MC_PLAYBACK_STATE_REWINDING = 11;
-
-  /// < Connecting (Since 6.0)
-  static const int MC_PLAYBACK_STATE_CONNECTING = 12;
-
-  /// < Buffering (Since 6.0)
-  static const int MC_PLAYBACK_STATE_BUFFERING = 13;
-
-  /// < Error (Since 6.0)
-  static const int MC_PLAYBACK_STATE_ERROR = 14;
-}
-
-/// @brief Enumeration for the content age rating of the media content by the media controller server.
-/// @since_tizen 5.0
-///
-/// @see mc_server_set_content_age_rating()
-/// @see mc_client_get_age_rating()
-abstract class mc_content_age_rating_e {
-  /// < Suitable for all ages
-  static const int MC_CONTENT_RATING_ALL = 0;
-
-  /// < Suitable for ages 1 and up
-  static const int MC_CONTENT_RATING_1_PLUS = 1;
-
-  /// < Suitable for ages 2 and up
-  static const int MC_CONTENT_RATING_2_PLUS = 2;
-
-  /// < Suitable for ages 3 and up
-  static const int MC_CONTENT_RATING_3_PLUS = 3;
-
-  /// < Suitable for ages 4 and up
-  static const int MC_CONTENT_RATING_4_PLUS = 4;
-
-  /// < Suitable for ages 5 and up
-  static const int MC_CONTENT_RATING_5_PLUS = 5;
-
-  /// < Suitable for ages 6 and up
-  static const int MC_CONTENT_RATING_6_PLUS = 6;
-
-  /// < Suitable for ages 7 and up
-  static const int MC_CONTENT_RATING_7_PLUS = 7;
-
-  /// < Suitable for ages 8 and up
-  static const int MC_CONTENT_RATING_8_PLUS = 8;
-
-  /// < Suitable for ages 9 and up
-  static const int MC_CONTENT_RATING_9_PLUS = 9;
-
-  /// < Suitable for ages 10 and up
-  static const int MC_CONTENT_RATING_10_PLUS = 10;
-
-  /// < Suitable for ages 11 and up
-  static const int MC_CONTENT_RATING_11_PLUS = 11;
-
-  /// < Suitable for ages 12 and up
-  static const int MC_CONTENT_RATING_12_PLUS = 12;
-
-  /// < Suitable for ages 13 and up
-  static const int MC_CONTENT_RATING_13_PLUS = 13;
-
-  /// < Suitable for ages 14 and up
-  static const int MC_CONTENT_RATING_14_PLUS = 14;
-
-  /// < Suitable for ages 15 and up
-  static const int MC_CONTENT_RATING_15_PLUS = 15;
-
-  /// < Suitable for ages 16 and up
-  static const int MC_CONTENT_RATING_16_PLUS = 16;
-
-  /// < Suitable for ages 17 and up
-  static const int MC_CONTENT_RATING_17_PLUS = 17;
-
-  /// < Suitable for ages 18 and up
-  static const int MC_CONTENT_RATING_18_PLUS = 18;
-
-  /// < Suitable for ages 19 and up
-  static const int MC_CONTENT_RATING_19_PLUS = 19;
-}
 
 /// @brief Called when requesting the list of created servers.
 /// @since_tizen 2.4
@@ -7825,3 +7905,5 @@ typedef Dartmc_server_search_cmd_received_cbFunction = void Function(
     ffi.Pointer<ffi.Char> request_id,
     mc_search_h search,
     ffi.Pointer<ffi.Void> user_data);
+
+const int MEDIA_CONTROLLER_ERROR_CLASS = -50462720;

--- a/lib/src/bindings/9.0/generated_bindings_capi_media_metadata_editor.dart
+++ b/lib/src/bindings/9.0/generated_bindings_capi_media_metadata_editor.dart
@@ -378,9 +378,34 @@ class Tizen90CapiMediaMetadataEditor {
 
 /// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
 /// @deprecated Deprecated since 9.0.
-/// @brief The handle of media metadata.
+/// @brief The enumerations of media metadata error.
 /// @since_tizen 2.4
-typedef metadata_editor_h = ffi.Pointer<ffi.Void>;
+abstract class metadata_editor_error_e {
+  /// < Successful
+  static const int METADATA_EDITOR_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int METADATA_EDITOR_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int METADATA_EDITOR_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < File not exist
+  static const int METADATA_EDITOR_ERROR_FILE_EXISTS = -17;
+
+  /// < Permission denied
+  static const int METADATA_EDITOR_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Unsupported type
+  static const int METADATA_EDITOR_ERROR_NOT_SUPPORTED = -1073741822;
+
+  /// < Invalid internal operation
+  static const int METADATA_EDITOR_ERROR_OPERATION_FAILED = -27000831;
+
+  /// < Update not possible (Since 6.0)
+  static const int METADATA_EDITOR_ERROR_METADATA_UPDATE_NOT_POSSIBLE =
+      -27000830;
+}
 
 /// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
 /// @deprecated Deprecated since 9.0.
@@ -426,3 +451,11 @@ abstract class metadata_editor_attr_e {
   /// < Unsynchronized lyric
   static const int METADATA_EDITOR_ATTR_UNSYNCLYRICS = 12;
 }
+
+/// @ingroup CAPI_MEDIA_METADATA_EDITOR_MODULE
+/// @deprecated Deprecated since 9.0.
+/// @brief The handle of media metadata.
+/// @since_tizen 2.4
+typedef metadata_editor_h = ffi.Pointer<ffi.Void>;
+
+const int METADATA_EDITOR_ERROR_CLASS = -27000832;

--- a/lib/src/bindings/9.0/generated_bindings_capi_media_metadata_extractor.dart
+++ b/lib/src/bindings/9.0/generated_bindings_capi_media_metadata_extractor.dart
@@ -386,11 +386,27 @@ class Tizen90CapiMediaMetadataExtractor {
 }
 
 /// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
-/// @brief The metadata extractor handle.
+/// @brief Enumeration for metadata extractor error.
 /// @since_tizen 2.3
-typedef metadata_extractor_h = ffi.Pointer<metadata_extractor_s>;
+abstract class metadata_extractor_error_e {
+  /// < Successful
+  static const int METADATA_EXTRACTOR_ERROR_NONE = 0;
 
-final class metadata_extractor_s extends ffi.Opaque {}
+  /// < Invalid parameter
+  static const int METADATA_EXTRACTOR_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int METADATA_EXTRACTOR_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < File does not exist
+  static const int METADATA_EXTRACTOR_ERROR_FILE_EXISTS = -17;
+
+  /// < Permission denied
+  static const int METADATA_EXTRACTOR_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Invalid internal operation
+  static const int METADATA_EXTRACTOR_ERROR_OPERATION_FAILED = -26411007;
+}
 
 /// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
 /// @brief Enumeration for attribute.
@@ -504,3 +520,12 @@ abstract class metadata_extractor_attr_e {
   /// < Stitched type. (0:None, 1:Non-stitched, 2:stitched) (Since 9.0)
   static const int METADATA_360_STITCHED = 35;
 }
+
+final class metadata_extractor_s extends ffi.Opaque {}
+
+/// @ingroup CAPI_METADATA_EXTRACTOR_MODULE
+/// @brief The metadata extractor handle.
+/// @since_tizen 2.3
+typedef metadata_extractor_h = ffi.Pointer<metadata_extractor_s>;
+
+const int METADATA_EXTRACTOR_ERROR_CLASS = -26411008;

--- a/lib/src/bindings/9.0/generated_bindings_capi_media_screen_mirroring.dart
+++ b/lib/src/bindings/9.0/generated_bindings_capi_media_screen_mirroring.dart
@@ -886,30 +886,6 @@ class Tizen90CapiMediaScreenMirroring {
           int Function(scmirroring_sink_h, ffi.Pointer<ffi.Int32>)>();
 }
 
-/// @brief	The handle to the screen mirroring sink.
-/// @since_tizen 2.4
-typedef scmirroring_sink_h = ffi.Pointer<ffi.Void>;
-
-/// @brief Called when state of screen mirroring sink handle is changed.
-/// @since_tizen 2.4
-///
-/// @details This callback is called for state and error of screen mirroring sink will be delivered together.
-/// Error can be handled by return value of CAPIs. so there is no need to handle it here.
-///
-/// @param[in] error     The error code
-/// @param[in] state     The screen mirroring sink state
-/// @param[in] user_data The user data passed from the scmirroring_sink_set_state_cb() function
-///
-/// @pre scmirroring_sink_create()
-///
-/// @see scmirroring_sink_create()
-typedef scmirroring_sink_state_cb
-    = ffi.Pointer<ffi.NativeFunction<scmirroring_sink_state_cbFunction>>;
-typedef scmirroring_sink_state_cbFunction = ffi.Void Function(
-    ffi.Int32 error, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
-typedef Dartscmirroring_sink_state_cbFunction = void Function(
-    int error, int state, ffi.Pointer<ffi.Void> user_data);
-
 /// @brief Enumeration to provide screen mirroring error information.
 /// @since_tizen 2.4
 abstract class scmirroring_error_e {
@@ -964,6 +940,41 @@ abstract class scmirroring_sink_state_e {
   static const int SCMIRRORING_SINK_STATE_MAX = 7;
 }
 
+/// @brief Enumeration for screen mirroring resolution.
+/// @since_tizen 2.4
+abstract class scmirroring_resolution_e {
+  static const int SCMIRRORING_RESOLUTION_UNKNOWN = 0;
+
+  /// < W-1920, H-1080, 30 fps
+  static const int SCMIRRORING_RESOLUTION_1920x1080_P30 = 1;
+
+  /// < W-1280, H-720, 30 fps
+  static const int SCMIRRORING_RESOLUTION_1280x720_P30 = 2;
+
+  /// < W-960, H-540, 30 fps
+  static const int SCMIRRORING_RESOLUTION_960x540_P30 = 4;
+
+  /// < W-864, H-480, 30 fps
+  static const int SCMIRRORING_RESOLUTION_864x480_P30 = 8;
+
+  /// < W-720, H-480, 30 fps
+  static const int SCMIRRORING_RESOLUTION_720x480_P60 = 16;
+
+  /// < W-640, H-480, 60 fps
+  static const int SCMIRRORING_RESOLUTION_640x480_P60 = 32;
+
+  /// < W-640, H-360, 30 fps
+  static const int SCMIRRORING_RESOLUTION_640x360_P30 = 64;
+  static const int SCMIRRORING_RESOLUTION_MAX = 128;
+}
+
+/// @brief Ability to send to multisink.
+/// @since_tizen 3.0
+abstract class scmirroring_multisink_e {
+  static const int SCMIRRORING_MULTISINK_DISABLE = 0;
+  static const int SCMIRRORING_MULTISINK_ENABLE = 1;
+}
+
 /// @brief Enumeration for screen mirroring display surface type.
 /// @since_tizen 2.4
 abstract class scmirroring_display_type_e {
@@ -973,16 +984,6 @@ abstract class scmirroring_display_type_e {
   /// < Use Evas pixmap surface to display streaming multimedia data
   static const int SCMIRRORING_DISPLAY_TYPE_EVAS = 1;
   static const int SCMIRRORING_DISPLAY_TYPE_MAX = 2;
-}
-
-/// @brief Enumeration for screen mirroring video codec.
-/// @since_tizen 2.4
-abstract class scmirroring_video_codec_e {
-  /// < Screen mirroring is not negotiated yet
-  static const int SCMIRRORING_VIDEO_CODEC_NONE = 0;
-
-  /// < H.264 codec for video
-  static const int SCMIRRORING_VIDEO_CODEC_H264 = 1;
 }
 
 /// @brief Enumeration for screen mirroring audio codec.
@@ -1000,3 +1001,57 @@ abstract class scmirroring_audio_codec_e {
   /// < LPCM codec for audio
   static const int SCMIRRORING_AUDIO_CODEC_LPCM = 3;
 }
+
+/// @brief Enumeration for screen mirroring video codec.
+/// @since_tizen 2.4
+abstract class scmirroring_video_codec_e {
+  /// < Screen mirroring is not negotiated yet
+  static const int SCMIRRORING_VIDEO_CODEC_NONE = 0;
+
+  /// < H.264 codec for video
+  static const int SCMIRRORING_VIDEO_CODEC_H264 = 1;
+}
+
+/// @brief Enumeration for screen mirroring direct streaming mode.
+/// @since_tizen 3.0
+abstract class scmirroring_direct_streaming_e {
+  /// < Disable screen mirroring direct streaming mode
+  static const int SCMIRRORING_DIRECT_STREAMING_DISABLED = 0;
+
+  /// < Enable direct streaming for files
+  static const int SCMIRRORING_DIRECT_STREAMING_ENABLED = 1;
+}
+
+/// @brief Enumeration for screen mirroring AV streaming transport.
+/// @since_tizen 3.0
+abstract class scmirroring_av_transport_e {
+  /// < UDP transport for AV streaming data
+  static const int SCMIRRORING_AV_TRANSPORT_UDP = 0;
+
+  /// < TCP transport for AV streaming data
+  static const int SCMIRRORING_AV_TRANSPORT_TCP = 1;
+}
+
+/// @brief	The handle to the screen mirroring sink.
+/// @since_tizen 2.4
+typedef scmirroring_sink_h = ffi.Pointer<ffi.Void>;
+
+/// @brief Called when state of screen mirroring sink handle is changed.
+/// @since_tizen 2.4
+///
+/// @details This callback is called for state and error of screen mirroring sink will be delivered together.
+/// Error can be handled by return value of CAPIs. so there is no need to handle it here.
+///
+/// @param[in] error     The error code
+/// @param[in] state     The screen mirroring sink state
+/// @param[in] user_data The user data passed from the scmirroring_sink_set_state_cb() function
+///
+/// @pre scmirroring_sink_create()
+///
+/// @see scmirroring_sink_create()
+typedef scmirroring_sink_state_cb
+    = ffi.Pointer<ffi.NativeFunction<scmirroring_sink_state_cbFunction>>;
+typedef scmirroring_sink_state_cbFunction = ffi.Void Function(
+    ffi.Int32 error, ffi.Int32 state, ffi.Pointer<ffi.Void> user_data);
+typedef Dartscmirroring_sink_state_cbFunction = void Function(
+    int error, int state, ffi.Pointer<ffi.Void> user_data);

--- a/lib/src/bindings/9.0/generated_bindings_capi_media_sound_pool.dart
+++ b/lib/src/bindings/9.0/generated_bindings_capi_media_sound_pool.dart
@@ -865,10 +865,52 @@ class Tizen90CapiMediaSoundPool {
       .asFunction<int Function(sound_pool_h, int, ffi.Pointer<ffi.Int32>)>();
 }
 
-/// @brief Sound pool handle type.
+/// @brief Enumeration for Tizen Sound Pool error.
 ///
 /// @since_tizen 4.0
-typedef sound_pool_h = ffi.Pointer<ffi.Void>;
+abstract class sound_pool_error_e {
+  static const int SOUND_POOL_ERROR_NONE = 0;
+  static const int SOUND_POOL_ERROR_KEY_NOT_AVAILABLE = -126;
+  static const int SOUND_POOL_ERROR_OUT_OF_MEMORY = -12;
+  static const int SOUND_POOL_ERROR_INVALID_PARAMETER = -22;
+  static const int SOUND_POOL_ERROR_INVALID_OPERATION = -38;
+  static const int SOUND_POOL_ERROR_NOT_PERMITTED = -1;
+  static const int SOUND_POOL_ERROR_NO_SUCH_FILE = -2;
+}
+
+/// @brief Enumeration of sound pool stream state.
+///
+/// @since_tizen 4.0
+abstract class sound_pool_stream_state_e {
+  /// < Stream state isn't determined
+  static const int SOUND_POOL_STREAM_STATE_NONE = 0;
+
+  /// < Stream state is playing
+  static const int SOUND_POOL_STREAM_STATE_PLAYING = 1;
+
+  /// < Stream state is paused
+  static const int SOUND_POOL_STREAM_STATE_PAUSED = 2;
+
+  /// < Stream state is stopped
+  static const int SOUND_POOL_STREAM_STATE_STOPPED = 3;
+
+  /// < Stream state is finished
+  static const int SOUND_POOL_STREAM_STATE_FINISHED = 4;
+
+  /// < Stream state is suspended
+  static const int SOUND_POOL_STREAM_STATE_SUSPENDED = 5;
+}
+
+/// @brief Enumeration of sound pool stream priority policy.
+///
+/// @since_tizen 4.0
+abstract class sound_pool_stream_priority_policy_e {
+  /// < Stream priority policy is mute
+  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_MUTE = 0;
+
+  /// < Stream priority policy is suspended
+  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_SUSPENDED = 1;
+}
 
 /// @brief Enumeration of sound pool state.
 ///
@@ -880,6 +922,11 @@ abstract class sound_pool_state_e {
   /// < Sound pool inactive state: streams can't be played
   static const int SOUND_POOL_STATE_INACTIVE = 1;
 }
+
+/// @brief Sound pool handle type.
+///
+/// @since_tizen 4.0
+typedef sound_pool_h = ffi.Pointer<ffi.Void>;
 
 /// @brief Called when the sound pool state is changed.
 ///
@@ -910,17 +957,6 @@ typedef Dartsound_pool_state_changed_cbFunction = void Function(
     int prev_state,
     int cur_state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration of sound pool stream priority policy.
-///
-/// @since_tizen 4.0
-abstract class sound_pool_stream_priority_policy_e {
-  /// < Stream priority policy is mute
-  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_MUTE = 0;
-
-  /// < Stream priority policy is suspended
-  static const int SOUND_POOL_STREAM_PRIORITY_POLICY_SUSPENDED = 1;
-}
 
 /// @brief Called when the sound pool stream state is changed.
 ///
@@ -954,26 +990,3 @@ typedef Dartsound_pool_stream_state_changed_cbFunction = void Function(
     int prev_state,
     int cur_state,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration of sound pool stream state.
-///
-/// @since_tizen 4.0
-abstract class sound_pool_stream_state_e {
-  /// < Stream state isn't determined
-  static const int SOUND_POOL_STREAM_STATE_NONE = 0;
-
-  /// < Stream state is playing
-  static const int SOUND_POOL_STREAM_STATE_PLAYING = 1;
-
-  /// < Stream state is paused
-  static const int SOUND_POOL_STREAM_STATE_PAUSED = 2;
-
-  /// < Stream state is stopped
-  static const int SOUND_POOL_STREAM_STATE_STOPPED = 3;
-
-  /// < Stream state is finished
-  static const int SOUND_POOL_STREAM_STATE_FINISHED = 4;
-
-  /// < Stream state is suspended
-  static const int SOUND_POOL_STREAM_STATE_SUSPENDED = 5;
-}

--- a/lib/src/bindings/9.0/generated_bindings_capi_media_thumbnail_util.dart
+++ b/lib/src/bindings/9.0/generated_bindings_capi_media_thumbnail_util.dart
@@ -156,3 +156,31 @@ class Tizen90CapiMediaThumbnailUtil {
               ffi.Pointer<ffi.UnsignedInt>,
               ffi.Pointer<ffi.UnsignedInt>)>();
 }
+
+/// @ingroup CAPI_MEDIA_THUMBNAIL_UTIL_MODULE
+/// @brief Enumeration for a thumbnail util error.
+/// @since_tizen 2.4
+abstract class thumbnail_util_error_e {
+  /// < Successful
+  static const int THUMBNAIL_UTIL_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int THUMBNAIL_UTIL_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int THUMBNAIL_UTIL_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Invalid Operation
+  static const int THUMBNAIL_UTIL_ERROR_INVALID_OPERATION = -38;
+
+  /// < No space left on device
+  static const int THUMBNAIL_UTIL_ERROR_FILE_NO_SPACE_ON_DEVICE = -28;
+
+  /// < Permission denied
+  static const int THUMBNAIL_UTIL_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Unsupported Content (Since 4.0)
+  static const int THUMBNAIL_UTIL_ERROR_UNSUPPORTED_CONTENT = -49872895;
+}
+
+const int THUMBNAIL_UTIL_ERROR_CLASS = -49872896;

--- a/lib/src/bindings/9.0/generated_bindings_capi_network_bluetooth.dart
+++ b/lib/src/bindings/9.0/generated_bindings_capi_network_bluetooth.dart
@@ -10739,6 +10739,187 @@ class Tizen90CapiNetworkBluetooth {
                   ffi.Pointer<bt_adapter_le_device_scan_result_info_s>>)>();
 }
 
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of PBAP fields.
+/// @since_tizen 3.0
+abstract class bt_pbap_field_e {
+  /// < All field
+  static const int BT_PBAP_FIELD_ALL = -1;
+
+  /// < vCard Version
+  static const int BT_PBAP_FIELD_VERSION = 1;
+
+  /// < Formatted Name
+  static const int BT_PBAP_FIELD_FN = 2;
+
+  /// < Structured Presentation of Name
+  static const int BT_PBAP_FIELD_N = 4;
+
+  /// < Associated Image or Photo
+  static const int BT_PBAP_FIELD_PHOTO = 8;
+
+  /// < Birthday
+  static const int BT_PBAP_FIELD_BDAY = 16;
+
+  /// < Delivery Address
+  static const int BT_PBAP_FIELD_ADR = 32;
+
+  /// < Delivery
+  static const int BT_PBAP_FIELD_LABEL = 64;
+
+  /// < Telephone Number
+  static const int BT_PBAP_FIELD_TEL = 128;
+
+  /// < Electronic Mail Address
+  static const int BT_PBAP_FIELD_EMAIL = 256;
+
+  /// < Electronic Mail
+  static const int BT_PBAP_FIELD_MAILER = 512;
+
+  /// < Time Zone
+  static const int BT_PBAP_FIELD_TZ = 1024;
+
+  /// < Geographic Position
+  static const int BT_PBAP_FIELD_GEO = 2048;
+
+  /// < Job
+  static const int BT_PBAP_FIELD_TITLE = 4096;
+
+  /// < Role within the Organization
+  static const int BT_PBAP_FIELD_ROLE = 8192;
+
+  /// < Organization Logo
+  static const int BT_PBAP_FIELD_LOGO = 16384;
+
+  /// < vCard of Person Representing
+  static const int BT_PBAP_FIELD_AGENT = 32768;
+
+  /// < Name of Organization
+  static const int BT_PBAP_FIELD_ORG = 65536;
+
+  /// < Comments
+  static const int BT_PBAP_FIELD_NOTE = 131072;
+
+  /// < Revision
+  static const int BT_PBAP_FIELD_REV = 262144;
+
+  /// < Pronunciation of Name
+  static const int BT_PBAP_FIELD_SOUND = 524288;
+
+  /// < Uniform Resource Locator
+  static const int BT_PBAP_FIELD_URL = 1048576;
+
+  /// < Unique ID
+  static const int BT_PBAP_FIELD_UID = 2097152;
+
+  /// < Public Encryption Key
+  static const int BT_PBAP_FIELD_KEY = 4194304;
+
+  /// < Nickname
+  static const int BT_PBAP_FIELD_NICKNAME = 8388608;
+
+  /// < Categories
+  static const int BT_PBAP_FIELD_CATEGORIES = 16777216;
+
+  /// < Product ID
+  static const int BT_PBAP_FIELD_PROID = 33554432;
+
+  /// < Class information
+  static const int BT_PBAP_FIELD_CLASS = 67108864;
+
+  /// < String used for sorting operations
+  static const int BT_PBAP_FIELD_SORT_STRING = 134217728;
+
+  /// < Time stamp
+  static const int BT_PBAP_FIELD_X_IRMC_CALL_DATETIME = 268435456;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_MODULE
+/// @brief Enumerations of Bluetooth error codes.
+/// @since_tizen 2.3
+abstract class bt_error_e {
+  /// < Successful
+  static const int BT_ERROR_NONE = 0;
+
+  /// < Operation cancelled
+  static const int BT_ERROR_CANCELLED = -125;
+
+  /// < Invalid parameter
+  static const int BT_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int BT_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < Device or resource busy
+  static const int BT_ERROR_RESOURCE_BUSY = -16;
+
+  /// < Timeout error
+  static const int BT_ERROR_TIMED_OUT = -1073741823;
+
+  /// < Operation now in progress
+  static const int BT_ERROR_NOW_IN_PROGRESS = -115;
+
+  /// < BT is Not Supported
+  static const int BT_ERROR_NOT_SUPPORTED = -1073741822;
+
+  /// < Permission denied
+  static const int BT_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Quota exceeded
+  static const int BT_ERROR_QUOTA_EXCEEDED = -122;
+
+  /// < No data available
+  static const int BT_ERROR_NO_DATA = -61;
+
+  /// < Device policy restriction (Since 3.0)
+  static const int BT_ERROR_DEVICE_POLICY_RESTRICTION = -1073741820;
+
+  /// < Local adapter not initialized
+  static const int BT_ERROR_NOT_INITIALIZED = -29359871;
+
+  /// < Local adapter not enabled
+  static const int BT_ERROR_NOT_ENABLED = -29359870;
+
+  /// < Operation already done
+  static const int BT_ERROR_ALREADY_DONE = -29359869;
+
+  /// < Operation failed
+  static const int BT_ERROR_OPERATION_FAILED = -29359868;
+
+  /// < Operation not in progress
+  static const int BT_ERROR_NOT_IN_PROGRESS = -29359867;
+
+  /// < Remote device not bonded
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_BONDED = -29359866;
+
+  /// < Authentication rejected
+  static const int BT_ERROR_AUTH_REJECTED = -29359865;
+
+  /// < Authentication failed
+  static const int BT_ERROR_AUTH_FAILED = -29359864;
+
+  /// < Remote device not found
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_FOUND = -29359863;
+
+  /// < Service search failed
+  static const int BT_ERROR_SERVICE_SEARCH_FAILED = -29359862;
+
+  /// < Remote device is not connected
+  static const int BT_ERROR_REMOTE_DEVICE_NOT_CONNECTED = -29359861;
+
+  /// < Resource temporarily unavailable
+  static const int BT_ERROR_AGAIN = -29359860;
+
+  /// < Service Not Found
+  static const int BT_ERROR_SERVICE_NOT_FOUND = -29359859;
+
+  /// < Authorization rejected (Since 5.0)
+  static const int BT_ERROR_AUTHORIZATION_REJECTED = -29359858;
+
+  /// < Max of connection exceeded (Since 8.0)
+  static const int BT_ERROR_MAX_CONNECTION = -29359857;
+}
+
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
 /// @brief  Enumerations of the Bluetooth adapter state.
 /// @since_tizen 2.3
@@ -10763,6 +10944,201 @@ abstract class bt_adapter_visibility_mode_e {
   /// < Discoverable mode with time limit. After specific period,
   /// it is changed to #BT_ADAPTER_VISIBILITY_MODE_NON_DISCOVERABLE.
   static const int BT_ADAPTER_VISIBILITY_MODE_LIMITED_DISCOVERABLE = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief Enumerations of the discovery state of Bluetooth device.
+/// @since_tizen 2.3
+abstract class bt_adapter_device_discovery_state_e {
+  /// < Device discovery is started
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_STARTED = 0;
+
+  /// < Device discovery is finished
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_FINISHED = 1;
+
+  /// < The remote Bluetooth device is found
+  static const int BT_ADAPTER_DEVICE_DISCOVERY_FOUND = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising state.
+/// @since_tizen 2.3
+abstract class bt_adapter_le_advertising_state_e {
+  /// < Bluetooth advertising is stopped
+  static const int BT_ADAPTER_LE_ADVERTISING_STOPPED = 0;
+
+  /// < Bluetooth advertising is started
+  static const int BT_ADAPTER_LE_ADVERTISING_STARTED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising mode.
+/// @since_tizen 2.3.1
+abstract class bt_adapter_le_advertising_mode_e {
+  /// < Balanced advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_BALANCED = 0;
+
+  /// < Low latency advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_LATENCY = 1;
+
+  /// < Low energy advertising mode
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_ENERGY = 2;
+
+  /// < Custom mode to set advertising parameters
+  static const int BT_ADAPTER_LE_ADVERTISING_MODE_CUSTOM = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth advertising filter policy.
+/// @since_tizen 2.3
+abstract class bt_adapter_le_advertising_filter_policy_e {
+  /// < White list is not in use
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_DEFAULT = 0;
+
+  /// < Allow the scan
+  /// request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_SCAN_WL = 1;
+
+  /// < Allow the connection
+  /// request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_CONN_WL = 2;
+
+  /// < Allow the
+  /// scan and connection request that in the White list
+  static const int BT_ADAPTER_LE_ADVERTISING_FILTER_ALLOW_SCAN_CONN_WL = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief Enumerations of the Bluetooth LE advertising flags.
+/// @since_tizen 8.0
+abstract class bt_adapter_le_advertising_flags_e {
+  /// < LE Limited Discoverable Mode
+  static const int BT_ADAPTER_LE_ADVERTISING_FLAGS_LIM_DISC = 1;
+
+  /// < LE General Discoverable Mode
+  static const int BT_ADAPTER_LE_ADVERTISING_FLAGS_GEN_DISC = 2;
+
+  /// < BR/EDR Not Supported
+  static const int BT_ADAPTER_LE_ADVERTISING_FLAGS_BREDR_UNSUP = 4;
+
+  /// < Simultaneous LE and BR/EDR to Same Device Capable (Controller)
+  static const int BT_ADAPTER_LE_ADVERTISING_FLAGS_CONTROLLER = 8;
+
+  /// < Simultaneous LE and BR/EDR to Same Device Capable (Host)
+  static const int BT_ADAPTER_LE_ADVERTISING_FLAGS_SIM_HOST = 16;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth LE packet type.
+/// @since_tizen 2.3
+abstract class bt_adapter_le_packet_type_e {
+  /// < Advertising packet
+  static const int BT_ADAPTER_LE_PACKET_ADVERTISING = 0;
+
+  /// < Scan response packet
+  static const int BT_ADAPTER_LE_PACKET_SCAN_RESPONSE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief  Enumerations of the Bluetooth le scan mode.
+/// @since_tizen 3.0
+abstract class bt_adapter_le_scan_mode_e {
+  /// < Balanced mode of power consumption and connection latency
+  static const int BT_ADAPTER_LE_SCAN_MODE_BALANCED = 0;
+
+  /// < Low connection latency but high power consumption
+  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_LATENCY = 1;
+
+  /// < Low power consumption but high connection latency
+  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_ENERGY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device disconnect reason.
+/// @since_tizen 2.3
+abstract class bt_device_disconnect_reason_e {
+  /// < Disconnected by unknown reason
+  static const int BT_DEVICE_DISCONNECT_REASON_UNKNOWN = 0;
+
+  /// < Disconnected by timeout
+  static const int BT_DEVICE_DISCONNECT_REASON_TIMEOUT = 1;
+
+  /// < Disconnected by local host
+  static const int BT_DEVICE_DISCONNECT_REASON_LOCAL_HOST = 2;
+
+  /// < Disconnected by remote
+  static const int BT_DEVICE_DISCONNECT_REASON_REMOTE = 3;
+
+  /// < Disconnected by MIC failure (Since 9.0)
+  static const int BT_DEVICE_DISCONNECT_REASON_MIC_FAILURE = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of connection link type.
+/// @since_tizen 2.3
+abstract class bt_device_connection_link_type_e {
+  /// < BR/EDR link
+  static const int BT_DEVICE_CONNECTION_LINK_BREDR = 0;
+
+  /// < LE link
+  static const int BT_DEVICE_CONNECTION_LINK_LE = 1;
+
+  /// < The connection type default
+  static const int BT_DEVICE_CONNECTION_LINK_DEFAULT = 255;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device authorization state.
+/// @since_tizen 2.3
+abstract class bt_device_authorization_e {
+  /// < The remote Bluetooth device is authorized
+  static const int BT_DEVICE_AUTHORIZED = 0;
+
+  /// < The remote Bluetooth device is unauthorized
+  static const int BT_DEVICE_UNAUTHORIZED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of Bluetooth profile.
+/// @since_tizen 2.3
+abstract class bt_profile_e {
+  /// < RFCOMM Profile
+  static const int BT_PROFILE_RFCOMM = 1;
+
+  /// < Advanced Audio Distribution Profile Source role
+  static const int BT_PROFILE_A2DP = 2;
+
+  /// < Headset Profile
+  static const int BT_PROFILE_HSP = 4;
+
+  /// < Human Interface Device Profile
+  static const int BT_PROFILE_HID = 8;
+
+  /// < Network Access Point Profile
+  static const int BT_PROFILE_NAP = 16;
+
+  /// < Audio Gateway Profile
+  static const int BT_PROFILE_AG = 32;
+
+  /// < Generic Attribute Profile
+  static const int BT_PROFILE_GATT = 64;
+
+  /// < NAP server Profile
+  static const int BT_PROFILE_NAP_SERVER = 128;
+
+  /// < Advanced Audio Distribution Profile Sink role
+  static const int BT_PROFILE_A2DP_SINK = 256;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Enumerations of device address type.
+/// @since_tizen 2.3
+abstract class bt_device_address_type_e {
+  /// < Public address
+  static const int BT_DEVICE_PUBLIC_ADDRESS = 0;
+
+  /// < Random address
+  static const int BT_DEVICE_RANDOM_ADDRESS = 1;
 }
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
@@ -10848,88 +11224,36 @@ abstract class bt_service_class_t {
   static const int BT_SC_MAX = 16777216;
 }
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief  Called when you get bonded devices repeatedly.
-/// @since_tizen 2.3
-///
-/// @param[in] device_info The bonded device information
-/// @param[in] user_data The user data passed from the foreach function
-/// @return @c true to continue with the next iteration of the loop,
-/// \n @c false to break out of the loop.
-/// @pre bt_adapter_foreach_bonded_device() will invoke this function.
-///
-/// @see bt_adapter_foreach_bonded_device()
-typedef bt_adapter_bonded_device_cb
-    = ffi.Pointer<ffi.NativeFunction<bt_adapter_bonded_device_cbFunction>>;
-typedef bt_adapter_bonded_device_cbFunction = ffi.Bool Function(
-    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
-typedef Dartbt_adapter_bonded_device_cbFunction = bool Function(
-    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Device information structure used for identifying pear device.
+/// @brief  Enumerations of major service class.
 /// @since_tizen 2.3
-///
-/// @see #bt_class_s
-/// @see bt_device_bond_created_cb()
-final class bt_device_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
+abstract class bt_major_service_class_e {
+  /// < Limited discoverable mode
+  static const int BT_MAJOR_SERVICE_CLASS_LIMITED_DISCOVERABLE_MODE = 8192;
 
-  /// < The name of remote device
-  external ffi.Pointer<ffi.Char> remote_name;
+  /// < Positioning class
+  static const int BT_MAJOR_SERVICE_CLASS_POSITIONING = 65536;
 
-  /// < The Bluetooth classes
-  external bt_class_s bt_class;
+  /// < Networking class
+  static const int BT_MAJOR_SERVICE_CLASS_NETWORKING = 131072;
 
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+  /// < Rendering class
+  static const int BT_MAJOR_SERVICE_CLASS_RENDERING = 262144;
 
-  /// < The number of services
-  @ffi.Int()
-  external int service_count;
+  /// < Capturing class
+  static const int BT_MAJOR_SERVICE_CLASS_CAPTURING = 524288;
 
-  /// < The bonding state
-  @ffi.Bool()
-  external bool is_bonded;
+  /// < Object transferring class
+  static const int BT_MAJOR_SERVICE_CLASS_OBJECT_TRANSFER = 1048576;
 
-  /// < The connection state
-  @ffi.Bool()
-  external bool is_connected;
+  /// < Audio class
+  static const int BT_MAJOR_SERVICE_CLASS_AUDIO = 2097152;
 
-  /// < The authorization state
-  @ffi.Bool()
-  external bool is_authorized;
+  /// < Telephony class
+  static const int BT_MAJOR_SERVICE_CLASS_TELEPHONY = 4194304;
 
-  /// < manufacturer specific data length
-  @ffi.Int()
-  external int manufacturer_data_len;
-
-  /// < manufacturer specific data
-  external ffi.Pointer<ffi.Char> manufacturer_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Class structure of device and service.
-/// @since_tizen 2.3
-///
-/// @see #bt_device_info_s
-/// @see #bt_adapter_device_discovery_info_s
-/// @see bt_device_bond_created_cb()
-/// @see bt_adapter_device_discovery_state_changed_cb()
-final class bt_class_s extends ffi.Struct {
-  /// < Major device class.
-  @ffi.Int32()
-  external int major_device_class;
-
-  /// < Minor device class.
-  @ffi.Int32()
-  external int minor_device_class;
-
-  /// < Major service class mask.
-  /// This value can be a combination of #bt_major_service_class_e like #BT_MAJOR_SERVICE_CLASS_RENDERING | #BT_MAJOR_SERVICE_CLASS_AUDIO
-  @ffi.Int()
-  external int major_service_class_mask;
+  /// < Information class
+  static const int BT_MAJOR_SERVICE_CLASS_INFORMATION = 8388608;
 }
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
@@ -11230,6 +11554,1026 @@ abstract class bt_minor_device_class_e {
   static const int BT_MINOR_DEVICE_CLASS_HEALTH_ANKLE_PROSTHESIS = 52;
 }
 
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief  Enumerations of gap appearance type.
+/// @since_tizen 2.3
+abstract class bt_appearance_type_e {
+  /// < Unknown appearance type
+  static const int BT_APPEARANCE_TYPE_UNKNOWN = 0;
+
+  /// < Generic Phone type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_PHONE = 64;
+
+  /// < Generic Computer type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_COMPUTER = 128;
+
+  /// < Generic Watch type - Generic category
+  static const int BT_APPEARANCE_TYPE_GENERIC_WATCH = 192;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief  Enumerations of the Bluetooth device's LE connection mode.
+/// @since_tizen 3.0
+abstract class bt_device_le_connection_mode_e {
+  /// < Balanced mode of power consumption and connection latency
+  static const int BT_DEVICE_LE_CONNECTION_MODE_BALANCED = 0;
+
+  /// < Low connection latency but high power consumption
+  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_LATENCY = 1;
+
+  /// < Low power consumption but high connection latency
+  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_ENERGY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief  Enumerations of connected Bluetooth device event role.
+/// @since_tizen 2.3
+abstract class bt_socket_role_e {
+  /// < Unknown role
+  static const int BT_SOCKET_UNKNOWN = 0;
+
+  /// < Server role
+  static const int BT_SOCKET_SERVER = 1;
+
+  /// < Client role
+  static const int BT_SOCKET_CLIENT = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief  Enumerations of Bluetooth socket connection state.
+/// @since_tizen 2.3
+abstract class bt_socket_connection_state_e {
+  /// < RFCOMM is connected
+  static const int BT_SOCKET_CONNECTED = 0;
+
+  /// < RFCOMM is disconnected
+  static const int BT_SOCKET_DISCONNECTED = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
+/// @brief  Enumerations for the types of profiles related with audio.
+/// @since_tizen 2.3
+abstract class bt_audio_profile_type_e {
+  /// < All supported profiles related with audio (Both Host and Device role)
+  static const int BT_AUDIO_PROFILE_TYPE_ALL = 0;
+
+  /// < local device AG and remote device HF Client (Host role, ex: mobile)
+  static const int BT_AUDIO_PROFILE_TYPE_HSP_HFP = 1;
+
+  /// < A2DP Source Connection, remote device is A2DP Sink (Host role, ex: mobile)
+  static const int BT_AUDIO_PROFILE_TYPE_A2DP = 2;
+
+  /// < local device HF Client and remote device AG (Device role, ex: headset)
+  static const int BT_AUDIO_PROFILE_TYPE_AG = 3;
+
+  /// < A2DP Sink Connection, remote device is A2DP Source (Device role, ex: headset)
+  static const int BT_AUDIO_PROFILE_TYPE_A2DP_SINK = 4;
+}
+
+/// @internal
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_AG_MODULE
+/// @brief  Enumerations for the call handling event.
+/// @since_tizen 2.3
+abstract class bt_ag_call_handling_event_e {
+  /// < Request to answer an incoming call
+  static const int BT_AG_CALL_HANDLING_EVENT_ANSWER = 0;
+
+  /// < Request to release a call
+  static const int BT_AG_CALL_HANDLING_EVENT_RELEASE = 1;
+
+  /// < Request to reject an incoming call
+  static const int BT_AG_CALL_HANDLING_EVENT_REJECT = 2;
+}
+
+/// @internal
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_AG_MODULE
+/// @brief  Enumerations for the multi call handling event.
+/// @since_tizen 2.3
+abstract class bt_ag_multi_call_handling_event_e {
+  /// < Request to release held calls
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_RELEASE_HELD_CALLS = 0;
+
+  /// < Request to release active calls
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_RELEASE_ACTIVE_CALLS = 1;
+
+  /// < Request to put active calls into hold state and activate another (held or waiting) call
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_ACTIVATE_HELD_CALL = 2;
+
+  /// < Request to add a held call to the conversation
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_MERGE_CALLS = 3;
+
+  /// < Request to let a user who has two calls to connect these two calls together and release its connections to both other parties
+  static const int BT_AG_MULTI_CALL_HANDLING_EVENT_EXPLICIT_CALL_TRANSFER = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the equalizer state.
+/// @since_tizen 2.4
+abstract class bt_avrcp_equalizer_state_e {
+  /// < Equalizer Off
+  static const int BT_AVRCP_EQUALIZER_STATE_OFF = 1;
+
+  /// < Equalizer On
+  static const int BT_AVRCP_EQUALIZER_STATE_ON = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the repeat mode.
+/// @since_tizen 2.4
+abstract class bt_avrcp_repeat_mode_e {
+  /// < Repeat Off
+  static const int BT_AVRCP_REPEAT_MODE_OFF = 1;
+
+  /// < Single track repeat
+  static const int BT_AVRCP_REPEAT_MODE_SINGLE_TRACK = 2;
+
+  /// < All track repeat
+  static const int BT_AVRCP_REPEAT_MODE_ALL_TRACK = 3;
+
+  /// < Group repeat
+  static const int BT_AVRCP_REPEAT_MODE_GROUP = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the shuffle mode.
+/// @since_tizen 2.4
+abstract class bt_avrcp_shuffle_mode_e {
+  /// < Shuffle Off
+  static const int BT_AVRCP_SHUFFLE_MODE_OFF = 1;
+
+  /// < All tracks shuffle
+  static const int BT_AVRCP_SHUFFLE_MODE_ALL_TRACK = 2;
+
+  /// < Group shuffle
+  static const int BT_AVRCP_SHUFFLE_MODE_GROUP = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the scan mode.
+/// @since_tizen 2.4
+abstract class bt_avrcp_scan_mode_e {
+  /// < Scan Off
+  static const int BT_AVRCP_SCAN_MODE_OFF = 1;
+
+  /// < All tracks scan
+  static const int BT_AVRCP_SCAN_MODE_ALL_TRACK = 2;
+
+  /// < Group scan
+  static const int BT_AVRCP_SCAN_MODE_GROUP = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumerations for the player state.
+/// @since_tizen 3.0
+abstract class bt_avrcp_player_state_e {
+  /// < Stopped
+  static const int BT_AVRCP_PLAYER_STATE_STOPPED = 0;
+
+  /// < Playing
+  static const int BT_AVRCP_PLAYER_STATE_PLAYING = 1;
+
+  /// < Paused
+  static const int BT_AVRCP_PLAYER_STATE_PAUSED = 2;
+
+  /// < Seek Forward
+  static const int BT_AVRCP_PLAYER_STATE_FORWARD_SEEK = 3;
+
+  /// < Seek Rewind
+  static const int BT_AVRCP_PLAYER_STATE_REWIND_SEEK = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief  Enumeration for the player control commands.
+/// @since_tizen 3.0
+abstract class bt_avrcp_player_command_e {
+  /// < Play
+  static const int BT_AVRCP_CONTROL_PLAY = 1;
+
+  /// < Pause
+  static const int BT_AVRCP_CONTROL_PAUSE = 2;
+
+  /// < Stop
+  static const int BT_AVRCP_CONTROL_STOP = 3;
+
+  /// < Next Track
+  static const int BT_AVRCP_CONTROL_NEXT = 4;
+
+  /// < Previous track
+  static const int BT_AVRCP_CONTROL_PREVIOUS = 5;
+
+  /// < Fast Forward
+  static const int BT_AVRCP_CONTROL_FAST_FORWARD = 6;
+
+  /// < Rewind
+  static const int BT_AVRCP_CONTROL_REWIND = 7;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
+/// @brief Structure of Track metadata information.
+/// @since_tizen 3.0
+///
+/// @see #bt_class_s
+final class bt_avrcp_metadata_attributes_info_s extends ffi.Struct {
+  /// < Title
+  external ffi.Pointer<ffi.Char> title;
+
+  /// < Artist
+  external ffi.Pointer<ffi.Char> artist;
+
+  /// < Album name
+  external ffi.Pointer<ffi.Char> album;
+
+  /// < Album Genre
+  external ffi.Pointer<ffi.Char> genre;
+
+  /// < The total number of tracks
+  @ffi.UnsignedInt()
+  external int total_tracks;
+
+  /// < Track number
+  @ffi.UnsignedInt()
+  external int number;
+
+  /// < Duration
+  @ffi.UnsignedInt()
+  external int duration;
+}
+
+/// @deprecated Deprecated since 5.0.
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
+/// @brief  Enumerations for the data channel type.
+/// @since_tizen 2.3
+/// @remarks Deprecated, because of no usecase and supported devices.
+abstract class bt_hdp_channel_type_e {
+  /// < Reliable Data Channel
+  static const int BT_HDP_CHANNEL_TYPE_RELIABLE = 1;
+
+  /// < Streaming Data Channel
+  static const int BT_HDP_CHANNEL_TYPE_STREAMING = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the integer type for GATT handle's value.
+/// @since_tizen 2.3.1
+abstract class bt_data_type_int_e {
+  /// < 8 bit signed int type
+  static const int BT_DATA_TYPE_SINT8 = 0;
+
+  /// < 16 bit signed int type
+  static const int BT_DATA_TYPE_SINT16 = 1;
+
+  /// < 32 bit signed int type
+  static const int BT_DATA_TYPE_SINT32 = 2;
+
+  /// < 8 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT8 = 3;
+
+  /// < 16 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT16 = 4;
+
+  /// < 32 bit unsigned int type
+  static const int BT_DATA_TYPE_UINT32 = 5;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the float type for GATT handle's value.
+/// @since_tizen 2.3.1
+abstract class bt_data_type_float_e {
+  /// < 32 bit float type
+  static const int BT_DATA_TYPE_FLOAT = 0;
+
+  /// < 16 bit float type
+  static const int BT_DATA_TYPE_SFLOAT = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the write type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_write_type_e {
+  /// < Write without response type
+  static const int BT_GATT_WRITE_TYPE_WRITE_NO_RESPONSE = 0;
+
+  /// < Write type
+  static const int BT_GATT_WRITE_TYPE_WRITE = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the GATT handle's type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_type_e {
+  /// < GATT service type
+  static const int BT_GATT_TYPE_SERVICE = 1;
+
+  /// < GATT characteristic type
+  static const int BT_GATT_TYPE_CHARACTERISTIC = 2;
+
+  /// < GATT descriptor type
+  static const int BT_GATT_TYPE_DESCRIPTOR = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the service type.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_service_type_e {
+  /// < GATT primary service type
+  static const int BT_GATT_SERVICE_TYPE_PRIMARY = 1;
+
+  /// < GATT secondary service type
+  static const int BT_GATT_SERVICE_TYPE_SECONDARY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the characteristic's property.
+/// @since_tizen 2.3.1
+abstract class bt_gatt_property_e {
+  /// < Broadcast property
+  static const int BT_GATT_PROPERTY_BROADCAST = 1;
+
+  /// < Read property
+  static const int BT_GATT_PROPERTY_READ = 2;
+
+  /// < Write without response property
+  static const int BT_GATT_PROPERTY_WRITE_WITHOUT_RESPONSE = 4;
+
+  /// < Write property
+  static const int BT_GATT_PROPERTY_WRITE = 8;
+
+  /// < Notify property
+  static const int BT_GATT_PROPERTY_NOTIFY = 16;
+
+  /// < Indicate property
+  static const int BT_GATT_PROPERTY_INDICATE = 32;
+
+  /// < Authenticated signed writes property
+  static const int BT_GATT_PROPERTY_AUTHENTICATED_SIGNED_WRITES = 64;
+
+  /// < Extended properties
+  static const int BT_GATT_PROPERTY_EXTENDED_PROPERTIES = 128;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
+/// @brief  Enumerations of gatt server's service changing mode.
+/// @since_tizen 3.0
+abstract class bt_gatt_client_service_change_type_e {
+  /// < Service added
+  static const int BT_GATT_CLIENT_SERVICE_ADDED = 0;
+
+  /// < Service removed
+  static const int BT_GATT_CLIENT_SERVICE_REMOVED = 1;
+
+  /// < Resync is required (Since 6.5)
+  static const int BT_GATT_CLIENT_SERVICE_RESYNC = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
+/// @brief  Enumerations of the attribute's permission.
+/// @since_tizen 3.0
+abstract class bt_gatt_permission_e {
+  /// < Readable permission
+  static const int BT_GATT_PERMISSION_READ = 1;
+
+  /// < Writable permission
+  static const int BT_GATT_PERMISSION_WRITE = 2;
+
+  /// < Readable permission required encryption
+  static const int BT_GATT_PERMISSION_ENCRYPT_READ = 4;
+
+  /// < Writable permission required encryption
+  static const int BT_GATT_PERMISSION_ENCRYPT_WRITE = 8;
+
+  /// < Readable permission required encryption and authentication
+  static const int BT_GATT_PERMISSION_ENCRYPT_AUTHENTICATED_READ = 16;
+
+  /// < Writable permission required encryption and authentication
+  static const int BT_GATT_PERMISSION_ENCRYPT_AUTHENTICATED_WRITE = 32;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
+/// @brief  Enumerations of the remote device request types for attributes.
+/// @since_tizen 3.0
+abstract class bt_gatt_att_request_type_e {
+  /// < Read Requested
+  static const int BT_GATT_REQUEST_TYPE_READ = 0;
+
+  /// < Write Requested
+  static const int BT_GATT_REQUEST_TYPE_WRITE = 1;
+}
+
+/// @internal
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PAN_NAP_MODULE
+/// @brief  Enumerations for the types of PAN (Personal Area Networking) service.
+/// @since_tizen 2.3
+abstract class bt_panu_service_type_e {
+  /// < Network Access Point
+  static const int BT_PANU_SERVICE_TYPE_NAP = 0;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of address book location for PBAP.
+/// @since_tizen 3.0
+abstract class bt_pbap_address_book_source_e {
+  /// < Request for Addressbook from remote device
+  static const int BT_PBAP_SOURCE_DEVICE = 0;
+
+  /// < Request for address book from SIM
+  static const int BT_PBAP_SOURCE_SIM = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of folder type.
+/// @since_tizen 3.0
+abstract class bt_pbap_folder_type_e {
+  /// < Request for address book
+  static const int BT_PBAP_FOLDER_PHONE_BOOK = 0;
+
+  /// < Request for incoming calls
+  static const int BT_PBAP_FOLDER_INCOMING = 1;
+
+  /// < Request for outgoing calls
+  static const int BT_PBAP_FOLDER_OUTGOING = 2;
+
+  /// < Request for missed calls
+  static const int BT_PBAP_FOLDER_MISSED = 3;
+
+  /// < Request for combined calls
+  static const int BT_PBAP_FOLDER_COMBINED = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of phone book search fields.
+/// @since_tizen 3.0
+abstract class bt_pbap_search_field_e {
+  /// < Request for search by name (default)
+  static const int BT_PBAP_SEARCH_NAME = 0;
+
+  /// < Request for search by phone number
+  static const int BT_PBAP_SEARCH_NUMBER = 1;
+
+  /// < Request for search by sound
+  static const int BT_PBAP_SEARCH_SOUND = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of vCard Formats.
+/// @since_tizen 3.0
+abstract class bt_pbap_vcard_format_e {
+  /// < vCard format 2.1 (default)
+  static const int BT_PBAP_VCARD_FORMAT_VCARD21 = 0;
+
+  /// < vCard format 3.0
+  static const int BT_PBAP_VCARD_FORMAT_VCARD30 = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief  Enumeration of sorting orders.
+/// @since_tizen 3.0
+abstract class bt_pbap_sort_order_e {
+  /// < Filter order indexed (default)
+  static const int BT_PBAP_ORDER_INDEXED = 0;
+
+  /// < Filter order alphanumeric
+  static const int BT_PBAP_ORDER_ALPHANUMERIC = 1;
+
+  /// < Filter order phonetic
+  static const int BT_PBAP_ORDER_PHONETIC = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Class structure of device and service.
+/// @since_tizen 2.3
+///
+/// @see #bt_device_info_s
+/// @see #bt_adapter_device_discovery_info_s
+/// @see bt_device_bond_created_cb()
+/// @see bt_adapter_device_discovery_state_changed_cb()
+final class bt_class_s extends ffi.Struct {
+  /// < Major device class.
+  @ffi.Int32()
+  external int major_device_class;
+
+  /// < Minor device class.
+  @ffi.Int32()
+  external int minor_device_class;
+
+  /// < Major service class mask.
+  /// This value can be a combination of #bt_major_service_class_e like #BT_MAJOR_SERVICE_CLASS_RENDERING | #BT_MAJOR_SERVICE_CLASS_AUDIO
+  @ffi.Int()
+  external int major_service_class_mask;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief Structure of device discovery information.
+/// @since_tizen 2.3
+///
+/// @see #bt_class_s
+/// @see bt_adapter_device_discovery_state_changed_cb()
+final class bt_adapter_device_discovery_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The name of remote device
+  external ffi.Pointer<ffi.Char> remote_name;
+
+  /// < The Bluetooth classes
+  external bt_class_s bt_class;
+
+  /// < The strength indicator of received signal
+  @ffi.Int()
+  external int rssi;
+
+  /// < The bonding state
+  @ffi.Bool()
+  external bool is_bonded;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services
+  @ffi.Int()
+  external int service_count;
+
+  /// < The Bluetooth appearance
+  @ffi.Int32()
+  external int appearance;
+
+  /// < manufacturer specific data length
+  @ffi.Int()
+  external int manufacturer_data_len;
+
+  /// < manufacturer specific data
+  external ffi.Pointer<ffi.Char> manufacturer_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief Structure of le scan result information.
+/// @since_tizen 2.3.1
+///
+/// @see bt_adapter_le_start_scan()
+final class bt_adapter_le_device_scan_result_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The address type of remote device
+  @ffi.Int32()
+  external int address_type;
+
+  /// < The strength indicator of received signal
+  @ffi.Int()
+  external int rssi;
+
+  /// < advertising indication data length
+  @ffi.Int()
+  external int adv_data_len;
+
+  /// < advertising indication data
+  external ffi.Pointer<ffi.Char> adv_data;
+
+  /// < scan response data length
+  @ffi.Int()
+  external int scan_data_len;
+
+  /// < scan response data
+  external ffi.Pointer<ffi.Char> scan_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief The structure for LE iBeacon scan result information.
+/// @since_tizen 4.0
+///
+/// @see bt_adapter_le_start_scan()
+final class bt_adapter_le_ibeacon_scan_result_info_s extends ffi.Struct {
+  /// < Company ID
+  @ffi.Int()
+  external int company_id;
+
+  /// < iBeacon type
+  @ffi.Int()
+  external int ibeacon_type;
+
+  /// < UUID
+  external ffi.Pointer<ffi.Char> uuid;
+
+  /// < Major ID
+  @ffi.Int()
+  external int major_id;
+
+  /// < Minor ID
+  @ffi.Int()
+  external int minor_id;
+
+  /// < Measured power
+  @ffi.Int()
+  external int measured_power;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief LE service data structure.
+/// @since_tizen 2.3.1
+///
+/// @see bt_adapter_le_get_scan_result_service_data()
+final class bt_adapter_le_service_data_s extends ffi.Struct {
+  /// < 16 bit UUID of the service data
+  external ffi.Pointer<ffi.Char> service_uuid;
+
+  /// < Service data
+  external ffi.Pointer<ffi.Char> service_data;
+
+  /// < Service data length
+  @ffi.Int()
+  external int service_data_len;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Device information structure used for identifying pear device.
+/// @since_tizen 2.3
+///
+/// @see #bt_class_s
+/// @see bt_device_bond_created_cb()
+final class bt_device_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The name of remote device
+  external ffi.Pointer<ffi.Char> remote_name;
+
+  /// < The Bluetooth classes
+  external bt_class_s bt_class;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services
+  @ffi.Int()
+  external int service_count;
+
+  /// < The bonding state
+  @ffi.Bool()
+  external bool is_bonded;
+
+  /// < The connection state
+  @ffi.Bool()
+  external bool is_connected;
+
+  /// < The authorization state
+  @ffi.Bool()
+  external bool is_authorized;
+
+  /// < manufacturer specific data length
+  @ffi.Int()
+  external int manufacturer_data_len;
+
+  /// < manufacturer specific data
+  external ffi.Pointer<ffi.Char> manufacturer_data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Service Discovery Protocol (SDP) data structure.
+///
+/// @details This protocol is used for discovering available services or pear device,
+/// and finding one to connect with.
+///
+/// @since_tizen 2.3
+/// @see bt_device_service_searched_cb()
+final class bt_device_sdp_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The UUID list of service
+  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
+
+  /// < The number of services.
+  @ffi.Int()
+  external int service_count;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
+/// @brief Device connection information structure.
+/// @since_tizen 2.3
+///
+/// @see bt_device_connection_state_changed_cb()
+final class bt_device_connection_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < Link type
+  @ffi.Int32()
+  external int link;
+
+  /// < Disconnection reason
+  @ffi.Int32()
+  external int disconn_reason;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief Rfcomm connection data used for exchanging data between Bluetooth devices.
+/// @since_tizen 2.3
+///
+/// @see bt_socket_connection_state_changed_cb()
+final class bt_socket_connection_s extends ffi.Struct {
+  /// < The file descriptor of connected socket
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The file descriptor of the server socket or -1 for client connection
+  @ffi.Int()
+  external int server_fd;
+
+  /// < The local device role in this connection
+  @ffi.Int32()
+  external int local_role;
+
+  /// < The remote device address
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The service UUId
+  external ffi.Pointer<ffi.Char> service_uuid;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief Structure of RFCOMM received data.
+/// @since_tizen 2.3
+///
+/// @remarks User can use standard linux functions for reading/writing \n
+/// data from/to sockets.
+///
+/// @see bt_socket_data_received_cb()
+final class bt_socket_received_data_s extends ffi.Struct {
+  /// < The socket fd
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The length of the received data
+  @ffi.Int()
+  external int data_size;
+
+  /// < The received data
+  external ffi.Pointer<ffi.Char> data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
+/// @brief Attribute protocol MTU change information structure.
+/// @since_tizen 4.0
+///
+/// @see bt_gatt_client_att_mtu_changed_cb()
+final class bt_gatt_client_att_mtu_info_s extends ffi.Struct {
+  /// < The address of remote device
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < MTU value
+  @ffi.UnsignedInt()
+  external int mtu;
+
+  /// < Request status
+  @ffi.UnsignedInt()
+  external int status;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID mouse's button.
+/// @since_tizen 3.0
+abstract class bt_hid_mouse_button_e {
+  /// <The mouse's none value
+  static const int BT_HID_MOUSE_BUTTON_NONE = 0;
+
+  /// <The mouse's left button value
+  static const int BT_HID_MOUSE_BUTTON_LEFT = 1;
+
+  /// <The mouse's right button value
+  static const int BT_HID_MOUSE_BUTTON_RIGHT = 2;
+
+  /// <The mouse's middle button value
+  static const int BT_HID_MOUSE_BUTTON_MIDDLE = 4;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing the HID mouse event information.
+/// @since_tizen 3.0
+///
+/// @see bt_hid_device_send_mouse_event()
+final class bt_hid_mouse_data_s extends ffi.Struct {
+  /// < The button values, we can combine key's values when we pressed multiple mouse buttons
+  @ffi.Int()
+  external int buttons;
+
+  /// < The location's x value, -128 ~127
+  @ffi.Int()
+  external int axis_x;
+
+  /// < The location's y value, -128 ~127
+  @ffi.Int()
+  external int axis_y;
+
+  /// < The padding value, -128 ~127
+  @ffi.Int()
+  external int padding;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing the HID keyboard event information.
+/// @details If you want to know more detail values, refer to http://www.usb.org/developers/hidpage/ and see "HID Usage Tables"
+/// @since_tizen 3.0
+///
+/// @see bt_hid_device_send_key_event()
+final class bt_hid_key_data_s extends ffi.Struct {
+  /// < The modifier keys : such as shift, alt
+  @ffi.UnsignedChar()
+  external int modifier;
+
+  /// < The key value - currently pressed keys : Max 8 at once
+  @ffi.Array.multi([8])
+  external ffi.Array<ffi.UnsignedChar> key;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID header type.
+/// @since_tizen 3.0
+abstract class bt_hid_header_type_e {
+  /// < The Bluetooth HID header type: Handshake
+  static const int BT_HID_HEADER_HANDSHAKE = 0;
+
+  /// < The Bluetooth HID header type: HID control
+  static const int BT_HID_HEADER_HID_CONTROL = 1;
+
+  /// < The Bluetooth HID header type: Get report
+  static const int BT_HID_HEADER_GET_REPORT = 2;
+
+  /// < The Bluetooth HID header type: Set report
+  static const int BT_HID_HEADER_SET_REPORT = 3;
+
+  /// < The Bluetooth HID header type: Get protocol
+  static const int BT_HID_HEADER_GET_PROTOCOL = 4;
+
+  /// < The Bluetooth HID header type: Set protocol
+  static const int BT_HID_HEADER_SET_PROTOCOL = 5;
+
+  /// < The Bluetooth HID header type: Data
+  static const int BT_HID_HEADER_DATA = 6;
+
+  /// < The Bluetooth HID header type: Unknown
+  static const int BT_HID_HEADER_UNKNOWN = 7;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID parameter type.
+/// @since_tizen 3.0
+abstract class bt_hid_param_type_e {
+  /// < Parameter type: Input
+  static const int BT_HID_PARAM_DATA_RTYPE_INPUT = 0;
+
+  /// < Parameter type: Output
+  static const int BT_HID_PARAM_DATA_RTYPE_OUTPUT = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief Enumerations of the Bluetooth HID handshake type.
+/// @since_tizen 3.0
+abstract class bt_hid_handshake_type_e {
+  /// < Handshake error code none
+  static const int BT_HID_HANDSHAKE_SUCCESSFUL = 0;
+
+  /// < Handshake error code Not Ready
+  static const int BT_HID_HANDSHAKE_NOT_READY = 1;
+
+  /// < Handshake error code send invalid report id
+  static const int BT_HID_HANDSHAKE_ERR_INVALID_REPORT_ID = 2;
+
+  /// < Handshake error code request unsupported request
+  static const int BT_HID_HANDSHAKE_ERR_UNSUPPORTED_REQUEST = 3;
+
+  /// < Handshake error code received invalid parameter
+  static const int BT_HID_HANDSHAKE_ERR_INVALID_PARAMETER = 4;
+
+  /// < unknown error
+  static const int BT_HID_HANDSHAKE_ERR_UNKNOWN = 14;
+
+  /// < Fatal error
+  static const int BT_HID_HANDSHAKE_ERR_FATAL = 15;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
+/// @brief The structure type containing data received from the HID Host.
+/// @since_tizen 3.0
+final class bt_hid_device_received_data_s extends ffi.Struct {
+  /// < The remote device's address
+  external ffi.Pointer<ffi.Char> address;
+
+  /// < The header type
+  @ffi.Int32()
+  external int header_type;
+
+  /// < The parameter type
+  @ffi.Int32()
+  external int param_type;
+
+  /// < The length of the received data
+  @ffi.Int()
+  external int data_size;
+
+  /// < The received data
+  external ffi.Pointer<ffi.Char> data;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
+/// @brief The structure type containing vCard information.
+/// @since_tizen 3.0
+///
+/// @see bt_pbap_client_pull_vcard()
+final class bt_pbap_vcard_info_s extends ffi.Struct {
+  /// < The vcard index, used as a parameter for bt_pbap_client_pull_vcard()
+  @ffi.Int()
+  external int index;
+
+  /// < The contact name of the vCard
+  external ffi.Pointer<ffi.Char> contact_name;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
+/// @brief Enumeration for the scan filter type.
+/// @since_tizen 4.0
+/// @see bt_adapter_le_scan_filter_set_type()
+abstract class bt_adapter_le_scan_filter_type_e {
+  /// < iBeacon filter type
+  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_IBEACON = 0;
+
+  /// < Proximity UUID filter type
+  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_PROXIMITY_UUID = 1;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
+/// @brief L2CAP CoC connection data used for exchanging data between Bluetooth devices.
+/// @since_tizen 7.0
+///
+/// @see bt_socket_l2cap_channel_connection_state_changed_cb()
+final class bt_socket_l2cap_le_connection_s extends ffi.Struct {
+  /// < The file descriptor of connected socket
+  @ffi.Int()
+  external int socket_fd;
+
+  /// < The file descriptor of the server socket or -1 for client connection
+  @ffi.Int()
+  external int server_fd;
+
+  /// < The local device role in this connection
+  @ffi.Int32()
+  external int local_role;
+
+  /// < The remote device address
+  external ffi.Pointer<ffi.Char> remote_address;
+
+  /// < The psm of the connected socket
+  @ffi.Int()
+  external int psm;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_ADV_EXT_MODULE
+/// @brief Enumerations of the Bluetooth LE scan role.
+/// @since_tizen 8.0
+abstract class bt_adapter_le_scan_role_e {
+  /// < Scan all
+  static const int BT_ADAPTER_LE_SCAN_ALL = 0;
+
+  /// < Legacy scan only
+  static const int BT_ADAPTER_LE_SCAN_LEGACY_ONLY = 1;
+
+  /// < Extended scan only
+  static const int BT_ADAPTER_LE_SCAN_EXTENDED_ONLY = 2;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_ADV_EXT_MODULE
+/// @brief Enumerations of the Bluetooth LE phy.
+/// @since_tizen 8.0
+abstract class bt_adapter_le_phy_e {
+  /// < All phy
+  static const int BT_LE_ALL_PHY = 0;
+
+  /// < 1M phy
+  static const int BT_LE_1M_PHY = 1;
+
+  /// < 2M phy
+  static const int BT_LE_2M_PHY = 2;
+
+  /// < Coded phy
+  static const int BT_LE_CODED_PHY = 3;
+}
+
+/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
+/// @brief  Called when you get bonded devices repeatedly.
+/// @since_tizen 2.3
+///
+/// @param[in] device_info The bonded device information
+/// @param[in] user_data The user data passed from the foreach function
+/// @return @c true to continue with the next iteration of the loop,
+/// \n @c false to break out of the loop.
+/// @pre bt_adapter_foreach_bonded_device() will invoke this function.
+///
+/// @see bt_adapter_foreach_bonded_device()
+typedef bt_adapter_bonded_device_cb
+    = ffi.Pointer<ffi.NativeFunction<bt_adapter_bonded_device_cbFunction>>;
+typedef bt_adapter_bonded_device_cbFunction = ffi.Bool Function(
+    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
+typedef Dartbt_adapter_bonded_device_cbFunction = bool Function(
+    ffi.Pointer<bt_device_info_s> device_info, ffi.Pointer<ffi.Void> user_data);
+
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
 /// @brief  Called when the Bluetooth adapter state changes.
 /// @since_tizen 2.3
@@ -11337,80 +12681,6 @@ typedef Dartbt_adapter_device_discovery_state_changed_cbFunction
         ffi.Pointer<bt_adapter_device_discovery_info_s> discovery_info,
         ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief Enumerations of the discovery state of Bluetooth device.
-/// @since_tizen 2.3
-abstract class bt_adapter_device_discovery_state_e {
-  /// < Device discovery is started
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_STARTED = 0;
-
-  /// < Device discovery is finished
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_FINISHED = 1;
-
-  /// < The remote Bluetooth device is found
-  static const int BT_ADAPTER_DEVICE_DISCOVERY_FOUND = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_MODULE
-/// @brief Structure of device discovery information.
-/// @since_tizen 2.3
-///
-/// @see #bt_class_s
-/// @see bt_adapter_device_discovery_state_changed_cb()
-final class bt_adapter_device_discovery_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The name of remote device
-  external ffi.Pointer<ffi.Char> remote_name;
-
-  /// < The Bluetooth classes
-  external bt_class_s bt_class;
-
-  /// < The strength indicator of received signal
-  @ffi.Int()
-  external int rssi;
-
-  /// < The bonding state
-  @ffi.Bool()
-  external bool is_bonded;
-
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
-
-  /// < The number of services
-  @ffi.Int()
-  external int service_count;
-
-  /// < The Bluetooth appearance
-  @ffi.Int32()
-  external int appearance;
-
-  /// < manufacturer specific data length
-  @ffi.Int()
-  external int manufacturer_data_len;
-
-  /// < manufacturer specific data
-  external ffi.Pointer<ffi.Char> manufacturer_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief  Enumerations of gap appearance type.
-/// @since_tizen 2.3
-abstract class bt_appearance_type_e {
-  /// < Unknown appearance type
-  static const int BT_APPEARANCE_TYPE_UNKNOWN = 0;
-
-  /// < Generic Phone type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_PHONE = 64;
-
-  /// < Generic Computer type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_COMPUTER = 128;
-
-  /// < Generic Watch type - Generic category
-  static const int BT_APPEARANCE_TYPE_GENERIC_WATCH = 192;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief  Called when the LE advertisement has been found.
 /// @since_tizen 2.3.1
@@ -11430,107 +12700,6 @@ typedef Dartbt_adapter_le_scan_result_cbFunction = void Function(
     int result,
     ffi.Pointer<bt_adapter_le_device_scan_result_info_s> info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief Structure of le scan result information.
-/// @since_tizen 2.3.1
-///
-/// @see bt_adapter_le_start_scan()
-final class bt_adapter_le_device_scan_result_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The address type of remote device
-  @ffi.Int32()
-  external int address_type;
-
-  /// < The strength indicator of received signal
-  @ffi.Int()
-  external int rssi;
-
-  /// < advertising indication data length
-  @ffi.Int()
-  external int adv_data_len;
-
-  /// < advertising indication data
-  external ffi.Pointer<ffi.Char> adv_data;
-
-  /// < scan response data length
-  @ffi.Int()
-  external int scan_data_len;
-
-  /// < scan response data
-  external ffi.Pointer<ffi.Char> scan_data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device address type.
-/// @since_tizen 2.3
-abstract class bt_device_address_type_e {
-  /// < Public address
-  static const int BT_DEVICE_PUBLIC_ADDRESS = 0;
-
-  /// < Random address
-  static const int BT_DEVICE_RANDOM_ADDRESS = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth LE packet type.
-/// @since_tizen 2.3
-abstract class bt_adapter_le_packet_type_e {
-  /// < Advertising packet
-  static const int BT_ADAPTER_LE_PACKET_ADVERTISING = 0;
-
-  /// < Scan response packet
-  static const int BT_ADAPTER_LE_PACKET_SCAN_RESPONSE = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief LE service data structure.
-/// @since_tizen 2.3.1
-///
-/// @see bt_adapter_le_get_scan_result_service_data()
-final class bt_adapter_le_service_data_s extends ffi.Struct {
-  /// < 16 bit UUID of the service data
-  external ffi.Pointer<ffi.Char> service_uuid;
-
-  /// < Service data
-  external ffi.Pointer<ffi.Char> service_data;
-
-  /// < Service data length
-  @ffi.Int()
-  external int service_data_len;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief The structure for LE iBeacon scan result information.
-/// @since_tizen 4.0
-///
-/// @see bt_adapter_le_start_scan()
-final class bt_adapter_le_ibeacon_scan_result_info_s extends ffi.Struct {
-  /// < Company ID
-  @ffi.Int()
-  external int company_id;
-
-  /// < iBeacon type
-  @ffi.Int()
-  external int ibeacon_type;
-
-  /// < UUID
-  external ffi.Pointer<ffi.Char> uuid;
-
-  /// < Major ID
-  @ffi.Int()
-  external int major_id;
-
-  /// < Minor ID
-  @ffi.Int()
-  external int minor_id;
-
-  /// < Measured power
-  @ffi.Int()
-  external int measured_power;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief The handle to control Bluetooth LE advertising.
@@ -11601,59 +12770,6 @@ typedef Dartbt_adapter_le_advertising_state_changed_cbFunction = void Function(
     int adv_state,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth advertising state.
-/// @since_tizen 2.3
-abstract class bt_adapter_le_advertising_state_e {
-  /// < Bluetooth advertising is stopped
-  static const int BT_ADAPTER_LE_ADVERTISING_STOPPED = 0;
-
-  /// < Bluetooth advertising is started
-  static const int BT_ADAPTER_LE_ADVERTISING_STARTED = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth advertising mode.
-/// @since_tizen 2.3.1
-abstract class bt_adapter_le_advertising_mode_e {
-  /// < Balanced advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_BALANCED = 0;
-
-  /// < Low latency advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_LATENCY = 1;
-
-  /// < Low energy advertising mode
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_LOW_ENERGY = 2;
-
-  /// < Custom mode to set advertising parameters
-  static const int BT_ADAPTER_LE_ADVERTISING_MODE_CUSTOM = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief  Enumerations of the Bluetooth le scan mode.
-/// @since_tizen 3.0
-abstract class bt_adapter_le_scan_mode_e {
-  /// < Balanced mode of power consumption and connection latency
-  static const int BT_ADAPTER_LE_SCAN_MODE_BALANCED = 0;
-
-  /// < Low connection latency but high power consumption
-  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_LATENCY = 1;
-
-  /// < Low power consumption but high connection latency
-  static const int BT_ADAPTER_LE_SCAN_MODE_LOW_ENERGY = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device authorization state.
-/// @since_tizen 2.3
-abstract class bt_device_authorization_e {
-  /// < The remote Bluetooth device is authorized
-  static const int BT_DEVICE_AUTHORIZED = 0;
-
-  /// < The remote Bluetooth device is unauthorized
-  static const int BT_DEVICE_UNAUTHORIZED = 1;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief  Called when you get connected profiles repeatedly.
 /// @since_tizen 2.3
@@ -11670,52 +12786,6 @@ typedef bt_device_connected_profileFunction = ffi.Bool Function(
     ffi.Int32 profile, ffi.Pointer<ffi.Void> user_data);
 typedef Dartbt_device_connected_profileFunction = bool Function(
     int profile, ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of Bluetooth profile.
-/// @since_tizen 2.3
-abstract class bt_profile_e {
-  /// < RFCOMM Profile
-  static const int BT_PROFILE_RFCOMM = 1;
-
-  /// < Advanced Audio Distribution Profile Source role
-  static const int BT_PROFILE_A2DP = 2;
-
-  /// < Headset Profile
-  static const int BT_PROFILE_HSP = 4;
-
-  /// < Human Interface Device Profile
-  static const int BT_PROFILE_HID = 8;
-
-  /// < Network Access Point Profile
-  static const int BT_PROFILE_NAP = 16;
-
-  /// < Audio Gateway Profile
-  static const int BT_PROFILE_AG = 32;
-
-  /// < Generic Attribute Profile
-  static const int BT_PROFILE_GATT = 64;
-
-  /// < NAP server Profile
-  static const int BT_PROFILE_NAP_SERVER = 128;
-
-  /// < Advanced Audio Distribution Profile Sink role
-  static const int BT_PROFILE_A2DP_SINK = 256;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief  Enumerations of the Bluetooth device's LE connection mode.
-/// @since_tizen 3.0
-abstract class bt_device_le_connection_mode_e {
-  /// < Balanced mode of power consumption and connection latency
-  static const int BT_DEVICE_LE_CONNECTION_MODE_BALANCED = 0;
-
-  /// < Low connection latency but high power consumption
-  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_LATENCY = 1;
-
-  /// < Low power consumption but high connection latency
-  static const int BT_DEVICE_LE_CONNECTION_MODE_LOW_ENERGY = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief Called when the process of creating bond finishes.
@@ -11813,26 +12883,6 @@ typedef Dartbt_device_service_searched_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Service Discovery Protocol (SDP) data structure.
-///
-/// @details This protocol is used for discovering available services or pear device,
-/// and finding one to connect with.
-///
-/// @since_tizen 2.3
-/// @see bt_device_service_searched_cb()
-final class bt_device_sdp_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The UUID list of service
-  external ffi.Pointer<ffi.Pointer<ffi.Char>> service_uuid;
-
-  /// < The number of services.
-  @ffi.Int()
-  external int service_count;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
 /// @brief  Called when the connection state is changed.
 /// @since_tizen 2.3
 ///
@@ -11851,58 +12901,6 @@ typedef Dartbt_device_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<bt_device_connection_info_s> conn_info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Device connection information structure.
-/// @since_tizen 2.3
-///
-/// @see bt_device_connection_state_changed_cb()
-final class bt_device_connection_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < Link type
-  @ffi.Int32()
-  external int link;
-
-  /// < Disconnection reason
-  @ffi.Int32()
-  external int disconn_reason;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of connection link type.
-/// @since_tizen 2.3
-abstract class bt_device_connection_link_type_e {
-  /// < BR/EDR link
-  static const int BT_DEVICE_CONNECTION_LINK_BREDR = 0;
-
-  /// < LE link
-  static const int BT_DEVICE_CONNECTION_LINK_LE = 1;
-
-  /// < The connection type default
-  static const int BT_DEVICE_CONNECTION_LINK_DEFAULT = 255;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_DEVICE_MODULE
-/// @brief Enumerations of device disconnect reason.
-/// @since_tizen 2.3
-abstract class bt_device_disconnect_reason_e {
-  /// < Disconnected by unknown reason
-  static const int BT_DEVICE_DISCONNECT_REASON_UNKNOWN = 0;
-
-  /// < Disconnected by timeout
-  static const int BT_DEVICE_DISCONNECT_REASON_TIMEOUT = 1;
-
-  /// < Disconnected by local host
-  static const int BT_DEVICE_DISCONNECT_REASON_LOCAL_HOST = 2;
-
-  /// < Disconnected by remote
-  static const int BT_DEVICE_DISCONNECT_REASON_REMOTE = 3;
-
-  /// < Disconnected by MIC failure (Since 9.0)
-  static const int BT_DEVICE_DISCONNECT_REASON_MIC_FAILURE = 4;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief Called when you receive data.
@@ -11925,27 +12923,6 @@ typedef bt_socket_data_received_cbFunction = ffi.Void Function(
 typedef Dartbt_socket_data_received_cbFunction = void Function(
     ffi.Pointer<bt_socket_received_data_s> data,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief Structure of RFCOMM received data.
-/// @since_tizen 2.3
-///
-/// @remarks User can use standard linux functions for reading/writing \n
-/// data from/to sockets.
-///
-/// @see bt_socket_data_received_cb()
-final class bt_socket_received_data_s extends ffi.Struct {
-  /// < The socket fd
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The length of the received data
-  @ffi.Int()
-  external int data_size;
-
-  /// < The received data
-  external ffi.Pointer<ffi.Char> data;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief  Called when a RFCOMM connection is requested.
@@ -11993,56 +12970,6 @@ typedef Dartbt_socket_connection_state_changed_cbFunction = void Function(
     int connection_state,
     ffi.Pointer<bt_socket_connection_s> connection,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief  Enumerations of Bluetooth socket connection state.
-/// @since_tizen 2.3
-abstract class bt_socket_connection_state_e {
-  /// < RFCOMM is connected
-  static const int BT_SOCKET_CONNECTED = 0;
-
-  /// < RFCOMM is disconnected
-  static const int BT_SOCKET_DISCONNECTED = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief Rfcomm connection data used for exchanging data between Bluetooth devices.
-/// @since_tizen 2.3
-///
-/// @see bt_socket_connection_state_changed_cb()
-final class bt_socket_connection_s extends ffi.Struct {
-  /// < The file descriptor of connected socket
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The file descriptor of the server socket or -1 for client connection
-  @ffi.Int()
-  external int server_fd;
-
-  /// < The local device role in this connection
-  @ffi.Int32()
-  external int local_role;
-
-  /// < The remote device address
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The service UUId
-  external ffi.Pointer<ffi.Char> service_uuid;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief  Enumerations of connected Bluetooth device event role.
-/// @since_tizen 2.3
-abstract class bt_socket_role_e {
-  /// < Unknown role
-  static const int BT_SOCKET_UNKNOWN = 0;
-
-  /// < Server role
-  static const int BT_SOCKET_SERVER = 1;
-
-  /// < Client role
-  static const int BT_SOCKET_CLIENT = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_OPP_SERVER_MODULE
 /// @brief  Called when an OPP connection is requested.
@@ -12214,45 +13141,6 @@ typedef Dartbt_hid_device_connection_state_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing the HID mouse event information.
-/// @since_tizen 3.0
-///
-/// @see bt_hid_device_send_mouse_event()
-final class bt_hid_mouse_data_s extends ffi.Struct {
-  /// < The button values, we can combine key's values when we pressed multiple mouse buttons
-  @ffi.Int()
-  external int buttons;
-
-  /// < The location's x value, -128 ~127
-  @ffi.Int()
-  external int axis_x;
-
-  /// < The location's y value, -128 ~127
-  @ffi.Int()
-  external int axis_y;
-
-  /// < The padding value, -128 ~127
-  @ffi.Int()
-  external int padding;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing the HID keyboard event information.
-/// @details If you want to know more detail values, refer to http://www.usb.org/developers/hidpage/ and see "HID Usage Tables"
-/// @since_tizen 3.0
-///
-/// @see bt_hid_device_send_key_event()
-final class bt_hid_key_data_s extends ffi.Struct {
-  /// < The modifier keys : such as shift, alt
-  @ffi.UnsignedChar()
-  external int modifier;
-
-  /// < The key value - currently pressed keys : Max 8 at once
-  @ffi.Array.multi([8])
-  external ffi.Array<ffi.UnsignedChar> key;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
 /// @brief  Called when the HID Device receives data from the HID Host.
 /// @details The following error codes can be delivered: \n
 /// #BT_ERROR_NONE \n
@@ -12270,89 +13158,6 @@ typedef bt_hid_device_data_received_cbFunction = ffi.Void Function(
 typedef Dartbt_hid_device_data_received_cbFunction = void Function(
     ffi.Pointer<bt_hid_device_received_data_s> data,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief The structure type containing data received from the HID Host.
-/// @since_tizen 3.0
-final class bt_hid_device_received_data_s extends ffi.Struct {
-  /// < The remote device's address
-  external ffi.Pointer<ffi.Char> address;
-
-  /// < The header type
-  @ffi.Int32()
-  external int header_type;
-
-  /// < The parameter type
-  @ffi.Int32()
-  external int param_type;
-
-  /// < The length of the received data
-  @ffi.Int()
-  external int data_size;
-
-  /// < The received data
-  external ffi.Pointer<ffi.Char> data;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief Enumerations of the Bluetooth HID header type.
-/// @since_tizen 3.0
-abstract class bt_hid_header_type_e {
-  /// < The Bluetooth HID header type: Handshake
-  static const int BT_HID_HEADER_HANDSHAKE = 0;
-
-  /// < The Bluetooth HID header type: HID control
-  static const int BT_HID_HEADER_HID_CONTROL = 1;
-
-  /// < The Bluetooth HID header type: Get report
-  static const int BT_HID_HEADER_GET_REPORT = 2;
-
-  /// < The Bluetooth HID header type: Set report
-  static const int BT_HID_HEADER_SET_REPORT = 3;
-
-  /// < The Bluetooth HID header type: Get protocol
-  static const int BT_HID_HEADER_GET_PROTOCOL = 4;
-
-  /// < The Bluetooth HID header type: Set protocol
-  static const int BT_HID_HEADER_SET_PROTOCOL = 5;
-
-  /// < The Bluetooth HID header type: Data
-  static const int BT_HID_HEADER_DATA = 6;
-
-  /// < The Bluetooth HID header type: Unknown
-  static const int BT_HID_HEADER_UNKNOWN = 7;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HID_DEVICE_MODULE
-/// @brief Enumerations of the Bluetooth HID parameter type.
-/// @since_tizen 3.0
-abstract class bt_hid_param_type_e {
-  /// < Parameter type: Input
-  static const int BT_HID_PARAM_DATA_RTYPE_INPUT = 0;
-
-  /// < Parameter type: Output
-  static const int BT_HID_PARAM_DATA_RTYPE_OUTPUT = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
-/// @brief  Enumerations for the types of profiles related with audio.
-/// @since_tizen 2.3
-abstract class bt_audio_profile_type_e {
-  /// < All supported profiles related with audio (Both Host and Device role)
-  static const int BT_AUDIO_PROFILE_TYPE_ALL = 0;
-
-  /// < local device AG and remote device HF Client (Host role, ex: mobile)
-  static const int BT_AUDIO_PROFILE_TYPE_HSP_HFP = 1;
-
-  /// < A2DP Source Connection, remote device is A2DP Sink (Host role, ex: mobile)
-  static const int BT_AUDIO_PROFILE_TYPE_A2DP = 2;
-
-  /// < local device HF Client and remote device AG (Device role, ex: headset)
-  static const int BT_AUDIO_PROFILE_TYPE_AG = 3;
-
-  /// < A2DP Sink Connection, remote device is A2DP Source (Device role, ex: headset)
-  static const int BT_AUDIO_PROFILE_TYPE_A2DP_SINK = 4;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AUDIO_MODULE
 /// @brief  Called when the connection state is changed.
@@ -12401,82 +13206,6 @@ typedef Dartbt_avrcp_target_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<ffi.Char> remote_address,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the equalizer state.
-/// @since_tizen 2.4
-abstract class bt_avrcp_equalizer_state_e {
-  /// < Equalizer Off
-  static const int BT_AVRCP_EQUALIZER_STATE_OFF = 1;
-
-  /// < Equalizer On
-  static const int BT_AVRCP_EQUALIZER_STATE_ON = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the repeat mode.
-/// @since_tizen 2.4
-abstract class bt_avrcp_repeat_mode_e {
-  /// < Repeat Off
-  static const int BT_AVRCP_REPEAT_MODE_OFF = 1;
-
-  /// < Single track repeat
-  static const int BT_AVRCP_REPEAT_MODE_SINGLE_TRACK = 2;
-
-  /// < All track repeat
-  static const int BT_AVRCP_REPEAT_MODE_ALL_TRACK = 3;
-
-  /// < Group repeat
-  static const int BT_AVRCP_REPEAT_MODE_GROUP = 4;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the shuffle mode.
-/// @since_tizen 2.4
-abstract class bt_avrcp_shuffle_mode_e {
-  /// < Shuffle Off
-  static const int BT_AVRCP_SHUFFLE_MODE_OFF = 1;
-
-  /// < All tracks shuffle
-  static const int BT_AVRCP_SHUFFLE_MODE_ALL_TRACK = 2;
-
-  /// < Group shuffle
-  static const int BT_AVRCP_SHUFFLE_MODE_GROUP = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the scan mode.
-/// @since_tizen 2.4
-abstract class bt_avrcp_scan_mode_e {
-  /// < Scan Off
-  static const int BT_AVRCP_SCAN_MODE_OFF = 1;
-
-  /// < All tracks scan
-  static const int BT_AVRCP_SCAN_MODE_ALL_TRACK = 2;
-
-  /// < Group scan
-  static const int BT_AVRCP_SCAN_MODE_GROUP = 3;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumerations for the player state.
-/// @since_tizen 3.0
-abstract class bt_avrcp_player_state_e {
-  /// < Stopped
-  static const int BT_AVRCP_PLAYER_STATE_STOPPED = 0;
-
-  /// < Playing
-  static const int BT_AVRCP_PLAYER_STATE_PLAYING = 1;
-
-  /// < Paused
-  static const int BT_AVRCP_PLAYER_STATE_PAUSED = 2;
-
-  /// < Seek Forward
-  static const int BT_AVRCP_PLAYER_STATE_FORWARD_SEEK = 3;
-
-  /// < Seek Rewind
-  static const int BT_AVRCP_PLAYER_STATE_REWIND_SEEK = 4;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
 /// @brief  Called when the equalizer state is changed by the remote control device.
@@ -12583,37 +13312,6 @@ typedef Dartbt_avrcp_track_info_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief Structure of Track metadata information.
-/// @since_tizen 3.0
-///
-/// @see #bt_class_s
-final class bt_avrcp_metadata_attributes_info_s extends ffi.Struct {
-  /// < Title
-  external ffi.Pointer<ffi.Char> title;
-
-  /// < Artist
-  external ffi.Pointer<ffi.Char> artist;
-
-  /// < Album name
-  external ffi.Pointer<ffi.Char> album;
-
-  /// < Album Genre
-  external ffi.Pointer<ffi.Char> genre;
-
-  /// < The total number of tracks
-  @ffi.UnsignedInt()
-  external int total_tracks;
-
-  /// < Track number
-  @ffi.UnsignedInt()
-  external int number;
-
-  /// < Duration
-  @ffi.UnsignedInt()
-  external int duration;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
 /// @brief  Called when the connection state is changed.
 /// @since_tizen 3.0
 /// @param[in] connected  The state to be changed. true means connected state, Otherwise, false.
@@ -12629,32 +13327,6 @@ typedef bt_avrcp_control_connection_state_changed_cbFunction
 typedef Dartbt_avrcp_control_connection_state_changed_cbFunction
     = void Function(bool connected, ffi.Pointer<ffi.Char> remote_address,
         ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_MODULE
-/// @brief  Enumeration for the player control commands.
-/// @since_tizen 3.0
-abstract class bt_avrcp_player_command_e {
-  /// < Play
-  static const int BT_AVRCP_CONTROL_PLAY = 1;
-
-  /// < Pause
-  static const int BT_AVRCP_CONTROL_PAUSE = 2;
-
-  /// < Stop
-  static const int BT_AVRCP_CONTROL_STOP = 3;
-
-  /// < Next Track
-  static const int BT_AVRCP_CONTROL_NEXT = 4;
-
-  /// < Previous track
-  static const int BT_AVRCP_CONTROL_PREVIOUS = 5;
-
-  /// < Fast Forward
-  static const int BT_AVRCP_CONTROL_FAST_FORWARD = 6;
-
-  /// < Rewind
-  static const int BT_AVRCP_CONTROL_REWIND = 7;
-}
 
 /// @deprecated Deprecated since 5.0.
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
@@ -12686,19 +13358,6 @@ typedef Dartbt_hdp_connected_cbFunction = void Function(
     int type,
     int channel,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @deprecated Deprecated since 5.0.
-/// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
-/// @brief  Enumerations for the data channel type.
-/// @since_tizen 2.3
-/// @remarks Deprecated, because of no usecase and supported devices.
-abstract class bt_hdp_channel_type_e {
-  /// < Reliable Data Channel
-  static const int BT_HDP_CHANNEL_TYPE_RELIABLE = 1;
-
-  /// < Streaming Data Channel
-  static const int BT_HDP_CHANNEL_TYPE_STREAMING = 2;
-}
 
 /// @deprecated Deprecated since 5.0.
 /// @ingroup CAPI_NETWORK_BLUETOOTH_HDP_MODULE
@@ -12752,54 +13411,6 @@ typedef Dartbt_hdp_data_received_cbFunction = void Function(int channel,
 /// @since_tizen 2.3.1
 typedef bt_gatt_h = ffi.Pointer<ffi.Void>;
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the integer type for GATT handle's value.
-/// @since_tizen 2.3.1
-abstract class bt_data_type_int_e {
-  /// < 8 bit signed int type
-  static const int BT_DATA_TYPE_SINT8 = 0;
-
-  /// < 16 bit signed int type
-  static const int BT_DATA_TYPE_SINT16 = 1;
-
-  /// < 32 bit signed int type
-  static const int BT_DATA_TYPE_SINT32 = 2;
-
-  /// < 8 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT8 = 3;
-
-  /// < 16 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT16 = 4;
-
-  /// < 32 bit unsigned int type
-  static const int BT_DATA_TYPE_UINT32 = 5;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the float type for GATT handle's value.
-/// @since_tizen 2.3.1
-abstract class bt_data_type_float_e {
-  /// < 32 bit float type
-  static const int BT_DATA_TYPE_FLOAT = 0;
-
-  /// < 16 bit float type
-  static const int BT_DATA_TYPE_SFLOAT = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the GATT handle's type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_type_e {
-  /// < GATT service type
-  static const int BT_GATT_TYPE_SERVICE = 1;
-
-  /// < GATT characteristic type
-  static const int BT_GATT_TYPE_CHARACTERISTIC = 2;
-
-  /// < GATT descriptor type
-  static const int BT_GATT_TYPE_DESCRIPTOR = 3;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief The handle of a GATT client which is associated with a remote device.
 /// @since_tizen 2.3.1
@@ -12824,17 +13435,6 @@ typedef bt_gatt_foreach_cbFunction = ffi.Bool Function(ffi.Int total,
     ffi.Int index, bt_gatt_h gatt_handle, ffi.Pointer<ffi.Void> user_data);
 typedef Dartbt_gatt_foreach_cbFunction = bool Function(int total, int index,
     bt_gatt_h gatt_handle, ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the write type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_write_type_e {
-  /// < Write without response type
-  static const int BT_GATT_WRITE_TYPE_WRITE_NO_RESPONSE = 0;
-
-  /// < Write type
-  static const int BT_GATT_WRITE_TYPE_WRITE = 1;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief  Called when the client request(e.g. read / write) has been completed.
@@ -12875,24 +13475,6 @@ typedef Dartbt_gatt_client_att_mtu_changed_cbFunction = void Function(
     bt_gatt_client_h client,
     ffi.Pointer<bt_gatt_client_att_mtu_info_s> mtu_info,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
-/// @brief Attribute protocol MTU change information structure.
-/// @since_tizen 4.0
-///
-/// @see bt_gatt_client_att_mtu_changed_cb()
-final class bt_gatt_client_att_mtu_info_s extends ffi.Struct {
-  /// < The address of remote device
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < MTU value
-  @ffi.UnsignedInt()
-  external int mtu;
-
-  /// < Request status
-  @ffi.UnsignedInt()
-  external int status;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
 /// @brief  Called when a value of a watched characteristic's GATT handle has been changed.
@@ -12939,20 +13521,6 @@ typedef Dartbt_gatt_client_service_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Char> service_uuid,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_CLIENT_MODULE
-/// @brief  Enumerations of gatt server's service changing mode.
-/// @since_tizen 3.0
-abstract class bt_gatt_client_service_change_type_e {
-  /// < Service added
-  static const int BT_GATT_CLIENT_SERVICE_ADDED = 0;
-
-  /// < Service removed
-  static const int BT_GATT_CLIENT_SERVICE_REMOVED = 1;
-
-  /// < Resync is required (Since 6.5)
-  static const int BT_GATT_CLIENT_SERVICE_RESYNC = 2;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
 /// @brief Called when the connection state is changed.
 ///
@@ -12981,17 +13549,6 @@ typedef Dartbt_gatt_connection_state_changed_cbFunction = void Function(
     bool connected,
     ffi.Pointer<ffi.Char> remote_address,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_MODULE
-/// @brief  Enumerations of the service type.
-/// @since_tizen 2.3.1
-abstract class bt_gatt_service_type_e {
-  /// < GATT primary service type
-  static const int BT_GATT_SERVICE_TYPE_PRIMARY = 1;
-
-  /// < GATT secondary service type
-  static const int BT_GATT_SERVICE_TYPE_SECONDARY = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
 /// @brief The handle of a GATT server.
@@ -13108,17 +13665,6 @@ typedef Dartbt_gatt_server_write_value_requested_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
-/// @brief  Enumerations of the remote device request types for attributes.
-/// @since_tizen 3.0
-abstract class bt_gatt_att_request_type_e {
-  /// < Read Requested
-  static const int BT_GATT_REQUEST_TYPE_READ = 0;
-
-  /// < Write Requested
-  static const int BT_GATT_REQUEST_TYPE_WRITE = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_GATT_SERVER_MODULE
 /// @brief  Called when the sending notification / indication is done.
 /// @since_tizen 3.0
 ///
@@ -13186,37 +13732,6 @@ typedef Dartbt_pbap_connection_state_changed_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of address book location for PBAP.
-/// @since_tizen 3.0
-abstract class bt_pbap_address_book_source_e {
-  /// < Request for Addressbook from remote device
-  static const int BT_PBAP_SOURCE_DEVICE = 0;
-
-  /// < Request for address book from SIM
-  static const int BT_PBAP_SOURCE_SIM = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of folder type.
-/// @since_tizen 3.0
-abstract class bt_pbap_folder_type_e {
-  /// < Request for address book
-  static const int BT_PBAP_FOLDER_PHONE_BOOK = 0;
-
-  /// < Request for incoming calls
-  static const int BT_PBAP_FOLDER_INCOMING = 1;
-
-  /// < Request for outgoing calls
-  static const int BT_PBAP_FOLDER_OUTGOING = 2;
-
-  /// < Request for missed calls
-  static const int BT_PBAP_FOLDER_MISSED = 3;
-
-  /// < Request for combined calls
-  static const int BT_PBAP_FOLDER_COMBINED = 4;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
 /// @brief  Called when PBAP Phonebook size calculation completes.
 /// @details The following error codes can be delivered: \n
 /// #BT_ERROR_NONE \n
@@ -13242,31 +13757,6 @@ typedef Dartbt_pbap_phone_book_size_cbFunction = void Function(
     ffi.Pointer<ffi.Char> remote_address,
     int size,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of vCard Formats.
-/// @since_tizen 3.0
-abstract class bt_pbap_vcard_format_e {
-  /// < vCard format 2.1 (default)
-  static const int BT_PBAP_VCARD_FORMAT_VCARD21 = 0;
-
-  /// < vCard format 3.0
-  static const int BT_PBAP_VCARD_FORMAT_VCARD30 = 1;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of sorting orders.
-/// @since_tizen 3.0
-abstract class bt_pbap_sort_order_e {
-  /// < Filter order indexed (default)
-  static const int BT_PBAP_ORDER_INDEXED = 0;
-
-  /// < Filter order alphanumeric
-  static const int BT_PBAP_ORDER_ALPHANUMERIC = 1;
-
-  /// < Filter order phonetic
-  static const int BT_PBAP_ORDER_PHONETIC = 2;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
 /// @brief  Called when PBAP Phonebook Pull completes.
@@ -13326,50 +13816,10 @@ typedef Dartbt_pbap_list_vcards_cbFunction = void Function(
     int count,
     ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief The structure type containing vCard information.
-/// @since_tizen 3.0
-///
-/// @see bt_pbap_client_pull_vcard()
-final class bt_pbap_vcard_info_s extends ffi.Struct {
-  /// < The vcard index, used as a parameter for bt_pbap_client_pull_vcard()
-  @ffi.Int()
-  external int index;
-
-  /// < The contact name of the vCard
-  external ffi.Pointer<ffi.Char> contact_name;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_PBAP_MODULE
-/// @brief  Enumeration of phone book search fields.
-/// @since_tizen 3.0
-abstract class bt_pbap_search_field_e {
-  /// < Request for search by name (default)
-  static const int BT_PBAP_SEARCH_NAME = 0;
-
-  /// < Request for search by phone number
-  static const int BT_PBAP_SEARCH_NUMBER = 1;
-
-  /// < Request for search by sound
-  static const int BT_PBAP_SEARCH_SOUND = 2;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
 /// @brief The handle of a Bluetooth LE scan filter.
 /// @since_tizen 4.0
 typedef bt_scan_filter_h = ffi.Pointer<ffi.Void>;
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
-/// @brief Enumeration for the scan filter type.
-/// @since_tizen 4.0
-/// @see bt_adapter_le_scan_filter_set_type()
-abstract class bt_adapter_le_scan_filter_type_e {
-  /// < iBeacon filter type
-  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_IBEACON = 0;
-
-  /// < Proximity UUID filter type
-  static const int BT_ADAPTER_LE_SCAN_FILTER_TYPE_PROXIMITY_UUID = 1;
-}
 
 /// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
 /// @brief  Called when the l2cap channel socket connection state changes.
@@ -13401,32 +13851,6 @@ typedef Dartbt_socket_l2cap_channel_connection_state_changed_cbFunction
         ffi.Pointer<bt_socket_l2cap_le_connection_s> connection,
         ffi.Pointer<ffi.Void> user_data);
 
-/// @ingroup CAPI_NETWORK_BLUETOOTH_SOCKET_MODULE
-/// @brief L2CAP CoC connection data used for exchanging data between Bluetooth devices.
-/// @since_tizen 7.0
-///
-/// @see bt_socket_l2cap_channel_connection_state_changed_cb()
-final class bt_socket_l2cap_le_connection_s extends ffi.Struct {
-  /// < The file descriptor of connected socket
-  @ffi.Int()
-  external int socket_fd;
-
-  /// < The file descriptor of the server socket or -1 for client connection
-  @ffi.Int()
-  external int server_fd;
-
-  /// < The local device role in this connection
-  @ffi.Int32()
-  external int local_role;
-
-  /// < The remote device address
-  external ffi.Pointer<ffi.Char> remote_address;
-
-  /// < The psm of the connected socket
-  @ffi.Int()
-  external int psm;
-}
-
 /// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_ADV_EXT_MODULE
 /// @brief Called when the LE advertisement has been found.
 /// @since_tizen 8.0
@@ -13449,34 +13873,3 @@ typedef Dartbt_adapter_le_new_scan_result_cbFunction = void Function(
 /// @brief The handle of a new scan result.
 /// @since_tizen 8.0
 typedef bt_new_scan_result_h = ffi.Pointer<ffi.Void>;
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_ADV_EXT_MODULE
-/// @brief Enumerations of the Bluetooth LE scan role.
-/// @since_tizen 8.0
-abstract class bt_adapter_le_scan_role_e {
-  /// < Scan all
-  static const int BT_ADAPTER_LE_SCAN_ALL = 0;
-
-  /// < Legacy scan only
-  static const int BT_ADAPTER_LE_SCAN_LEGACY_ONLY = 1;
-
-  /// < Extended scan only
-  static const int BT_ADAPTER_LE_SCAN_EXTENDED_ONLY = 2;
-}
-
-/// @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_ADV_EXT_MODULE
-/// @brief Enumerations of the Bluetooth LE phy.
-/// @since_tizen 8.0
-abstract class bt_adapter_le_phy_e {
-  /// < All phy
-  static const int BT_LE_ALL_PHY = 0;
-
-  /// < 1M phy
-  static const int BT_LE_1M_PHY = 1;
-
-  /// < 2M phy
-  static const int BT_LE_2M_PHY = 2;
-
-  /// < Coded phy
-  static const int BT_LE_CODED_PHY = 3;
-}

--- a/lib/src/bindings/9.0/generated_bindings_capi_system_info.dart
+++ b/lib/src/bindings/9.0/generated_bindings_capi_system_info.dart
@@ -377,6 +377,38 @@ class Tizen90CapiSystemInfo {
           int Function(ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Int32>)>();
 }
 
+/// @brief Enumeration for system information error codes.
+abstract class system_info_error_e {
+  /// < Successful
+  static const int SYSTEM_INFO_ERROR_NONE = 0;
+
+  /// < Invalid parameter
+  static const int SYSTEM_INFO_ERROR_INVALID_PARAMETER = -22;
+
+  /// < Out of memory
+  static const int SYSTEM_INFO_ERROR_OUT_OF_MEMORY = -12;
+
+  /// < An input/output error occurred when reading value from system
+  static const int SYSTEM_INFO_ERROR_IO_ERROR = -5;
+
+  /// < No permission to use the API
+  static const int SYSTEM_INFO_ERROR_PERMISSION_DENIED = -13;
+
+  /// < Not supported parameter (Since 3.0)
+  static const int SYSTEM_INFO_ERROR_NOT_SUPPORTED = -1073741822;
+}
+
+/// @internal
+/// @brief It is not decided if it should be opened to public.
+abstract class system_info_type_e {
+  static const int SYSTEM_INFO_TYPE_MIN = 0;
+  static const int SYSTEM_INFO_BOOL = 0;
+  static const int SYSTEM_INFO_INT = 1;
+  static const int SYSTEM_INFO_DOUBLE = 2;
+  static const int SYSTEM_INFO_STRING = 3;
+  static const int SYSTEM_INFO_TYPE_MAX = 4;
+}
+
 /// @internal
 /// @brief Enumeration for system information key.
 abstract class system_info_key_e {
@@ -424,15 +456,4 @@ abstract class system_info_key_e {
 
   /// < @internal Indicates whether the device supports tethering
   static const int SYSTEM_INFO_KEY_TETHERING_SUPPORTED = 14;
-}
-
-/// @internal
-/// @brief It is not decided if it should be opened to public.
-abstract class system_info_type_e {
-  static const int SYSTEM_INFO_TYPE_MIN = 0;
-  static const int SYSTEM_INFO_BOOL = 0;
-  static const int SYSTEM_INFO_INT = 1;
-  static const int SYSTEM_INFO_DOUBLE = 2;
-  static const int SYSTEM_INFO_STRING = 3;
-  static const int SYSTEM_INFO_TYPE_MAX = 4;
 }

--- a/lib/src/bindings/9.0/generated_bindings_mv_barcode_detector.dart
+++ b/lib/src/bindings/9.0/generated_bindings_mv_barcode_detector.dart
@@ -83,6 +83,123 @@ class Tizen90MvBarcodeDetector {
           ffi.Pointer<ffi.Void>)>();
 }
 
+/// @brief Enumeration for supported barcode types.
+/// @details QR codes (versions 1 to 40) and set of 1D barcodes are supported
+///
+/// @since_tizen 2.4
+/// @remarks #MV_BARCODE_UNDEFINED is deprecated. Use #MV_BARCODE_UNKNOWN instead
+abstract class mv_barcode_type_e {
+  /// < 2D barcode - Quick Response code
+  static const int MV_BARCODE_QR = 0;
+
+  /// < 1D barcode - Universal Product Code with 12-digit
+  static const int MV_BARCODE_UPC_A = 1;
+
+  /// < 1D barcode - Universal Product Code with 6-digit
+  static const int MV_BARCODE_UPC_E = 2;
+
+  /// < 1D barcode - International Article Number with 8-digit
+  static const int MV_BARCODE_EAN_8 = 3;
+
+  /// < 1D barcode - International Article Number with 13-digit
+  static const int MV_BARCODE_EAN_13 = 4;
+
+  /// < 1D barcode - Code 128
+  static const int MV_BARCODE_CODE128 = 5;
+
+  /// < 1D barcode - Code 39
+  static const int MV_BARCODE_CODE39 = 6;
+
+  /// < 1D barcode - Interleaved Two of Five
+  static const int MV_BARCODE_I2_5 = 7;
+
+  /// < @deprecated Undefined (Deprecated since 6.0)
+  static const int MV_BARCODE_UNDEFINED = 8;
+
+  /// < 1D barcode - International Article Number with 2-digit(add-on) (since 6.0)
+  static const int MV_BARCODE_EAN_2 = 9;
+
+  /// < 1D barcode - International Article Number with 5-digit(add-on) (since 6.0)
+  static const int MV_BARCODE_EAN_5 = 10;
+
+  /// < 1D barcode - Code 93 (since 6.0)
+  static const int MV_BARCODE_CODE93 = 11;
+
+  /// < 1D barcode - CODABAR (since 6.0)
+  static const int MV_BARCODE_CODABAR = 12;
+
+  /// < 1D barcode - GS1 DATABAR (since 6.0)
+  static const int MV_BARCODE_DATABAR = 13;
+
+  /// < 1D barcode - GS1 DATABAR EXPAND(since 6.0)
+  static const int MV_BARCODE_DATABAR_EXPAND = 14;
+
+  /// < Unknown (since 6.0)
+  static const int MV_BARCODE_UNKNOWN = 100;
+}
+
+/// @brief Enumeration for supported QR code error correction level.
+///
+/// @since_tizen 2.4
+/// @remarks This is unavailable for 1D barcodes
+abstract class mv_barcode_qr_ecc_e {
+  /// < Recovery up to  7% losses
+  static const int MV_BARCODE_QR_ECC_LOW = 0;
+
+  /// < Recovery up to 15% losses
+  static const int MV_BARCODE_QR_ECC_MEDIUM = 1;
+
+  /// < Recovery up to 25% losses
+  static const int MV_BARCODE_QR_ECC_QUARTILE = 2;
+
+  /// < Recovery up to 30% losses
+  static const int MV_BARCODE_QR_ECC_HIGH = 3;
+
+  /// < Unavailable
+  static const int MV_BARCODE_QR_ECC_UNAVAILABLE = 4;
+}
+
+/// @brief Enumeration for supported QR code encoding mode.
+///
+/// @since_tizen 2.4
+/// @remarks This is unavailable for 1D barcodes
+abstract class mv_barcode_qr_mode_e {
+  /// < Numeric digits
+  static const int MV_BARCODE_QR_MODE_NUMERIC = 0;
+
+  /// < Alphanumeric characters
+  static const int MV_BARCODE_QR_MODE_ALPHANUMERIC = 1;
+
+  /// < Raw 8-bit bytes
+  static const int MV_BARCODE_QR_MODE_BYTE = 2;
+
+  /// < UTF-8 character encoding
+  static const int MV_BARCODE_QR_MODE_UTF8 = 3;
+
+  /// < Unavailable
+  static const int MV_BARCODE_QR_MODE_UNAVAILABLE = 4;
+}
+
+/// @brief Enumeration for supported image formats for the barcode generating.
+///
+/// @since_tizen 2.4
+abstract class mv_barcode_image_format_e {
+  /// < Unavailable image format
+  static const int MV_BARCODE_IMAGE_FORMAT_UNAVAILABLE = -1;
+
+  /// < BMP image format
+  static const int MV_BARCODE_IMAGE_FORMAT_BMP = 0;
+
+  /// < JPEG image format
+  static const int MV_BARCODE_IMAGE_FORMAT_JPG = 1;
+
+  /// < PNG image format
+  static const int MV_BARCODE_IMAGE_FORMAT_PNG = 2;
+
+  /// < The number of supported image format
+  static const int MV_BARCODE_IMAGE_FORMAT_NUM = 3;
+}
+
 /// @brief Enumeration to target attribute
 ///
 /// @since_tizen 2.4
@@ -152,61 +269,6 @@ typedef Dartmv_barcode_detected_cbFunction = void Function(
     ffi.Pointer<ffi.Int32> types,
     int number_of_barcodes,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @brief Enumeration for supported barcode types.
-/// @details QR codes (versions 1 to 40) and set of 1D barcodes are supported
-///
-/// @since_tizen 2.4
-/// @remarks #MV_BARCODE_UNDEFINED is deprecated. Use #MV_BARCODE_UNKNOWN instead
-abstract class mv_barcode_type_e {
-  /// < 2D barcode - Quick Response code
-  static const int MV_BARCODE_QR = 0;
-
-  /// < 1D barcode - Universal Product Code with 12-digit
-  static const int MV_BARCODE_UPC_A = 1;
-
-  /// < 1D barcode - Universal Product Code with 6-digit
-  static const int MV_BARCODE_UPC_E = 2;
-
-  /// < 1D barcode - International Article Number with 8-digit
-  static const int MV_BARCODE_EAN_8 = 3;
-
-  /// < 1D barcode - International Article Number with 13-digit
-  static const int MV_BARCODE_EAN_13 = 4;
-
-  /// < 1D barcode - Code 128
-  static const int MV_BARCODE_CODE128 = 5;
-
-  /// < 1D barcode - Code 39
-  static const int MV_BARCODE_CODE39 = 6;
-
-  /// < 1D barcode - Interleaved Two of Five
-  static const int MV_BARCODE_I2_5 = 7;
-
-  /// < @deprecated Undefined (Deprecated since 6.0)
-  static const int MV_BARCODE_UNDEFINED = 8;
-
-  /// < 1D barcode - International Article Number with 2-digit(add-on) (since 6.0)
-  static const int MV_BARCODE_EAN_2 = 9;
-
-  /// < 1D barcode - International Article Number with 5-digit(add-on) (since 6.0)
-  static const int MV_BARCODE_EAN_5 = 10;
-
-  /// < 1D barcode - Code 93 (since 6.0)
-  static const int MV_BARCODE_CODE93 = 11;
-
-  /// < 1D barcode - CODABAR (since 6.0)
-  static const int MV_BARCODE_CODABAR = 12;
-
-  /// < 1D barcode - GS1 DATABAR (since 6.0)
-  static const int MV_BARCODE_DATABAR = 13;
-
-  /// < 1D barcode - GS1 DATABAR EXPAND(since 6.0)
-  static const int MV_BARCODE_DATABAR_EXPAND = 14;
-
-  /// < Unknown (since 6.0)
-  static const int MV_BARCODE_UNKNOWN = 100;
-}
 
 const String MV_BARCODE_DETECT_ATTR_TARGET = 'MV_BARCODE_DETECT_ATTR_TARGET';
 

--- a/lib/src/bindings/9.0/generated_bindings_mv_barcode_generator.dart
+++ b/lib/src/bindings/9.0/generated_bindings_mv_barcode_generator.dart
@@ -279,7 +279,7 @@ abstract class _mv_barcode_type_e {
 ///
 /// @since_tizen 2.4
 /// @remarks This is unavailable for 1D barcodes
-abstract class mv_barcode_qr_mode_e {
+abstract class _mv_barcode_qr_mode_e {
   /// < Numeric digits
   static const int MV_BARCODE_QR_MODE_NUMERIC = 0;
 
@@ -300,7 +300,7 @@ abstract class mv_barcode_qr_mode_e {
 ///
 /// @since_tizen 2.4
 /// @remarks This is unavailable for 1D barcodes
-abstract class mv_barcode_qr_ecc_e {
+abstract class _mv_barcode_qr_ecc_e {
   /// < Recovery up to  7% losses
   static const int MV_BARCODE_QR_ECC_LOW = 0;
 
@@ -320,7 +320,7 @@ abstract class mv_barcode_qr_ecc_e {
 /// @brief Enumeration for supported image formats for the barcode generating.
 ///
 /// @since_tizen 2.4
-abstract class mv_barcode_image_format_e {
+abstract class _mv_barcode_image_format_e {
   /// < Unavailable image format
   static const int MV_BARCODE_IMAGE_FORMAT_UNAVAILABLE = -1;
 

--- a/lib/src/bindings/9.0/generated_bindings_mv_face.dart
+++ b/lib/src/bindings/9.0/generated_bindings_mv_face.dart
@@ -1121,6 +1121,55 @@ class Tizen90MvFace {
 }
 
 /// @deprecated Deprecated since 9.0
+/// @brief Enumeration for eyes state type.
+///
+/// @since_tizen 3.0
+///
+/// @see mv_face_eye_condition_recognize()
+abstract class mv_face_eye_condition_e {
+  /// < Eyes are open
+  static const int MV_FACE_EYES_OPEN = 0;
+
+  /// < Eyes are closed
+  static const int MV_FACE_EYES_CLOSED = 1;
+
+  /// < The eyes condition wasn't determined
+  static const int MV_FACE_EYES_NOT_FOUND = 2;
+}
+
+/// @deprecated Deprecated since 9.0
+/// @brief Enumeration for expression types can be determined for faces.
+///
+/// @since_tizen 3.0
+///
+/// @see mv_face_facial_expression_recognize()
+abstract class mv_face_facial_expression_e {
+  /// < Unknown face expression
+  static const int MV_FACE_UNKNOWN = 0;
+
+  /// < Face expression is neutral
+  static const int MV_FACE_NEUTRAL = 1;
+
+  /// < Face expression is smiling
+  static const int MV_FACE_SMILE = 2;
+
+  /// < Face expression is sadness
+  static const int MV_FACE_SADNESS = 3;
+
+  /// < Face expression is surprise
+  static const int MV_FACE_SURPRISE = 4;
+
+  /// < Face expression is anger
+  static const int MV_FACE_ANGER = 5;
+
+  /// < Face expression is fear
+  static const int MV_FACE_FEAR = 6;
+
+  /// < Face expression is disgust
+  static const int MV_FACE_DISGUST = 7;
+}
+
+/// @deprecated Deprecated since 9.0
 /// @brief Called when faces are detected for the @a source.
 /// @details This type callback can be invoked each time when
 /// mv_face_detect() is called to process the results of face
@@ -1338,23 +1387,6 @@ typedef Dartmv_face_eye_condition_recognized_cbFunction = void Function(
     ffi.Pointer<ffi.Void> user_data);
 
 /// @deprecated Deprecated since 9.0
-/// @brief Enumeration for eyes state type.
-///
-/// @since_tizen 3.0
-///
-/// @see mv_face_eye_condition_recognize()
-abstract class mv_face_eye_condition_e {
-  /// < Eyes are open
-  static const int MV_FACE_EYES_OPEN = 0;
-
-  /// < Eyes are closed
-  static const int MV_FACE_EYES_CLOSED = 1;
-
-  /// < The eyes condition wasn't determined
-  static const int MV_FACE_EYES_NOT_FOUND = 2;
-}
-
-/// @deprecated Deprecated since 9.0
 /// @brief Called when facial expression is recognized.
 /// @details This type callback can be invoked each time when
 /// mv_face_facial_expression_recognize() is called for @a face_location to
@@ -1390,38 +1422,6 @@ typedef Dartmv_face_facial_expression_recognized_cbFunction = void Function(
     mv_common.mv_rectangle_s face_location,
     int facial_expression,
     ffi.Pointer<ffi.Void> user_data);
-
-/// @deprecated Deprecated since 9.0
-/// @brief Enumeration for expression types can be determined for faces.
-///
-/// @since_tizen 3.0
-///
-/// @see mv_face_facial_expression_recognize()
-abstract class mv_face_facial_expression_e {
-  /// < Unknown face expression
-  static const int MV_FACE_UNKNOWN = 0;
-
-  /// < Face expression is neutral
-  static const int MV_FACE_NEUTRAL = 1;
-
-  /// < Face expression is smiling
-  static const int MV_FACE_SMILE = 2;
-
-  /// < Face expression is sadness
-  static const int MV_FACE_SADNESS = 3;
-
-  /// < Face expression is surprise
-  static const int MV_FACE_SURPRISE = 4;
-
-  /// < Face expression is anger
-  static const int MV_FACE_ANGER = 5;
-
-  /// < Face expression is fear
-  static const int MV_FACE_FEAR = 6;
-
-  /// < Face expression is disgust
-  static const int MV_FACE_DISGUST = 7;
-}
 
 const String MV_FACE_DETECTION_MODEL_FILE_PATH =
     'MV_FACE_DETECTION_MODEL_FILE_PATH';

--- a/lib/src/bindings/9.0/generated_bindings_mv_inference.dart
+++ b/lib/src/bindings/9.0/generated_bindings_mv_inference.dart
@@ -840,6 +840,169 @@ class Tizen90MvInference {
 }
 
 /// @deprecated Deprecated since 9.0
+/// @brief Enumeration for inference backend.
+/// #MV_INFERENCE_BACKEND_OPENCV An open source computer vision and machine learning
+/// software library.
+/// (https://opencv.org/about/)
+/// #MV_INFERENCE_BACKEND_TFLITE Google-introduced open source inference engine for embedded systems,
+/// which runs Tensorflow Lite model.
+/// (https://www.tensorflow.org/lite/guide/get_started)
+/// #MV_INFERENCE_BACKEND_ARMNN ARM-introduced open source inference engine for CPUs, GPUs and NPUs, which
+/// enables efficient translation of existing neural network frameworks
+/// such as TensorFlow, TensorFlow Lite and Caffes, allowing them to
+/// run efficiently without modification on Embedded hardware.
+/// (https://developer.arm.com/ip-products/processors/machine-learning/arm-nn)
+/// #MV_INFERENCE_BACKEND_MLAPI Samsung-introduced open source ML single API framework of NNStreamer, which
+/// runs various NN models via tensor filters of NNStreamer. (Deprecated since 7.0)
+/// (https://github.com/nnstreamer/nnstreamer)
+/// #MV_INFERENCE_BACKEND_ONE Samsung-introduced open source inference engine called On-device Neural Engine, which
+/// performs inference of a given NN model on various devices such as CPU, GPU, DSP and NPU.
+/// (https://github.com/Samsung/ONE)
+///
+/// @since_tizen 5.5
+///
+/// @see mv_inference_prepare()
+abstract class mv_inference_backend_type_e {
+  /// < None
+  static const int MV_INFERENCE_BACKEND_NONE = -1;
+
+  /// < OpenCV
+  static const int MV_INFERENCE_BACKEND_OPENCV = 0;
+
+  /// < TensorFlow-Lite
+  static const int MV_INFERENCE_BACKEND_TFLITE = 1;
+
+  /// < @deprecated ARMNN (Since 6.0) (Deprecated since 8.0)
+  static const int MV_INFERENCE_BACKEND_ARMNN = 2;
+
+  /// < @deprecated ML Single API of NNStreamer (Deprecated since 7.0)
+  static const int MV_INFERENCE_BACKEND_MLAPI = 3;
+
+  /// < On-device Neural Engine (Since 6.0)
+  static const int MV_INFERENCE_BACKEND_ONE = 4;
+
+  /// < NNTrainer (Since 7.0)
+  static const int MV_INFERENCE_BACKEND_NNTRAINER = 5;
+
+  /// < SNPE Engine (Since 7.0)
+  static const int MV_INFERENCE_BACKEND_SNPE = 6;
+
+  /// < @deprecated Backend MAX (Deprecated since 7.0)
+  static const int MV_INFERENCE_BACKEND_MAX = 7;
+}
+
+/// @deprecated Deprecated since 9.0
+/// @brief Enumeration for inference target.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_target_device_e {
+  /// < None
+  static const int MV_INFERENCE_TARGET_DEVICE_NONE = 0;
+
+  /// < CPU
+  static const int MV_INFERENCE_TARGET_DEVICE_CPU = 1;
+
+  /// < GPU
+  static const int MV_INFERENCE_TARGET_DEVICE_GPU = 2;
+
+  /// < CUSTOM
+  static const int MV_INFERENCE_TARGET_DEVICE_CUSTOM = 4;
+
+  /// < Target MAX
+  static const int MV_INFERENCE_TARGET_DEVICE_MAX = 8;
+}
+
+/// @deprecated Deprecated since 9.0
+/// @brief Enumeration for input data type.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_data_type_e {
+  /// < Data type of a given pre-trained model is float.
+  static const int MV_INFERENCE_DATA_FLOAT32 = 0;
+
+  /// < Data type of a given pre-trained model is unsigned char.
+  static const int MV_INFERENCE_DATA_UINT8 = 1;
+}
+
+/// @deprecated Deprecated since 9.0
+/// @brief Enumeration for human pose landmark.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_human_pose_landmark_e {
+  /// < Head of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_HEAD = 1;
+
+  /// < Neck of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_NECK = 2;
+
+  /// < Thorax of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_THORAX = 3;
+
+  /// < Right shoulder of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_SHOULDER = 4;
+
+  /// < Right elbow of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_ELBOW = 5;
+
+  /// < Right wrist of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_WRIST = 6;
+
+  /// < Left shoulder of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_SHOULDER = 7;
+
+  /// < Left elbow of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_ELBOW = 8;
+
+  /// < Left wrist of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_WRIST = 9;
+
+  /// < Pelvis of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_PELVIS = 10;
+
+  /// < Right hip of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_HIP = 11;
+
+  /// < Right knee of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_KNEE = 12;
+
+  /// < Right ankle of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_RIGHT_ANKLE = 13;
+
+  /// < Left hip of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_HIP = 14;
+
+  /// < Left knee of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_KNEE = 15;
+
+  /// < Left ankle of human pose
+  static const int MV_INFERENCE_HUMAN_POSE_LEFT_ANKLE = 16;
+}
+
+/// @deprecated Deprecated since 9.0
+/// @brief Enumeration for human body parts.
+///
+/// @since_tizen 6.0
+abstract class mv_inference_human_body_part_e {
+  /// < HEAD, NECK, and THORAX
+  static const int MV_INFERENCE_HUMAN_BODY_PART_HEAD = 1;
+
+  /// < RIGHT SHOULDER, ELBOW, and WRIST
+  static const int MV_INFERENCE_HUMAN_BODY_PART_ARM_RIGHT = 2;
+
+  /// < LEFT SHOULDER, ELBOW, and WRIST
+  static const int MV_INFERENCE_HUMAN_BODY_PART_ARM_LEFT = 4;
+
+  /// < THORAX, PELVIS, RIGHT HIP, and LEFT HIP
+  static const int MV_INFERENCE_HUMAN_BODY_PART_BODY = 8;
+
+  /// < RIGHT HIP, KNEE, and ANKLE
+  static const int MV_INFERENCE_HUMAN_BODY_PART_LEG_RIGHT = 16;
+
+  /// < LEFT HIP, KNEE, and ANKLE
+  static const int MV_INFERENCE_HUMAN_BODY_PART_LEG_LEFT = 32;
+}
+
+/// @deprecated Deprecated since 9.0
 /// @brief The inference handle.
 /// @details Contains information about location of
 /// detected landmarks for one or more poses.

--- a/lib/src/bindings/9.0/generated_bindings_mv_landmark_detection.dart
+++ b/lib/src/bindings/9.0/generated_bindings_mv_landmark_detection.dart
@@ -331,9 +331,320 @@ class Tizen90MvLandmarkDetection {
       _mv_facial_landmark_get_positionPtr.asFunction<
           int Function(mv_facial_landmark_h, int, ffi.Pointer<ffi.UnsignedInt>,
               ffi.Pointer<ffi.UnsignedInt>)>();
+
+  /// @brief Creates pose landmark object handle.
+  /// @details Use this function to create an pose landmark object handle.
+  /// After creation the handle has to be prepared with
+  /// mv_pose_landmark_prepare() function to prepare
+  /// a pose landmark object.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[out] handle    The handle to the pose landmark object to be created
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_INTERNAL Internal Error
+  ///
+  /// @post Release @a handle by using
+  /// mv_pose_landmark_destroy() function when it is not needed
+  /// anymore
+  ///
+  /// @code
+  /// #include <mv_pose_landmark.h>
+  /// ...
+  /// mv_pose_landmark_h handle = NULL;
+  /// mv_pose_landmark_create(&handle);
+  /// ...
+  /// mv_pose_landmark_destroy(handle);
+  /// @endcode
+  ///
+  /// @see mv_pose_landmark_destroy()
+  int mv_pose_landmark_create(
+    ffi.Pointer<mv_pose_landmark_h> handle,
+  ) {
+    return _mv_pose_landmark_create(
+      handle,
+    );
+  }
+
+  late final _mv_pose_landmark_createPtr = _lookup<
+          ffi
+          .NativeFunction<ffi.Int Function(ffi.Pointer<mv_pose_landmark_h>)>>(
+      'mv_pose_landmark_create');
+  late final _mv_pose_landmark_create = _mv_pose_landmark_createPtr
+      .asFunction<int Function(ffi.Pointer<mv_pose_landmark_h>)>();
+
+  /// @brief Destroys pose landmark handle and releases all its resources.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle    The handle to the pose landmark object to be destroyed.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  ///
+  /// @pre Create an pose landmark handle by using mv_pose_landmark_create()
+  ///
+  /// @see mv_pose_landmark_create()
+  int mv_pose_landmark_destroy(
+    mv_pose_landmark_h handle,
+  ) {
+    return _mv_pose_landmark_destroy(
+      handle,
+    );
+  }
+
+  late final _mv_pose_landmark_destroyPtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(mv_pose_landmark_h)>>(
+          'mv_pose_landmark_destroy');
+  late final _mv_pose_landmark_destroy = _mv_pose_landmark_destroyPtr
+      .asFunction<int Function(mv_pose_landmark_h)>();
+
+  /// @brief Configures the backend to the inference handle.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle         The handle to the inference
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_OUT_OF_MEMORY Out of memory
+  int mv_pose_landmark_configure(
+    mv_pose_landmark_h handle,
+  ) {
+    return _mv_pose_landmark_configure(
+      handle,
+    );
+  }
+
+  late final _mv_pose_landmark_configurePtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(mv_pose_landmark_h)>>(
+          'mv_pose_landmark_configure');
+  late final _mv_pose_landmark_configure = _mv_pose_landmark_configurePtr
+      .asFunction<int Function(mv_pose_landmark_h)>();
+
+  /// @brief Prepares inference.
+  /// @details Use this function to prepare inference based on
+  /// the configured network.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle         The handle to the inference
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_INVALID_DATA Invalid model data
+  /// @retval #MEDIA_VISION_ERROR_OUT_OF_MEMORY Out of memory
+  int mv_pose_landmark_prepare(
+    mv_pose_landmark_h handle,
+  ) {
+    return _mv_pose_landmark_prepare(
+      handle,
+    );
+  }
+
+  late final _mv_pose_landmark_preparePtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(mv_pose_landmark_h)>>(
+          'mv_pose_landmark_prepare');
+  late final _mv_pose_landmark_prepare = _mv_pose_landmark_preparePtr
+      .asFunction<int Function(mv_pose_landmark_h)>();
+
+  /// @brief Inferences with a given facial on the @a source.
+  /// @details Use this function to inference with a given source.
+  ///
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle         The handle to the pose landmark object.
+  /// @param[in] source         The handle to the source of the media.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED_FORMAT Source colorspace
+  /// isn't supported
+  /// @retval #MEDIA_VISION_ERROR_OUT_OF_MEMORY Out of memory
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an pose landmark handle by calling mv_pose_landmark_create()
+  /// @pre Prepare an inference by calling mv_pose_landmark_configure()
+  /// @pre Prepare an pose landmark by calling mv_pose_landmark_prepare()
+  ///
+  /// @par Inference Example
+  /// @snippet pose_landmark_sync.c PLD sync
+  int mv_pose_landmark_inference(
+    mv_pose_landmark_h handle,
+    mv_common.mv_source_h source,
+  ) {
+    return _mv_pose_landmark_inference(
+      handle,
+      source,
+    );
+  }
+
+  late final _mv_pose_landmark_inferencePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(mv_pose_landmark_h,
+              mv_common.mv_source_h)>>('mv_pose_landmark_inference');
+  late final _mv_pose_landmark_inference = _mv_pose_landmark_inferencePtr
+      .asFunction<int Function(mv_pose_landmark_h, mv_common.mv_source_h)>();
+
+  /// @brief Performs asynchronously the pose landmark inference on the @a source.
+  ///
+  /// @since_tizen 9.0
+  /// @remarks This function operates asynchronously, so it returns immediately upon invocation.
+  /// The inference results are inserted into the outgoing queue within the framework
+  /// in the order of processing, and the results can be obtained through mv_pose_landmark_get_result_count()
+  /// and mv_pose_landmark_get_position().
+  ///
+  /// @param[in] handle         The handle to the inference
+  /// @param[in] source         The handle to the source of the media
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED_FORMAT Source colorspace
+  /// isn't supported
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an inference handle by calling mv_pose_landmark_create()
+  /// @pre Prepare an inference by calling mv_pose_landmark_configure()
+  /// @pre Prepare an inference by calling mv_pose_landmark_prepare()
+  ///
+  /// @par Async Inference Example
+  /// @snippet pose_landmark_async.c PLD async
+  int mv_pose_landmark_inference_async(
+    mv_pose_landmark_h handle,
+    mv_common.mv_source_h source,
+  ) {
+    return _mv_pose_landmark_inference_async(
+      handle,
+      source,
+    );
+  }
+
+  late final _mv_pose_landmark_inference_asyncPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(mv_pose_landmark_h,
+              mv_common.mv_source_h)>>('mv_pose_landmark_inference_async');
+  late final _mv_pose_landmark_inference_async =
+      _mv_pose_landmark_inference_asyncPtr.asFunction<
+          int Function(mv_pose_landmark_h, mv_common.mv_source_h)>();
+
+  /// @brief Gets the result count to objects.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle         The handle to the inference
+  /// @param[out] frame_number  A frame number inferenced.
+  /// @param[out] result_cnt    A number of results.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an inference handle by calling mv_pose_landmark_create()
+  /// @pre Prepare an inference by calling mv_pose_landmark_configure()
+  /// @pre Prepare an inference by calling mv_pose_landmark_prepare()
+  /// @pre Request an inference by calling mv_pose_landmark_inference()
+  int mv_pose_landmark_get_result_count(
+    mv_pose_landmark_h handle,
+    ffi.Pointer<ffi.UnsignedLong> frame_number,
+    ffi.Pointer<ffi.UnsignedInt> result_cnt,
+  ) {
+    return _mv_pose_landmark_get_result_count(
+      handle,
+      frame_number,
+      result_cnt,
+    );
+  }
+
+  late final _mv_pose_landmark_get_result_countPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Int Function(
+                  mv_pose_landmark_h,
+                  ffi.Pointer<ffi.UnsignedLong>,
+                  ffi.Pointer<ffi.UnsignedInt>)>>(
+      'mv_pose_landmark_get_result_count');
+  late final _mv_pose_landmark_get_result_count =
+      _mv_pose_landmark_get_result_countPtr.asFunction<
+          int Function(mv_pose_landmark_h, ffi.Pointer<ffi.UnsignedLong>,
+              ffi.Pointer<ffi.UnsignedInt>)>();
+
+  /// @brief Gets the pose landmark position values to a given index.
+  ///
+  /// @since_tizen 9.0
+  /// @remarks pos_x and pos_y arrays are allocated internally by the framework and will remain valid
+  /// until the handle is released.
+  /// Please do not deallocate them directly, and if you want to use them after the handle is released,
+  /// please copy them to user memory and use the copy.
+  ///
+  /// This function operates differently depending on the inference request method.
+  /// - After mv_facial_landmark_inference() calls, this function returns facial landmark positions immediately.
+  /// - After mv_facial_landmark_inference_async() calls, this function can be blocked until the asynchronous inference request is completed
+  /// or the timeout occurs if no result within 3 seconds.
+  ///
+  /// Additionally, after calling the mv_facial_landmark_inference_async function, the function operates
+  /// in asynchronous mode until the handle is released.
+  ///
+  /// @param[in] handle               The handle to the inference
+  /// @param[in] index                A result index.
+  /// @param[out] pos_x               An array containing x-coordinate values.
+  /// @param[out] pos_y               An array containing y-coordinate values.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an inference handle by calling mv_pose_landmark_create()
+  /// @pre Prepare an inference by calling mv_pose_landmark_configure()
+  /// @pre Prepare an inference by calling mv_pose_landmark_prepare()
+  /// @pre Prepare an inference by calling mv_pose_landmark_inference()
+  /// @pre Get result count by calling mv_pose_landmark_get_result_count()
+  int mv_pose_landmark_get_position(
+    mv_pose_landmark_h handle,
+    int index,
+    ffi.Pointer<ffi.UnsignedInt> pos_x,
+    ffi.Pointer<ffi.UnsignedInt> pos_y,
+  ) {
+    return _mv_pose_landmark_get_position(
+      handle,
+      index,
+      pos_x,
+      pos_y,
+    );
+  }
+
+  late final _mv_pose_landmark_get_positionPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(
+              mv_pose_landmark_h,
+              ffi.UnsignedInt,
+              ffi.Pointer<ffi.UnsignedInt>,
+              ffi.Pointer<ffi.UnsignedInt>)>>('mv_pose_landmark_get_position');
+  late final _mv_pose_landmark_get_position =
+      _mv_pose_landmark_get_positionPtr.asFunction<
+          int Function(mv_pose_landmark_h, int, ffi.Pointer<ffi.UnsignedInt>,
+              ffi.Pointer<ffi.UnsignedInt>)>();
 }
 
 /// @brief The facial landmark object handle.
 ///
 /// @since_tizen 9.0
 typedef mv_facial_landmark_h = ffi.Pointer<ffi.Void>;
+
+/// @brief The pose landmark object handle.
+///
+/// @since_tizen 9.0
+typedef mv_pose_landmark_h = ffi.Pointer<ffi.Void>;

--- a/lib/src/bindings/9.0/generated_bindings_mv_object_detection.dart
+++ b/lib/src/bindings/9.0/generated_bindings_mv_object_detection.dart
@@ -25,6 +25,321 @@ class Tizen90MvObjectDetection {
           lookup)
       : _lookup = lookup;
 
+  /// @brief Creates a inference handle for face detection object.
+  /// @details Use this function to create a inference handle. After the creation
+  /// the face detection task has to be prepared with
+  /// mv_face_detection_prepare() function to prepare a network
+  /// for the inference.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @remarks The @a handle should be released using mv_face_detection_destroy().
+  ///
+  /// @param[out] handle    The handle to the inference to be created.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_INTERNAL Internal Error
+  ///
+  /// @code
+  /// #include <mv_face_detection.h>
+  /// ...
+  /// mv_face_detection_h handle = NULL;
+  /// mv_face_detection_create(&handle);
+  /// ...
+  /// mv_face_detection_destroy(handle);
+  /// @endcode
+  ///
+  /// @see mv_face_detection_destroy()
+  /// @see mv_face_detection_prepare()
+  int mv_face_detection_create(
+    ffi.Pointer<mv_face_detection_h> handle,
+  ) {
+    return _mv_face_detection_create(
+      handle,
+    );
+  }
+
+  late final _mv_face_detection_createPtr = _lookup<
+          ffi
+          .NativeFunction<ffi.Int Function(ffi.Pointer<mv_face_detection_h>)>>(
+      'mv_face_detection_create');
+  late final _mv_face_detection_create = _mv_face_detection_createPtr
+      .asFunction<int Function(ffi.Pointer<mv_face_detection_h>)>();
+
+  /// @brief Destroys inference handle and releases all its resources.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle    The handle to the inference to be destroyed.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  ///
+  /// @pre Create inference handle by using mv_face_detection_create()
+  ///
+  /// @see mv_face_detection_create()
+  int mv_face_detection_destroy(
+    mv_face_detection_h handle,
+  ) {
+    return _mv_face_detection_destroy(
+      handle,
+    );
+  }
+
+  late final _mv_face_detection_destroyPtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(mv_face_detection_h)>>(
+          'mv_face_detection_destroy');
+  late final _mv_face_detection_destroy = _mv_face_detection_destroyPtr
+      .asFunction<int Function(mv_face_detection_h)>();
+
+  /// @brief Configures the backend for the face detection inference.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle         The handle to the inference
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_INVALID_OPERATION Invalid operation
+  /// @retval #MEDIA_VISION_ERROR_OUT_OF_MEMORY Out of memory
+  ///
+  /// @pre Create an inference handle by calling mv_face_detection_create()
+  int mv_face_detection_configure(
+    mv_face_detection_h handle,
+  ) {
+    return _mv_face_detection_configure(
+      handle,
+    );
+  }
+
+  late final _mv_face_detection_configurePtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(mv_face_detection_h)>>(
+          'mv_face_detection_configure');
+  late final _mv_face_detection_configure = _mv_face_detection_configurePtr
+      .asFunction<int Function(mv_face_detection_h)>();
+
+  /// @brief Prepares the face detection inference.
+  /// @details Use this function to prepare the face detection inference based on
+  /// the configured network.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle         The handle to the inference.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_INVALID_DATA Invalid model data
+  /// @retval #MEDIA_VISION_ERROR_OUT_OF_MEMORY Out of memory
+  /// @retval #MEDIA_VISION_ERROR_INVALID_OPERATION Invalid operation
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED_FORMAT Not supported format
+  ///
+  /// @pre Prepare an inference by calling mv_face_detection_configure()
+  int mv_face_detection_prepare(
+    mv_face_detection_h handle,
+  ) {
+    return _mv_face_detection_prepare(
+      handle,
+    );
+  }
+
+  late final _mv_face_detection_preparePtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(mv_face_detection_h)>>(
+          'mv_face_detection_prepare');
+  late final _mv_face_detection_prepare = _mv_face_detection_preparePtr
+      .asFunction<int Function(mv_face_detection_h)>();
+
+  /// @brief Performs the face detection inference on the @a source.
+  ///
+  /// @since_tizen 9.0
+  /// @remarks This function is synchronous and may take considerable time to run.
+  ///
+  /// @param[in] handle          The handle to the inference
+  /// @param[in] source         The handle to the source of the media
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED_FORMAT Source colorspace
+  /// isn't supported
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an inference handle by calling mv_face_detection_create()
+  /// @pre Prepare an inference by calling mv_face_detection_configure()
+  /// @pre Prepare an inference by calling mv_face_detection_prepare()
+  ///
+  /// @par Inference Example
+  /// @snippet face_detection_sync.c FD sync
+  int mv_face_detection_inference(
+    mv_face_detection_h handle,
+    mv_common.mv_source_h source,
+  ) {
+    return _mv_face_detection_inference(
+      handle,
+      source,
+    );
+  }
+
+  late final _mv_face_detection_inferencePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(mv_face_detection_h,
+              mv_common.mv_source_h)>>('mv_face_detection_inference');
+  late final _mv_face_detection_inference = _mv_face_detection_inferencePtr
+      .asFunction<int Function(mv_face_detection_h, mv_common.mv_source_h)>();
+
+  /// @brief Performs asynchronously the face detection inference on the @a source.
+  ///
+  /// @since_tizen 9.0
+  /// @remarks This function operates asynchronously, so it returns immediately upon invocation.
+  /// The inference results are inserted into the outgoing queue within the framework
+  /// in the order of processing, and the results can be obtained through mv_face_detection_get_result_count()
+  /// and mv_face_detection_get_bound_box().
+  ///
+  /// @param[in] handle         The handle to the inference
+  /// @param[in] source         The handle to the source of the media
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED_FORMAT Source colorspace
+  /// isn't supported
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an inference handle by calling mv_face_detection_create()
+  /// @pre Prepare an inference by calling mv_face_detection_configure()
+  /// @pre Prepare an inference by calling mv_face_detection_prepare()
+  ///
+  /// @par Async Inference Example
+  /// @snippet face_detection_async.c FD async
+  int mv_face_detection_inference_async(
+    mv_face_detection_h handle,
+    mv_common.mv_source_h source,
+  ) {
+    return _mv_face_detection_inference_async(
+      handle,
+      source,
+    );
+  }
+
+  late final _mv_face_detection_inference_asyncPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(mv_face_detection_h,
+              mv_common.mv_source_h)>>('mv_face_detection_inference_async');
+  late final _mv_face_detection_inference_async =
+      _mv_face_detection_inference_asyncPtr.asFunction<
+          int Function(mv_face_detection_h, mv_common.mv_source_h)>();
+
+  /// @brief Gets the face detection inference result on the @a handle.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle          The handle to the inference
+  /// @param[out] frame_number   A frame number inferenced.
+  /// @param[out] result_cnt     A number of results.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an inference handle by calling mv_face_detection_create()
+  /// @pre Prepare an inference by calling mv_face_detection_configure()
+  /// @pre Prepare an inference by calling mv_face_detection_prepare()
+  /// @pre Request an inference by calling mv_face_detection_inference()
+  int mv_face_detection_get_result_count(
+    mv_face_detection_h handle,
+    ffi.Pointer<ffi.UnsignedLong> frame_number,
+    ffi.Pointer<ffi.UnsignedInt> result_cnt,
+  ) {
+    return _mv_face_detection_get_result_count(
+      handle,
+      frame_number,
+      result_cnt,
+    );
+  }
+
+  late final _mv_face_detection_get_result_countPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Int Function(
+                  mv_face_detection_h,
+                  ffi.Pointer<ffi.UnsignedLong>,
+                  ffi.Pointer<ffi.UnsignedInt>)>>(
+      'mv_face_detection_get_result_count');
+  late final _mv_face_detection_get_result_count =
+      _mv_face_detection_get_result_countPtr.asFunction<
+          int Function(mv_face_detection_h, ffi.Pointer<ffi.UnsignedLong>,
+              ffi.Pointer<ffi.UnsignedInt>)>();
+
+  /// @brief Gets a bound box to detected face region.
+  ///
+  /// @since_tizen 9.0
+  ///
+  /// @param[in] handle              The handle to the inference
+  /// @param[in] index               A result index.
+  /// @param[out] left               An left position of bound box.
+  /// @param[out] top                An top position of bound box.
+  /// @param[out] right              An right position of bound box.
+  /// @param[out] bottom             An bottom position of bound box.
+  ///
+  /// @return @c 0 on success, otherwise a negative error value
+  /// @retval #MEDIA_VISION_ERROR_NONE Successful
+  /// @retval #MEDIA_VISION_ERROR_NOT_SUPPORTED Not supported
+  /// @retval #MEDIA_VISION_ERROR_INVALID_PARAMETER Invalid parameter
+  ///
+  /// @pre Create a source handle by calling mv_create_source()
+  /// @pre Create an inference handle by calling mv_face_detection_create()
+  /// @pre Prepare an inference by calling mv_face_detection_configure()
+  /// @pre Prepare an inference by calling mv_face_detection_prepare()
+  /// @pre Request an inference by calling mv_face_detection_inference()
+  /// @pre Get result count by calling mv_face_detection_get_result_count()
+  int mv_face_detection_get_bound_box(
+    mv_face_detection_h handle,
+    int index,
+    ffi.Pointer<ffi.Int> left,
+    ffi.Pointer<ffi.Int> top,
+    ffi.Pointer<ffi.Int> right,
+    ffi.Pointer<ffi.Int> bottom,
+  ) {
+    return _mv_face_detection_get_bound_box(
+      handle,
+      index,
+      left,
+      top,
+      right,
+      bottom,
+    );
+  }
+
+  late final _mv_face_detection_get_bound_boxPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(
+              mv_face_detection_h,
+              ffi.UnsignedInt,
+              ffi.Pointer<ffi.Int>,
+              ffi.Pointer<ffi.Int>,
+              ffi.Pointer<ffi.Int>,
+              ffi.Pointer<ffi.Int>)>>('mv_face_detection_get_bound_box');
+  late final _mv_face_detection_get_bound_box =
+      _mv_face_detection_get_bound_boxPtr.asFunction<
+          int Function(
+              mv_face_detection_h,
+              int,
+              ffi.Pointer<ffi.Int>,
+              ffi.Pointer<ffi.Int>,
+              ffi.Pointer<ffi.Int>,
+              ffi.Pointer<ffi.Int>)>();
+
   /// @brief Creates a inference handle for object detection object.
   /// @details Use this function to create a inference handle. After the creation
   /// the object detection 3d task has to be prepared with
@@ -335,6 +650,11 @@ class Tizen90MvObjectDetection {
               ffi.Pointer<ffi.Int>,
               ffi.Pointer<ffi.Int>)>();
 }
+
+/// @brief The face detection object handle.
+///
+/// @since_tizen 9.0
+typedef mv_face_detection_h = ffi.Pointer<ffi.Void>;
 
 /// @brief The object detection object handle.
 ///

--- a/lib/src/bindings/9.0/generated_bindings_tbm.dart
+++ b/lib/src/bindings/9.0/generated_bindings_tbm.dart
@@ -449,6 +449,8 @@ class Tizen90Tbm {
       _tbm_surface_get_formatPtr.asFunction<int Function(tbm_surface_h)>();
 }
 
+final class _tbm_surface extends ffi.Opaque {}
+
 /// @brief Enumeration for tbm_surface error type.
 /// @since_tizen 2.3
 abstract class tbm_surface_error_e {
@@ -544,11 +546,127 @@ typedef tbm_surface_plane_s = _tbm_surface_plane;
 /// @since_tizen 2.3
 typedef tbm_surface_h = ffi.Pointer<_tbm_surface>;
 
-final class _tbm_surface extends ffi.Opaque {}
-
 /// @brief Definition for the TBM surface information struct.
 /// @since_tizen 2.3
 typedef tbm_surface_info_s = _tbm_surface_info;
+
+const int TBM_FORMAT_C8 = 538982467;
+
+const int TBM_FORMAT_RGB332 = 943867730;
+
+const int TBM_FORMAT_BGR233 = 944916290;
+
+const int TBM_FORMAT_XRGB4444 = 842093144;
+
+const int TBM_FORMAT_XBGR4444 = 842089048;
+
+const int TBM_FORMAT_RGBX4444 = 842094674;
+
+const int TBM_FORMAT_BGRX4444 = 842094658;
+
+const int TBM_FORMAT_ARGB4444 = 842093121;
+
+const int TBM_FORMAT_ABGR4444 = 842089025;
+
+const int TBM_FORMAT_RGBA4444 = 842088786;
+
+const int TBM_FORMAT_BGRA4444 = 842088770;
+
+const int TBM_FORMAT_XRGB1555 = 892424792;
+
+const int TBM_FORMAT_XBGR1555 = 892420696;
+
+const int TBM_FORMAT_RGBX5551 = 892426322;
+
+const int TBM_FORMAT_BGRX5551 = 892426306;
+
+const int TBM_FORMAT_ARGB1555 = 892424769;
+
+const int TBM_FORMAT_ABGR1555 = 892420673;
+
+const int TBM_FORMAT_RGBA5551 = 892420434;
+
+const int TBM_FORMAT_BGRA5551 = 892420418;
+
+const int TBM_FORMAT_RGB565 = 909199186;
+
+const int TBM_FORMAT_BGR565 = 909199170;
+
+const int TBM_FORMAT_RGB888 = 875710290;
+
+const int TBM_FORMAT_BGR888 = 875710274;
+
+const int TBM_FORMAT_XRGB8888 = 875713112;
+
+const int TBM_FORMAT_XBGR8888 = 875709016;
+
+const int TBM_FORMAT_RGBX8888 = 875714642;
+
+const int TBM_FORMAT_BGRX8888 = 875714626;
+
+const int TBM_FORMAT_ARGB8888 = 875713089;
+
+const int TBM_FORMAT_ABGR8888 = 875708993;
+
+const int TBM_FORMAT_RGBA8888 = 875708754;
+
+const int TBM_FORMAT_BGRA8888 = 875708738;
+
+const int TBM_FORMAT_XRGB2101010 = 808669784;
+
+const int TBM_FORMAT_XBGR2101010 = 808665688;
+
+const int TBM_FORMAT_RGBX1010102 = 808671314;
+
+const int TBM_FORMAT_BGRX1010102 = 808671298;
+
+const int TBM_FORMAT_ARGB2101010 = 808669761;
+
+const int TBM_FORMAT_ABGR2101010 = 808665665;
+
+const int TBM_FORMAT_RGBA1010102 = 808665426;
+
+const int TBM_FORMAT_BGRA1010102 = 808665410;
+
+const int TBM_FORMAT_YUYV = 1448695129;
+
+const int TBM_FORMAT_YVYU = 1431918169;
+
+const int TBM_FORMAT_UYVY = 1498831189;
+
+const int TBM_FORMAT_VYUY = 1498765654;
+
+const int TBM_FORMAT_AYUV = 1448433985;
+
+const int TBM_FORMAT_NV12 = 842094158;
+
+const int TBM_FORMAT_NV21 = 825382478;
+
+const int TBM_FORMAT_NV16 = 909203022;
+
+const int TBM_FORMAT_NV61 = 825644622;
+
+const int TBM_FORMAT_YUV410 = 961959257;
+
+const int TBM_FORMAT_YVU410 = 961893977;
+
+const int TBM_FORMAT_YUV411 = 825316697;
+
+const int TBM_FORMAT_YVU411 = 825316953;
+
+const int TBM_FORMAT_YUV420 = 842093913;
+
+const int TBM_FORMAT_YVU420 = 842094169;
+
+const int TBM_FORMAT_YUV422 = 909202777;
+
+const int TBM_FORMAT_YVU422 = 909203033;
+
+const int TBM_FORMAT_YUV444 = 875713881;
+
+const int TBM_FORMAT_YVU444 = 875714137;
+
+const int TBM_FORMAT_NV12MT = 842091860;
 
 const int TBM_SURF_PLANE_MAX = 4;
 


### PR DESCRIPTION
This PR adds missing header files to the ffigen-*.dart and entrypoints.h across all supported Tizen versions (6.0 ~ 10.0), and regenerates the corresponding Dart bindings.